### PR TITLE
feat(@clayui/core): add TextHighlight component

### DIFF
--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {Text, TextHighlight} from '@clayui/core';
 import {useResource} from '@clayui/data-provider';
 import {
 	FetchPolicy,
 	NetworkStatus,
 } from '@clayui/data-provider/src/useResource';
-import ClayDropDown from '@clayui/drop-down';
+import DropDown from '@clayui/drop-down';
+import Layout from '@clayui/layout';
 import {FocusScope, useDebounce} from '@clayui/shared';
 import React, {useEffect, useRef, useState} from 'react';
 
@@ -26,11 +28,7 @@ const LoadingWithDebounce = ({
 	const debouncedLoadingChange = useDebounce(loading, 500);
 
 	if (networkStatus === 1 || debouncedLoadingChange) {
-		return (
-			<ClayDropDown.Item className="disabled">
-				Loading...
-			</ClayDropDown.Item>
-		);
+		return <DropDown.Item className="disabled">Loading...</DropDown.Item>;
 	}
 
 	return render;
@@ -112,6 +110,62 @@ export const Dynamic = () => (
 		</div>
 	</div>
 );
+
+export const CustomItem = () => {
+	const [value, setValue] = useState('');
+
+	return (
+		<div className="row">
+			<div className="col-md-5">
+				<div className="sheet">
+					<div className="form-group">
+						<label
+							htmlFor="clay-autocomplete-2"
+							id="clay-autocomplete-label-2"
+						>
+							Numbers (one-five)
+						</label>
+						<ClayAutocomplete
+							aria-labelledby="clay-autocomplete-label-2"
+							defaultItems={[
+								'one',
+								'two',
+								'three',
+								'four',
+								'five',
+							]}
+							id="clay-autocomplete-2"
+							messages={{
+								loading: 'Loading...',
+								notFound: 'No results found',
+							}}
+							onChange={setValue}
+							placeholder="Enter a number from One to Five"
+							value={value}
+						>
+							{(item) => (
+								<DropDown.Item key={item}>
+									<Layout.ContentRow>
+										<Layout.ContentCol expand>
+											<Text size={3}>
+												<TextHighlight match={value}>
+													{item}
+												</TextHighlight>
+											</Text>
+										</Layout.ContentCol>
+										<Layout.ContentCol>
+											<Text size={2}>Description</Text>
+										</Layout.ContentCol>
+									</Layout.ContentRow>
+								</DropDown.Item>
+							)}
+						</ClayAutocomplete>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
 
 export const AsyncFilter = () => {
 	const [value, setValue] = useState('');
@@ -259,7 +313,7 @@ export const Keyboard = () => {
 									active={active}
 									onActiveChange={setActive}
 								>
-									<ClayDropDown.ItemList>
+									<DropDown.ItemList>
 										{filteredItems.map((item) => (
 											<ClayAutocomplete.Item
 												key={item}
@@ -268,7 +322,7 @@ export const Keyboard = () => {
 												value={item}
 											/>
 										))}
-									</ClayDropDown.ItemList>
+									</DropDown.ItemList>
 								</ClayAutocomplete.DropDown>
 							</ClayAutocomplete>
 						</FocusScope>
@@ -315,7 +369,7 @@ export const AsyncData = () => {
 									(!!resource && !!value) || initialLoading
 								}
 							>
-								<ClayDropDown.ItemList>
+								<DropDown.ItemList>
 									<LoadingWithDebounce
 										loading={loading}
 										networkStatus={networkStatus}
@@ -324,9 +378,9 @@ export const AsyncData = () => {
 												{(error ||
 													(resource &&
 														resource.error)) && (
-													<ClayDropDown.Item className="disabled">
+													<DropDown.Item className="disabled">
 														No Results Found
-													</ClayDropDown.Item>
+													</DropDown.Item>
 												)}
 												{!error &&
 													resource &&
@@ -350,7 +404,7 @@ export const AsyncData = () => {
 											</>
 										}
 									/>
-								</ClayDropDown.ItemList>
+								</DropDown.ItemList>
 							</ClayAutocomplete.DropDown>
 							{loading && <ClayAutocomplete.LoadingIndicator />}
 						</ClayAutocomplete>

--- a/packages/clay-core/docs/api-text.mdx
+++ b/packages/clay-core/docs/api-text.mdx
@@ -7,3 +7,7 @@ mainTabURL: 'docs/components/text.html'
 ## Text
 
 <div>[APITable "clay-core/src/typography/Text.tsx"]</div>
+
+## TextHighlight
+
+<div>[APITable "clay-core/src/typography/TextHighlight.tsx"]</div>

--- a/packages/clay-core/docs/text.js
+++ b/packages/clay-core/docs/text.js
@@ -9,7 +9,7 @@
  */
 
 import Editor from '$clayui.com/src/components/Editor';
-import {Text} from '@clayui/core';
+import {Text, TextHighlight} from '@clayui/core';
 import React from 'react';
 
 const exampleImports = `import {Text} from '@clayui/core';
@@ -260,6 +260,29 @@ export const TextWeight = () => {
 		<Editor
 			code={exampleWeightCode}
 			imports={exampleImports}
+			scope={scope}
+		/>
+	);
+};
+
+const exampleTextHighlightImports = `import {TextHighlight} from '@clayui/core';
+import React from 'react';`;
+
+const exampleTextHighlightCode = `const Component = () => {
+    return (
+        <TextHighlight match="Ri s">Rick Sanchez</TextHighlight>
+      );
+  };
+  
+  render(<Component />)`;
+
+export const ExampleTextHighlight = () => {
+	const scope = {TextHighlight};
+
+	return (
+		<Editor
+			code={exampleTextHighlightCode}
+			imports={exampleTextHighlightImports}
 			scope={scope}
 		/>
 	);

--- a/packages/clay-core/docs/text.mdx
+++ b/packages/clay-core/docs/text.mdx
@@ -7,6 +7,7 @@ storybookPath: 'design-system-components-typography--text-typography'
 ---
 
 import {
+	ExampleTextHighlight,
 	TextColorFont,
 	TextItalicFont,
 	TextMonospaceFont,
@@ -27,6 +28,7 @@ import {
     -   [Monospace](#monospace)
 -   [Color](#color)
 -   [Font Weights](#font-weights)
+-   [Text Highlight](#text-highlight)
 
 </div>
 </div>
@@ -85,3 +87,9 @@ Text has the ability to apply different `color` fonts giving emphasis to the tex
 As well as [Heading](/docs/components/heading.html), Text provides its own font weight styles from `bolder` to `lighter` just indicating it in the property `weight`. The default font weight is `normal`.
 
 <TextWeight />
+
+## Text Highlight
+
+The `<TextHighlight />` component adds a highlight to the text characters that match the value that can be entered by the user, for example can be used in an Autocomplete component.
+
+<ExampleTextHighlight />

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -35,6 +35,7 @@
 		"@clayui/shared": "^3.87.0",
 		"@tanstack/react-virtual": "3.0.0-beta.18",
 		"classnames": "^2.2.6",
+		"fuzzy": "^0.1.3",
 		"react-dnd": "^11.1.1",
 		"react-dnd-html5-backend": "^11.1.1",
 		"react-transition-group": "^4.4.1"

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -15,7 +15,7 @@ export {
 } from '@clayui/modal';
 export {Provider, useProvider} from '@clayui/provider';
 
-export {Heading, Text} from './typography';
+export {Heading, Text, TextHighlight} from './typography';
 export {OverlayMask} from './overlay-mask';
 export {TreeView} from './tree-view';
 export {VerticalBar} from './vertical-bar';

--- a/packages/clay-core/src/typography/TextHighlight.tsx
+++ b/packages/clay-core/src/typography/TextHighlight.tsx
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import fuzzy from 'fuzzy';
+import React from 'react';
+
+type Props = {
+	/**
+	 * The component content.
+	 */
+	children: string;
+
+	/**
+	 * Match is the string that will be compared with value.
+	 */
+	match: string;
+};
+
+const optionsFuzzy = {post: '|+', pre: '+|'};
+
+export function TextHighlight({children, match}: Props) {
+	const fuzzyMatch = fuzzy.match(match, children, optionsFuzzy);
+
+	return (
+		<>
+			{match && fuzzyMatch
+				? fuzzyMatch.rendered
+						.split('|')
+						.map((item, index) => {
+							const Text = item.includes('+') ? 'span' : 'strong';
+							const value = item.replace(/\+/g, '');
+
+							return value ? (
+								<Text key={index}>{value}</Text>
+							) : null;
+						})
+						.filter(Boolean)
+				: children}
+		</>
+	);
+}

--- a/packages/clay-core/src/typography/index.ts
+++ b/packages/clay-core/src/typography/index.ts
@@ -5,3 +5,4 @@
 
 export {Heading} from './Heading';
 export {Text} from './Text';
+export {TextHighlight} from './TextHighlight';

--- a/packages/clay-core/stories/Text.stories.tsx
+++ b/packages/clay-core/stories/Text.stories.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 
-import {Text} from '../src/typography';
+import {Text, TextHighlight} from '../src/typography';
 
 export default {
 	argTypes: {
@@ -74,4 +74,13 @@ TextTypography.args = {
 	italic: false,
 	monospace: false,
 	truncate: false,
+};
+
+export const TextHighlightTypography = (args: any) => (
+	<TextHighlight match={args.match}>{args.value}</TextHighlight>
+);
+
+TextHighlightTypography.args = {
+	match: 'Ri s',
+	value: 'Rick Sanchez',
 };


### PR DESCRIPTION
Closes #5351

This PR adds the implementation of the `TextHighlight` component and documentation, I also added an example in the storybook of a custom item in Autocomplete using `TextHighlight`.