### PR TITLE
feat(@clayui/link): add extra aria-label when target is `_blank`

### DIFF
--- a/packages/clay-link/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-link/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,66 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ClayLink renders 1`] = `
-<a
-  className=""
-/>
+<div>
+  <a
+    class=""
+  />
+</div>
 `;
 
 exports[`ClayLink renders borderless links 1`] = `
-<a
-  className="link-outline-borderless"
-  href="#1"
->
-  Borderless
-</a>
+<div>
+  <a
+    class="link-outline-borderless"
+    href="#1"
+  >
+    Borderless
+  </a>
+</div>
 `;
 
 exports[`ClayLink renders outline links 1`] = `
-<a
-  className="link-outline link-outline-primary"
-  href="#1"
->
-  Outline
-</a>
+<div>
+  <a
+    class="link-outline link-outline-primary"
+    href="#1"
+  >
+    Outline
+  </a>
+</div>
 `;
 
 exports[`ClayLink renders with a children content 1`] = `
-<a
-  className=""
->
-  My Link
-</a>
+<div>
+  <a
+    class=""
+  >
+    My Link
+  </a>
+</div>
 `;
 
 exports[`ClayLink renders with a display type 1`] = `
-<a
-  className="c-link link-secondary text-decoration-underline"
-/>
+<div>
+  <a
+    class="c-link link-secondary text-decoration-underline"
+  />
+</div>
 `;
 
 exports[`ClayLink renders with href 1`] = `
-<a
-  className=""
-  href="#links"
-/>
+<div>
+  <a
+    class=""
+    href="#links"
+  />
+</div>
 `;
 
 exports[`ClayLink renders with monospaced 1`] = `
-<a
-  className="link-monospaced link-outline link-outline-borderless link-outline-primary"
-  href="#1"
->
-  M
-</a>
+<div>
+  <a
+    class="link-monospaced link-outline link-outline-borderless link-outline-primary"
+    href="#1"
+  >
+    M
+  </a>
+</div>
 `;
 
 exports[`ClayLink uses custom link component via context 1`] = `
-<a
-  className="c-link link-secondary text-decoration-underline"
-  href="#1"
->
-  <strong>
-    I am Bold!
-  </strong>
-</a>
+<div>
+  <a
+    class="c-link link-secondary text-decoration-underline"
+    href="#1"
+  >
+    <strong>
+      I am Bold!
+    </strong>
+  </a>
+</div>
 `;

--- a/packages/clay-link/src/__tests__/index.tsx
+++ b/packages/clay-link/src/__tests__/index.tsx
@@ -107,4 +107,10 @@ describe('ClayCard w/ @testing-library/react', () => {
 			'foo bar'
 		);
 	});
+
+	it('add extra aria-label when target is `_blank`', () => {
+		const {getByText} = render(<ClayLink target="_blank">Page</ClayLink>);
+
+		expect(getByText('(Opens a new window)')).toBeTruthy();
+	});
 });

--- a/packages/clay-link/src/__tests__/index.tsx
+++ b/packages/clay-link/src/__tests__/index.tsx
@@ -6,37 +6,36 @@
 import ClayLink, {ClayLinkContext} from '..';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
 
 describe('ClayLink', () => {
-	it('renders', () => {
-		const testRenderer = TestRenderer.create(<ClayLink />);
+	afterEach(cleanup);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+	it('renders', () => {
+		const {container} = render(<ClayLink />);
+
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with href', () => {
-		const testRenderer = TestRenderer.create(<ClayLink href="#links" />);
+		const {container} = render(<ClayLink href="#links" />);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with a children content', () => {
-		const testRenderer = TestRenderer.create(<ClayLink>My Link</ClayLink>);
+		const {container} = render(<ClayLink>My Link</ClayLink>);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with a display type', () => {
-		const testRenderer = TestRenderer.create(
-			<ClayLink displayType="secondary" />
-		);
+		const {container} = render(<ClayLink displayType="secondary" />);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with monospaced', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayLink
 				borderless
 				displayType="primary"
@@ -48,27 +47,27 @@ describe('ClayLink', () => {
 			</ClayLink>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders outline links', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayLink displayType="primary" href="#1" outline>
 				Outline
 			</ClayLink>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders borderless links', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayLink borderless href="#1">
 				Borderless
 			</ClayLink>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('uses custom link component via context', () => {
@@ -77,7 +76,7 @@ describe('ClayLink', () => {
 				<strong>{children}</strong>
 			</a>
 		);
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayLinkContext.Provider value={BoldLink}>
 				<ClayLink displayType="secondary" href="#1">
 					I am Bold!
@@ -85,12 +84,8 @@ describe('ClayLink', () => {
 			</ClayLinkContext.Provider>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
-});
-
-describe('ClayCard w/ @testing-library/react', () => {
-	afterEach(cleanup);
 
 	it('adds rel="noreferrer noopener" if target exists', () => {
 		const {container} = render(<ClayLink target="_blank" />);

--- a/packages/clay-link/src/index.tsx
+++ b/packages/clay-link/src/index.tsx
@@ -74,6 +74,13 @@ interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	fontSize?: Number;
 
 	/**
+	 * Messages used for announcement to SR. Use this for internationalization.
+	 */
+	messages?: {
+		opensNewWindow: string;
+	};
+
+	/**
 	 * Flag to indicate if the link should be monospaced.
 	 */
 	monospaced?: boolean;
@@ -94,6 +101,10 @@ interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	weight?: 'normal' | 'semi-bold';
 }
 
+const defaultMessages = {
+	opensNewWindow: '(Opens a new window)',
+};
+
 const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 	(
 		{
@@ -105,6 +116,7 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 			decoration,
 			displayType,
 			fontSize,
+			messages = defaultMessages,
 			monospaced,
 			outline,
 			rel,
@@ -166,6 +178,9 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 				{...otherProps}
 			>
 				{children}
+				{target === '_blank' && (
+					<span className="sr-only">{messages.opensNewWindow}</span>
+				)}
 			</TagOrComponent>
 		);
 	}


### PR DESCRIPTION
Closes #5355

This PR adds an extra label when `target` is set to `_blank`, it also adds a `messages` API which allows changing the text to handle internationalization.

Hey @marcoscv-work I didn't add the visual icon, do you have an example of what this should look like? I think we have to add this via a conditional as well because the link is used in several components and I'm not sure if that would be desired in some occasions.