### PR TITLE
fix(@clayui/core): fix bug that does not expand an asynchronous node with cursor

### DIFF
--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -118,6 +118,10 @@ export function useAPI(): [Selection, Expand, LoadMore] {
 					} else if (items.items) {
 						cursors.current.set(id, items.cursor);
 						insert([...layoutItem.loc, 0], items.items);
+
+						if (willToggle && !expandedKeys.has(id)) {
+							toggle(id);
+						}
 					}
 				})
 				.catch((error) => {


### PR DESCRIPTION
Fixes #5367

When we implemented asynchronous loading with the cursor it didn't expand the node because we only thought of the case that the node already had items in its first render, now we expand only when node it is not expanded to avoid collapsing the node when loading more data.