### PR TITLE
fix(@clayui/css): Links change spacing between text and icon back to 8px

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -703,16 +703,6 @@ $cadmin-link: map-deep-merge(
 			color: $cadmin-link-hover-color,
 			text-decoration: $cadmin-link-hover-decoration,
 		),
-		inline-item-before: (
-			margin-right: 4px,
-		),
-		inline-item-middle: (
-			margin-left: 4px,
-			margin-right: 4px,
-		),
-		inline-item-after: (
-			margin-left: 4px,
-		),
 	),
 	$cadmin-link
 );

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -586,16 +586,6 @@ $link: map-deep-merge(
 			color: $link-hover-color,
 			text-decoration: $link-hover-decoration,
 		),
-		inline-item-before: (
-			margin-right: 0.25rem,
-		),
-		inline-item-middle: (
-			margin-left: 0.25rem,
-			margin-right: 0.25rem,
-		),
-		inline-item-after: (
-			margin-left: 0.25rem,
-		),
 	),
 	$link
 );


### PR DESCRIPTION
fixes #5382