### PR TITLE
feat(@clayui/drop-down): add new prop to pass props to `DropDown.Search` button

### DIFF
--- a/packages/clay-drop-down/src/Search.tsx
+++ b/packages/clay-drop-down/src/Search.tsx
@@ -35,6 +35,11 @@ export interface IProps
 	spritemap?: string;
 
 	/**
+	 * Props to add to the button component.
+	 */
+	submitProps?: React.HTMLAttributes<HTMLButtonElement>;
+
+	/**
 	 * Current value of the input (controlled).
 	 */
 	value?: string;
@@ -42,12 +47,18 @@ export interface IProps
 
 const defaultOnSubmit = (event: React.SyntheticEvent) => event.preventDefault();
 
+const defaultSubmitProps = {
+	'aria-label': 'Search',
+	type: 'button',
+};
+
 const ClayDropDownSearch = ({
 	className,
 	defaultValue = '',
 	formProps = {},
 	onChange,
 	spritemap,
+	submitProps = defaultSubmitProps,
 	value: valueProp,
 	...otherProps
 }: IProps) => {
@@ -90,9 +101,9 @@ const ClayDropDownSearch = ({
 
 						<ClayInput.GroupInsetItem after tag="span">
 							<ClayButton
+								{...submitProps}
 								displayType="unstyled"
 								tabIndex={!tabFocus ? -1 : undefined}
-								type="button"
 							>
 								<ClayIcon
 									spritemap={spritemap}

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -392,6 +392,7 @@ exports[`ClayDropDown renders with search input 1`] = `
                   class="input-group-inset-item input-group-inset-item-after"
                 >
                   <button
+                    aria-label="Search"
                     class="btn btn-unstyled"
                     tabindex="-1"
                     type="button"


### PR DESCRIPTION
Fixes #5377

Eventually this causes the problem of prop drilling but to avoid this we would have to break the component into small parts for composition for now this is not what we want so it is acceptable to add this API here until we understand better how we want this component.