### PR TITLE
refactor(@clayui/core): uses `useNavigation` hook for keyboard navigation in TreeView

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -63,7 +63,7 @@ module.exports = {
 		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 59,
-			functions: 70,
+			functions: 69,
 			lines: 71,
 			statements: 71,
 		},

--- a/packages/clay-core/src/aria/index.ts
+++ b/packages/clay-core/src/aria/index.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export {useFocusWithin, FocusWithinProvider} from './useFocusWithin';

--- a/packages/clay-core/src/aria/useFocusWithin.tsx
+++ b/packages/clay-core/src/aria/useFocusWithin.tsx
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {getFocusableList} from '@clayui/shared';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react';
+
+type FocusContext = {
+	focusId: React.Key | null;
+	onFocusChange: (focusId: React.Key) => void;
+};
+
+const FocusContext = React.createContext<FocusContext>({} as FocusContext);
+
+const focusableElements = ['.treeview-link[tabindex]'];
+
+type Props<T> = {
+	children: React.ReactNode;
+	containerRef: React.RefObject<T>;
+};
+
+export function FocusWithinProvider<T extends HTMLElement>({
+	children,
+	containerRef,
+}: Props<T>) {
+	const [focusId, setFocusId] = useState<React.Key | null>(null);
+
+	useEffect(() => {
+		// TODO: Get this information using the collection API
+		const item = getFocusableList(containerRef, focusableElements)[0];
+		const [type, id] = item.getAttribute('data-id')!.split(',');
+		const key = type === 'number' ? Number(id) : id;
+
+		setFocusId(key);
+	}, []);
+
+	return (
+		<FocusContext.Provider value={{focusId, onFocusChange: setFocusId}}>
+			{children}
+		</FocusContext.Provider>
+	);
+}
+
+type FocusWithinProps = {
+	id: React.Key;
+	disabled: boolean;
+};
+
+export function useFocusWithin({disabled, id}: FocusWithinProps) {
+	const {focusId, onFocusChange} = useContext(FocusContext);
+
+	const onFocus = useCallback(() => {
+		if (focusId !== id) {
+			onFocusChange(id);
+		}
+	}, [focusId]);
+
+	return useMemo(() => {
+		if (disabled) {
+			return {
+				tabIndex: -1,
+			};
+		}
+
+		return {
+			onFocus,
+			tabIndex: focusId === id ? 0 : -1,
+		};
+	}, [focusId, onFocus]);
+}

--- a/packages/clay-core/src/aria/useFocusWithin.tsx
+++ b/packages/clay-core/src/aria/useFocusWithin.tsx
@@ -19,16 +19,16 @@ type FocusContext = {
 
 const FocusContext = React.createContext<FocusContext>({} as FocusContext);
 
-const focusableElements = ['.treeview-link[tabindex]'];
-
 type Props<T> = {
 	children: React.ReactNode;
 	containerRef: React.RefObject<T>;
+	focusableElements: Array<string>;
 };
 
 export function FocusWithinProvider<T extends HTMLElement>({
 	children,
 	containerRef,
+	focusableElements,
 }: Props<T>) {
 	const [focusId, setFocusId] = useState<React.Key | null>(null);
 

--- a/packages/clay-core/src/aria/useFocusWithin.tsx
+++ b/packages/clay-core/src/aria/useFocusWithin.tsx
@@ -35,6 +35,11 @@ export function FocusWithinProvider<T extends HTMLElement>({
 	useEffect(() => {
 		// TODO: Get this information using the collection API
 		const item = getFocusableList(containerRef, focusableElements)[0];
+
+		if (!item) {
+			return;
+		}
+
 		const [type, id] = item.getAttribute('data-id')!.split(',');
 		const key = type === 'number' ? Number(id) : id;
 

--- a/packages/clay-core/src/live-announcer/VisuallyHidden.tsx
+++ b/packages/clay-core/src/live-announcer/VisuallyHidden.tsx
@@ -9,13 +9,13 @@ const styles: React.CSSProperties = {
 	border: 0,
 	clip: 'rect(0 0 0 0)',
 	clipPath: 'inset(50%)',
-	height: 1,
+	height: '1px',
 	margin: '0 -1px -1px 0',
 	overflow: 'hidden',
 	padding: 0,
 	position: 'absolute',
 	whiteSpace: 'nowrap',
-	width: 1,
+	width: '1px',
 };
 
 type Props = {

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -229,7 +229,10 @@ export function TreeView<T>({
 			<DndProvider backend={HTML5Backend} context={dragAndDropContext}>
 				<TreeViewContext.Provider value={context}>
 					<DragAndDropProvider messages={messages} rootRef={rootRef}>
-						<FocusWithinProvider containerRef={rootRef}>
+						<FocusWithinProvider
+							containerRef={rootRef}
+							focusableElements={focusableElements}
+						>
 							<Collection<T> items={state.items}>
 								{children}
 							</Collection>

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -9,6 +9,7 @@ import React, {useRef} from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
+import {FocusWithinProvider} from '../aria';
 import {ChildrenFunction, Collection, ICollectionProps} from './Collection';
 import {DragAndDropMessages, DragAndDropProvider} from './DragAndDrop';
 import DragLayer from './DragLayer';
@@ -228,10 +229,12 @@ export function TreeView<T>({
 			<DndProvider backend={HTML5Backend} context={dragAndDropContext}>
 				<TreeViewContext.Provider value={context}>
 					<DragAndDropProvider messages={messages} rootRef={rootRef}>
-						<Collection<T> items={state.items}>
-							{children}
-						</Collection>
-						<DragLayer itemNameKey={itemNameKey} />
+						<FocusWithinProvider containerRef={rootRef}>
+							<Collection<T> items={state.items}>
+								{children}
+							</Collection>
+							<DragLayer itemNameKey={itemNameKey} />
+						</FocusWithinProvider>
 					</DragAndDropProvider>
 				</TreeViewContext.Provider>
 			</DndProvider>

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {FocusScope} from '@clayui/shared';
+import {useNavigation} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useRef} from 'react';
 import {DndProvider} from 'react-dnd';
@@ -117,6 +117,8 @@ interface ITreeViewProps<T>
 	showExpanderOnHover?: boolean;
 }
 
+const focusableElements = ['.treeview-link[tabindex]'];
+
 export function TreeView<T>(props: ITreeViewProps<T>): JSX.Element & {
 	Item: typeof TreeViewItem;
 	Group: typeof TreeViewGroup;
@@ -199,40 +201,41 @@ export function TreeView<T>({
 		...state,
 	};
 
+	const {navigationProps} = useNavigation({
+		containerRef: rootRef,
+		focusableElements,
+		orientation: 'vertical',
+		typeahead: true,
+		visible: true,
+	});
+
 	return (
-		<FocusScope>
-			<ul
-				{...otherProps}
-				className={classNames(
-					'treeview show-quick-actions-on-hover',
-					className,
-					{
-						[`treeview-${displayType}`]: displayType,
-						'show-component-expander-on-hover': showExpanderOnHover,
-					}
-				)}
-				ref={rootRef}
-				role="tree"
-				tabIndex={-1}
-			>
-				<DndProvider
-					backend={HTML5Backend}
-					context={dragAndDropContext}
-				>
-					<TreeViewContext.Provider value={context}>
-						<DragAndDropProvider
-							messages={messages}
-							rootRef={rootRef}
-						>
-							<Collection<T> items={state.items}>
-								{children}
-							</Collection>
-							<DragLayer itemNameKey={itemNameKey} />
-						</DragAndDropProvider>
-					</TreeViewContext.Provider>
-				</DndProvider>
-			</ul>
-		</FocusScope>
+		<ul
+			{...otherProps}
+			{...navigationProps}
+			className={classNames(
+				'treeview show-quick-actions-on-hover',
+				className,
+				{
+					[`treeview-${displayType}`]: displayType,
+					'show-component-expander-on-hover': showExpanderOnHover,
+				}
+			)}
+			ref={rootRef}
+			role="tree"
+			tabIndex={-1}
+		>
+			<DndProvider backend={HTML5Backend} context={dragAndDropContext}>
+				<TreeViewContext.Provider value={context}>
+					<DragAndDropProvider messages={messages} rootRef={rootRef}>
+						<Collection<T> items={state.items}>
+							{children}
+						</Collection>
+						<DragLayer itemNameKey={itemNameKey} />
+					</DragAndDropProvider>
+				</TreeViewContext.Provider>
+			</DndProvider>
+		</ul>
 	);
 }
 

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -332,7 +332,7 @@ export const TreeViewItem = React.forwardRef<
 							)(event);
 						}
 
-						if (event.defaultPrevented) {
+						if (event.defaultPrevented || event.key === Keys.Tab) {
 							return;
 						}
 

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -261,7 +261,16 @@ export const TreeViewItem = React.forwardRef<
 							: `string,${item.key}`
 					}
 					disabled={itemStackProps.disabled || nodeProps.disabled}
-					onBlur={() => actions && setFocus(false)}
+					onBlur={(event) => {
+						if (
+							actions &&
+							!item.itemRef.current?.contains(
+								event.relatedTarget as HTMLElement
+							)
+						) {
+							setFocus(false);
+						}
+					}}
 					onClick={(event) => {
 						if (itemStackProps.disabled || nodeProps.disabled) {
 							return;
@@ -854,6 +863,16 @@ function Actions({children, tabIndex}: TreeViewItemActionsProps) {
 										child.props.onClick(event);
 									}
 								},
+								onKeyDown: (
+									event: React.KeyboardEvent<HTMLButtonElement>
+								) => {
+									if (
+										event.key === Keys.Enter ||
+										event.key === Keys.Spacebar
+									) {
+										event.stopPropagation();
+									}
+								},
 								tabIndex,
 							})}
 						</Layout.ContentCol>
@@ -884,6 +903,16 @@ function Actions({children, tabIndex}: TreeViewItemActionsProps) {
 												child.props.trigger.props.onClick(
 													event
 												);
+											}
+										},
+										onKeyDown: (
+											event: React.KeyboardEvent<HTMLButtonElement>
+										) => {
+											if (
+												event.key === Keys.Enter ||
+												event.key === Keys.Spacebar
+											) {
+												event.stopPropagation();
 											}
 										},
 										tabIndex,

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -287,21 +287,17 @@ exports[`TreeView basic rendering render with actions 1`] = `
             >
               <button
                 class="component-action quick-action-item btn btn-monospaced"
+                tabindex="0"
                 type="button"
               >
-                <div
-                  class="c-inner"
-                  tabindex="-2"
+                <svg
+                  class="lexicon-icon lexicon-icon-times"
+                  role="presentation"
                 >
-                  <svg
-                    class="lexicon-icon lexicon-icon-times"
-                    role="presentation"
-                  >
-                    <use
-                      xlink:href="icons.svg#times"
-                    />
-                  </svg>
-                </div>
+                  <use
+                    xlink:href="icons.svg#times"
+                  />
+                </svg>
               </button>
             </div>
             <div
@@ -315,21 +311,17 @@ exports[`TreeView basic rendering render with actions 1`] = `
                   aria-expanded="false"
                   aria-haspopup="true"
                   class="dropdown-toggle component-action quick-action-item btn btn-monospaced"
+                  tabindex="0"
                   type="button"
                 >
-                  <div
-                    class="c-inner"
-                    tabindex="-2"
+                  <svg
+                    class="lexicon-icon lexicon-icon-ellipsis-v"
+                    role="presentation"
                   >
-                    <svg
-                      class="lexicon-icon lexicon-icon-ellipsis-v"
-                      role="presentation"
-                    >
-                      <use
-                        xlink:href="icons.svg#ellipsis-v"
-                      />
-                    </svg>
-                  </div>
+                    <use
+                      xlink:href="icons.svg#ellipsis-v"
+                    />
+                  </svg>
                 </button>
               </div>
             </div>

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -227,7 +227,7 @@ export const Actions = () => (
 		<TreeView.Item
 			actions={
 				<>
-					<Button displayType={null} monospaced>
+					<Button aria-label="Close" displayType={null} monospaced>
 						<Icon symbol="times" />
 					</Button>
 					<DropDownWithItems
@@ -237,7 +237,11 @@ export const Actions = () => (
 							{label: 'Three'},
 						]}
 						trigger={
-							<Button displayType={null} monospaced>
+							<Button
+								aria-label="More"
+								displayType={null}
+								monospaced
+							>
 								<Icon symbol="ellipsis-v" />
 							</Button>
 						}
@@ -258,7 +262,7 @@ export const Actions = () => (
 		<TreeView.Item
 			actions={
 				<>
-					<Button displayType={null} monospaced>
+					<Button aria-label="Close" displayType={null} monospaced>
 						<Icon symbol="times" />
 					</Button>
 					<DropDownWithItems
@@ -268,7 +272,11 @@ export const Actions = () => (
 							{label: 'Six'},
 						]}
 						trigger={
-							<Button displayType={null} monospaced>
+							<Button
+								aria-label="More"
+								displayType={null}
+								monospaced
+							>
 								<Icon symbol="ellipsis-v" />
 							</Button>
 						}

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -29,6 +29,8 @@ type Props<T> = {
 	 */
 	containerRef: React.MutableRefObject<T>;
 
+	focusableElements?: Array<string>;
+
 	/**
 	 * Flag to indicate if navigation should loop.
 	 */
@@ -63,6 +65,7 @@ export function useNavigation<T extends HTMLElement | null>({
 	activation = 'manual',
 	active,
 	containerRef,
+	focusableElements = FOCUSABLE_ELEMENTS,
 	loop = false,
 	onNavigate,
 	orientation = 'horizontal',
@@ -127,7 +130,7 @@ export function useNavigation<T extends HTMLElement | null>({
 				keys.includes(event.key) ||
 				(typeahead && !alternativeKeys.includes(event.key))
 			) {
-				const tabs = getFocusableList(containerRef);
+				const tabs = getFocusableList(containerRef, focusableElements);
 
 				let tab: HTMLElement | undefined;
 
@@ -174,7 +177,11 @@ export function useNavigation<T extends HTMLElement | null>({
 					default: {
 						const target = event.target as HTMLElement;
 
-						if (!typeahead || target.tagName === 'INPUT') {
+						if (
+							!typeahead ||
+							target.tagName === 'INPUT' ||
+							event.key === Keys.Tab
+						) {
 							return;
 						}
 
@@ -292,14 +299,15 @@ export function useNavigation<T extends HTMLElement | null>({
 }
 
 export function getFocusableList<T extends HTMLElement | null>(
-	containeRef: React.MutableRefObject<T>
+	containeRef: React.MutableRefObject<T>,
+	focusableElements: Array<string> = FOCUSABLE_ELEMENTS
 ) {
 	if (!containeRef.current) {
 		return [];
 	}
 
 	return Array.from<HTMLElement>(
-		containeRef.current.querySelectorAll(FOCUSABLE_ELEMENTS.join(','))
+		containeRef.current.querySelectorAll(focusableElements.join(','))
 	).filter((element) =>
 		isFocusable({
 			contentEditable: element.contentEditable,


### PR DESCRIPTION
Fixes #5334

Initial implementation to improve TreeView focus system, we are using `useNavigation` hook instead of FocusScope to handle focus and hotkeys, not covering all shortcut cases yet.

I still need to implement the TreeView focus control to retrieve the focus on the last item of the component, I will probably implement a component that can handle this since we already have 2 existing use cases in Clay that are starting to follow this behavior.