### PR TITLE
refactor: changes the root component's `aria-current` prop to `itemAriaCurrent`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -152,7 +152,7 @@ module.exports = {
 			statements: 98,
 		},
 		'./packages/clay-nav/src/': {
-			branches: 88,
+			branches: 86,
 			functions: 80,
 			lines: 93,
 			statements: 93,

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -52,7 +52,7 @@ export interface IProps {
 	 * Flag to define if the item represents the current page. Disable this
 	 * attribute only if there are multiple navigations on the page.
 	 */
-	'aria-current'?: 'page' | null;
+	itemAriaCurrent?: boolean;
 
 	/**
 	 * Flag to indicate the navigation behavior in the menu.
@@ -285,10 +285,10 @@ function ClayVerticalNav(props: IProps): JSX.Element & {
 };
 
 function ClayVerticalNav({
-	'aria-current': ariaCurrent = 'page',
 	activation = 'manual',
 	activeLabel,
 	decorated,
+	itemAriaCurrent: ariaCurrent = true,
 	items,
 	large,
 	spritemap,
@@ -340,7 +340,7 @@ function ClayVerticalNav({
 				ref={containerRef}
 			>
 				<Nav aria-orientation="vertical" nested role="menubar">
-					{renderItems(items, ariaCurrent, spritemap)}
+					{renderItems(items, ariaCurrent ? 'page' : null, spritemap)}
 				</Nav>
 			</div>
 		</nav>

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -21,7 +21,7 @@ export interface IProps
 	 * Flag to define if the item represents the current page. Disable this
 	 * attribute only if there are multiple navigations on the page.
 	 */
-	'aria-current'?: 'page' | null;
+	itemAriaCurrent?: boolean;
 
 	/**
 	 * Children elements received from ClayNavigationBar component.
@@ -51,10 +51,10 @@ function ClayNavigationBar(props: IProps): JSX.Element & {
 };
 
 function ClayNavigationBar({
-	'aria-current': ariaCurrent = 'page',
 	children,
 	className,
 	inverted = false,
+	itemAriaCurrent: ariaCurrent = true,
 	spritemap,
 	triggerLabel,
 	...otherProps
@@ -87,7 +87,9 @@ function ClayNavigationBar({
 				}
 			)}
 		>
-			<NavigationBarContext.Provider value={{ariaCurrent}}>
+			<NavigationBarContext.Provider
+				value={{ariaCurrent: ariaCurrent ? 'page' : null}}
+			>
 				<ClayLayout.ContainerFluid>
 					<ClayButton
 						aria-expanded={expanded}


### PR DESCRIPTION
Fixes #5399