### PR TITLE
feat(@clayui/empty-state): always render the title

### DIFF
--- a/packages/clay-empty-state/src/__tests__/index.tsx
+++ b/packages/clay-empty-state/src/__tests__/index.tsx
@@ -24,10 +24,10 @@ describe('ClayEmptyState', () => {
 		expect(container).toMatchSnapshot();
 	});
 
-	it('when passing `title` property with null, it will not render title section', () => {
+	it('when passing `title` property with null, render the title section', () => {
 		const {queryByText} = render(<ClayEmptyState title={null} />);
 
-		expect(queryByText('No results found')).toBeNull();
+		expect(queryByText('No results found')).toBeDefined();
 	});
 
 	it('renders with a children content', () => {

--- a/packages/clay-empty-state/src/index.tsx
+++ b/packages/clay-empty-state/src/index.tsx
@@ -33,6 +33,8 @@ interface IProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
 	title?: string | null;
 }
 
+const defaultTile = 'No results found';
+
 const ClayEmptyState = ({
 	children,
 	className,
@@ -40,7 +42,7 @@ const ClayEmptyState = ({
 	imgProps,
 	imgSrc,
 	small,
-	title = 'No results found',
+	title = defaultTile,
 	...otherProps
 }: IProps) => {
 	const hasImg = imgSrc || imgProps;
@@ -69,13 +71,13 @@ const ClayEmptyState = ({
 				</div>
 			)}
 
-			{title && (
-				<div className="c-empty-state-title">
-					<span className="text-truncate-inline">
-						<span className="text-truncate">{title}</span>
+			<div className="c-empty-state-title">
+				<span className="text-truncate-inline">
+					<span className="text-truncate">
+						{title || defaultTile}
 					</span>
-				</div>
-			)}
+				</span>
+			</div>
 
 			<div className="c-empty-state-text">{description}</div>
 


### PR DESCRIPTION
Fixes #5325

This PR changes the logic to always render the title even when it's not defined or when it's defined as `null` or an empty string, we didn't change the types to avoid breaking the DXP compilation but in the future we will make `title` required and remove the `null`. We don't want to do that right now because it's a breaking change.