### PR TITLE
fix(@clayui/css): Clay and Cadmin Menubar make collapsed nav 100% wide

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_menubar.scss
@@ -3,10 +3,7 @@
 $menubar-vertical-transparent-md: () !default;
 $menubar-vertical-transparent-md: map-deep-merge(
 	(
-		mobile: (
-			background-color: $white,
-		),
-		link: (
+		nav-link: (
 			border-radius: 0.375rem,
 			transition: #{color 0.15s ease-in-out,
 			background-color 0.15s ease-in-out,
@@ -37,33 +34,39 @@ $menubar-vertical-transparent-md: map-deep-merge(
 				font-weight: $font-weight-semi-bold,
 			),
 		),
-		link-mobile: (
-			hover: (
-				background-color: rgba($primary, 0.04),
-			),
-			focus: (
-				background-color: rgba($primary, 0.04),
-			),
-			active: (
-				background-color: c-unset,
-				color: c-unset,
-			),
-			active-class: (
-				background-color: rgba($primary, 0.06),
-				color: c-unset,
-			),
-		),
-		toggler-mobile: (
-			color: $gray-900,
-			font-size: 0.875rem,
-			font-weight: $font-weight-semi-bold,
-			transition: box-shadow 0.15s ease-in-out,
-			focus: (
-				box-shadow: clay-enable-shadows($component-focus-box-shadow),
-				outline: 0,
-			),
-			disabled: (
-				box-shadow: clay-enable-shadows(none),
+		media-breakpoint-down: (
+			sm: (
+				background-color: $white,
+				nav-link: (
+					hover: (
+						background-color: rgba($primary, 0.04),
+					),
+					focus: (
+						background-color: rgba($primary, 0.04),
+					),
+					active: (
+						background-color: c-unset,
+						color: c-unset,
+					),
+					active-class: (
+						background-color: rgba($primary, 0.06),
+						color: c-unset,
+					),
+				),
+				menubar-toggler: (
+					color: $gray-900,
+					font-size: 0.875rem,
+					font-weight: $font-weight-semi-bold,
+					transition: box-shadow 0.15s ease-in-out,
+					focus: (
+						box-shadow:
+							clay-enable-shadows($component-focus-box-shadow),
+						outline: 0,
+					),
+					disabled: (
+						box-shadow: clay-enable-shadows(none),
+					),
+				),
 			),
 		),
 	),
@@ -75,10 +78,7 @@ $menubar-vertical-transparent-md: map-deep-merge(
 $menubar-vertical-transparent-lg: () !default;
 $menubar-vertical-transparent-lg: map-deep-merge(
 	(
-		mobile: (
-			background-color: $white,
-		),
-		link: (
+		nav-link: (
 			border-radius: 0.375rem,
 			transition: #{color 0.15s ease-in-out,
 			background-color 0.15s ease-in-out,
@@ -109,33 +109,39 @@ $menubar-vertical-transparent-lg: map-deep-merge(
 				font-weight: $font-weight-semi-bold,
 			),
 		),
-		link-mobile: (
-			hover: (
-				background-color: rgba($primary, 0.04),
-			),
-			focus: (
-				background-color: rgba($primary, 0.04),
-			),
-			active: (
-				background-color: c-unset,
-				color: c-unset,
-			),
-			active-class: (
-				background-color: rgba($primary, 0.06),
-				color: $gray-900,
-			),
-		),
-		toggler-mobile: (
-			color: $gray-900,
-			font-size: 0.875rem,
-			font-weight: $font-weight-semi-bold,
-			transition: box-shadow 0.15s ease-in-out,
-			focus: (
-				box-shadow: clay-enable-shadows($component-focus-box-shadow),
-				outline: 0,
-			),
-			disabled: (
-				box-shadow: clay-enable-shadows(none),
+		media-breakpoint-down: (
+			md: (
+				background-color: $white,
+				nav-link: (
+					hover: (
+						background-color: rgba($primary, 0.04),
+					),
+					focus: (
+						background-color: rgba($primary, 0.04),
+					),
+					active: (
+						background-color: c-unset,
+						color: c-unset,
+					),
+					active-class: (
+						background-color: rgba($primary, 0.06),
+						color: $gray-900,
+					),
+				),
+				menubar-toggler: (
+					color: $gray-900,
+					font-size: 0.875rem,
+					font-weight: $font-weight-semi-bold,
+					transition: box-shadow 0.15s ease-in-out,
+					focus: (
+						box-shadow:
+							clay-enable-shadows($component-focus-box-shadow),
+						outline: 0,
+					),
+					disabled: (
+						box-shadow: clay-enable-shadows(none),
+					),
+				),
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/cadmin/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_menubar.scss
@@ -4,54 +4,58 @@ $cadmin-menubar-vertical-expand-md: () !default;
 $cadmin-menubar-vertical-expand-md: map-deep-merge(
 	(
 		max-width: 250px,
-		mobile: (
-			align-items: center,
-			display: flex,
-			flex-wrap: wrap,
-			justify-content: space-between,
-			margin-bottom: 24px,
-			margin-left: math-sign($cadmin-grid-gutter-width * 0.5),
-			margin-right: math-sign($cadmin-grid-gutter-width * 0.5),
-		),
-		collapse: (
+		menubar-collapse: (
 			display: block,
 		),
-		collapse-mobile: (
-			border-color: transparent,
-			border-style: solid,
-			border-width: 1px,
-			display: none,
-			left: -1px,
-			position: absolute,
-			right: -1px,
-			top: 100%,
-			z-index: $cadmin-zindex-menubar-vertical-expand-md-collapse-mobile,
-		),
-		collapse-nav-mobile: (
-			margin-bottom: 8px,
-			margin-top: 8px,
-		),
-		nav-nested-mobile: (
-			margin-bottom: 8px,
-			margin-top: 8px,
-		),
-		nav-nested-margins-item-mobile: (
-			margin-left: 0,
-		),
-		toggler-mobile: (
-			align-items: center,
-			border-color: transparent,
-			border-style: solid,
-			border-width: 1px,
-			display: flex,
-			height: 32px,
-			padding-left: 8px,
-			padding-right: 8px,
-			c-inner: (
+		media-breakpoint-down: (
+			sm: (
+				align-items: center,
+				display: flex,
+				flex-wrap: wrap,
+				justify-content: space-between,
+				margin-bottom: 24px,
+				margin-left: math-sign($cadmin-grid-gutter-width * 0.5),
+				margin-right: math-sign($cadmin-grid-gutter-width * 0.5),
 				max-width: none,
-			),
-			lexicon-icon: (
-				margin-top: 0,
+				menubar-collapse: (
+					border-color: transparent,
+					border-style: solid,
+					border-width: 1px,
+					display: none,
+					left: -1px,
+					position: absolute,
+					right: -1px,
+					top: 100%,
+					z-index:
+						$cadmin-zindex-menubar-vertical-expand-md-collapse-mobile,
+				),
+				nav-nested: (
+					margin-bottom: 8px,
+					margin-top: 8px,
+				),
+				nav-nested-margins: (
+					margin-bottom: 8px,
+					margin-top: 8px,
+				),
+				nav-nested-margins-item: (
+					margin-left: 0,
+				),
+				menubar-toggler: (
+					align-items: center,
+					border-color: transparent,
+					border-style: solid,
+					border-width: 1px,
+					display: flex,
+					height: 32px,
+					padding-left: 8px,
+					padding-right: 8px,
+					c-inner: (
+						max-width: none,
+					),
+					lexicon-icon: (
+						margin-top: 0,
+					),
+				),
 			),
 		),
 	),
@@ -61,11 +65,7 @@ $cadmin-menubar-vertical-expand-md: map-deep-merge(
 $cadmin-menubar-vertical-transparent-md: () !default;
 $cadmin-menubar-vertical-transparent-md: map-deep-merge(
 	(
-		breakpoint-up: md,
-		mobile: (
-			background-color: $cadmin-white,
-		),
-		link: (
+		nav-link: (
 			border-radius: 6px,
 			transition: #{color 0.15s ease-in-out,
 			background-color 0.15s ease-in-out,
@@ -103,50 +103,58 @@ $cadmin-menubar-vertical-transparent-md: map-deep-merge(
 				font-weight: $cadmin-font-weight-semi-bold,
 			),
 		),
-		link-mobile: (
-			border-radius: clay-enable-rounded(0),
-			color: $cadmin-gray-900,
-			hover: (
-				background-color: rgba($cadmin-primary, 0.04),
-				color: $cadmin-gray-900,
-			),
-			focus: (
-				background-color: rgba($cadmin-primary, 0.04),
-			),
-			active-class: (
-				background-color: rgba($cadmin-primary, 0.06),
-				color: $cadmin-gray-900,
-				font-weight: $cadmin-font-weight-semi-bold,
-			),
-			disabled: (
-				background-color: transparent,
-				color: $cadmin-gray-600,
-			),
-			show: (
-				background-color: c-unset,
-				color: c-unset,
-				font-weight: c-unset,
-			),
-		),
-		collapse-mobile: (
-			background-color: $cadmin-white,
-			border-color: $cadmin-gray-300,
-			border-radius: clay-enable-rounded($cadmin-border-radius),
-			box-shadow: clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
-		),
-		toggler-mobile: (
-			color: $cadmin-gray-900,
-			font-size: 14px,
-			font-weight: $cadmin-font-weight-semi-bold,
-			text-decoration: none,
-			transition: box-shadow 0.15s ease-in-out,
-			focus: (
-				box-shadow:
-					clay-enable-shadows($cadmin-component-focus-box-shadow),
-				outline: 0,
-			),
-			disabled: (
-				box-shadow: clay-enable-shadows(none),
+		media-breakpoint-down: (
+			sm: (
+				background-color: $cadmin-white,
+				nav-link: (
+					border-radius: clay-enable-rounded(0),
+					color: $cadmin-gray-900,
+					hover: (
+						background-color: rgba($cadmin-primary, 0.04),
+						color: $cadmin-gray-900,
+					),
+					focus: (
+						background-color: rgba($cadmin-primary, 0.04),
+					),
+					active-class: (
+						background-color: rgba($cadmin-primary, 0.06),
+						color: $cadmin-gray-900,
+						font-weight: $cadmin-font-weight-semi-bold,
+					),
+					disabled: (
+						background-color: transparent,
+						color: $cadmin-gray-600,
+					),
+					show: (
+						background-color: c-unset,
+						color: c-unset,
+						font-weight: c-unset,
+					),
+				),
+				menubar-collapse: (
+					background-color: $cadmin-white,
+					border-color: $cadmin-gray-300,
+					border-radius: clay-enable-rounded($cadmin-border-radius),
+					box-shadow:
+						clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
+				),
+				menubar-toggler: (
+					color: $cadmin-gray-900,
+					font-size: 14px,
+					font-weight: $cadmin-font-weight-semi-bold,
+					text-decoration: none,
+					transition: box-shadow 0.15s ease-in-out,
+					focus: (
+						box-shadow:
+							clay-enable-shadows(
+								$cadmin-component-focus-box-shadow
+							),
+						outline: 0,
+					),
+					disabled: (
+						box-shadow: clay-enable-shadows(none),
+					),
+				),
 			),
 		),
 	),
@@ -214,56 +222,59 @@ $cadmin-menubar-vertical-decorated-md-nav-link-after-active: map-deep-merge(
 $cadmin-menubar-vertical-expand-lg: () !default;
 $cadmin-menubar-vertical-expand-lg: map-deep-merge(
 	(
-		breakpoint-up: lg,
 		max-width: 250px,
-		mobile: (
-			align-items: center,
-			display: flex,
-			flex-wrap: wrap,
-			justify-content: space-between,
-			margin-bottom: 24px,
-			margin-left: math-sign($cadmin-grid-gutter-width * 0.5),
-			margin-right: math-sign($cadmin-grid-gutter-width * 0.5),
-		),
-		collapse: (
+		menubar-collapse: (
 			display: block,
 		),
-		collapse-mobile: (
-			border-color: transparent,
-			border-style: solid,
-			border-width: 1px,
-			display: none,
-			left: -1px,
-			position: absolute,
-			right: -1px,
-			top: 100%,
-			z-index: $cadmin-zindex-menubar-vertical-expand-md-collapse-mobile,
-		),
-		collapse-nav-mobile: (
-			margin-bottom: 8px,
-			margin-top: 8px,
-		),
-		nav-nested-mobile: (
-			margin-bottom: 8px,
-			margin-top: 8px,
-		),
-		nav-nested-margins-item-mobile: (
-			margin-left: 0,
-		),
-		toggler-mobile: (
-			align-items: center,
-			border-color: transparent,
-			border-style: solid,
-			border-width: 1px,
-			display: flex,
-			height: 32px,
-			padding-left: 8px,
-			padding-right: 8px,
-			c-inner: (
+		media-breakpoint-down: (
+			md: (
+				align-items: center,
+				display: flex,
+				flex-wrap: wrap,
+				justify-content: space-between,
+				margin-bottom: 24px,
+				margin-left: math-sign($cadmin-grid-gutter-width * 0.5),
+				margin-right: math-sign($cadmin-grid-gutter-width * 0.5),
 				max-width: none,
-			),
-			lexicon-icon: (
-				margin-top: 0,
+				menubar-collapse: (
+					border-color: transparent,
+					border-style: solid,
+					border-width: 1px,
+					display: none,
+					left: -1px,
+					position: absolute,
+					right: -1px,
+					top: 100%,
+					z-index:
+						$cadmin-zindex-menubar-vertical-expand-md-collapse-mobile,
+				),
+				nav-nested: (
+					margin-bottom: 8px,
+					margin-top: 8px,
+				),
+				nav-nested-margins: (
+					margin-bottom: 8px,
+					margin-top: 8px,
+				),
+				nav-nested-margins-item: (
+					margin-left: 0,
+				),
+				menubar-toggler: (
+					align-items: center,
+					border-color: transparent,
+					border-style: solid,
+					border-width: 1px,
+					display: flex,
+					height: 32px,
+					padding-left: 8px,
+					padding-right: 8px,
+					c-inner: (
+						max-width: none,
+					),
+					lexicon-icon: (
+						margin-top: 0,
+					),
+				),
 			),
 		),
 	),
@@ -273,11 +284,7 @@ $cadmin-menubar-vertical-expand-lg: map-deep-merge(
 $cadmin-menubar-vertical-transparent-lg: () !default;
 $cadmin-menubar-vertical-transparent-lg: map-deep-merge(
 	(
-		breakpoint-up: lg,
-		mobile: (
-			background-color: $cadmin-white,
-		),
-		link: (
+		nav-link: (
 			border-radius: 6px,
 			transition: #{color 0.15s ease-in-out,
 			background-color 0.15s ease-in-out,
@@ -315,50 +322,58 @@ $cadmin-menubar-vertical-transparent-lg: map-deep-merge(
 				font-weight: $cadmin-font-weight-semi-bold,
 			),
 		),
-		link-mobile: (
-			border-radius: clay-enable-rounded(0),
-			color: $cadmin-gray-900,
-			hover: (
-				background-color: rgba($cadmin-primary, 0.04),
-				color: $cadmin-gray-900,
-			),
-			focus: (
-				background-color: rgba($cadmin-primary, 0.04),
-			),
-			active-class: (
-				background-color: rgba($cadmin-primary, 0.06),
-				color: $cadmin-gray-900,
-				font-weight: $cadmin-font-weight-semi-bold,
-			),
-			disabled: (
-				background-color: transparent,
-				color: $cadmin-gray-600,
-			),
-			show: (
-				background-color: c-unset,
-				color: c-unset,
-				font-weight: c-unset,
-			),
-		),
-		collapse-mobile: (
-			background-color: $cadmin-white,
-			border-color: $cadmin-gray-300,
-			border-radius: clay-enable-rounded($cadmin-border-radius),
-			box-shadow: clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
-		),
-		toggler-mobile: (
-			color: $cadmin-gray-900,
-			font-size: 14px,
-			font-weight: $cadmin-font-weight-semi-bold,
-			text-decoration: none,
-			transition: box-shadow 0.15s ease-in-out,
-			focus: (
-				box-shadow:
-					clay-enable-shadows($cadmin-component-focus-box-shadow),
-				outline: 0,
-			),
-			disabled: (
-				box-shadow: clay-enable-shadows(none),
+		media-breakpoint-down: (
+			md: (
+				background-color: $cadmin-white,
+				nav-link: (
+					border-radius: clay-enable-rounded(0),
+					color: $cadmin-gray-900,
+					hover: (
+						background-color: rgba($cadmin-primary, 0.04),
+						color: $cadmin-gray-900,
+					),
+					focus: (
+						background-color: rgba($cadmin-primary, 0.04),
+					),
+					active-class: (
+						background-color: rgba($cadmin-primary, 0.06),
+						color: $cadmin-gray-900,
+						font-weight: $cadmin-font-weight-semi-bold,
+					),
+					disabled: (
+						background-color: transparent,
+						color: $cadmin-gray-600,
+					),
+					show: (
+						background-color: c-unset,
+						color: c-unset,
+						font-weight: c-unset,
+					),
+				),
+				menubar-collapse: (
+					background-color: $cadmin-white,
+					border-color: $cadmin-gray-300,
+					border-radius: clay-enable-rounded($cadmin-border-radius),
+					box-shadow:
+						clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
+				),
+				menubar-toggler: (
+					color: $cadmin-gray-900,
+					font-size: 14px,
+					font-weight: $cadmin-font-weight-semi-bold,
+					text-decoration: none,
+					transition: box-shadow 0.15s ease-in-out,
+					focus: (
+						box-shadow:
+							clay-enable-shadows(
+								$cadmin-component-focus-box-shadow
+							),
+						outline: 0,
+					),
+					disabled: (
+						box-shadow: clay-enable-shadows(none),
+					),
+				),
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/mixins/_breakpoints.scss
+++ b/packages/clay-css/src/scss/mixins/_breakpoints.scss
@@ -7,33 +7,35 @@
 /// @param {Map} $breakpoints[$grid-breakpoints] - A map that defines the breakpoints
 
 @mixin media-breakpoint-up($name, $breakpoints: null) {
-	$breakpoints: setter(
-		$breakpoints,
-		if(
-			variable-exists(grid-breakpoints),
-			$grid-breakpoints,
+	@if ($name != c-unset) {
+		$breakpoints: setter(
+			$breakpoints,
 			if(
-				variable-exists(cadmin-grid-breakpoints),
-				$cadmin-grid-breakpoints,
-				(
-					xs: 0,
-					sm: 576px,
-					md: 768px,
-					lg: 992px,
-					xl: 1280px,
+				variable-exists(grid-breakpoints),
+				$grid-breakpoints,
+				if(
+					variable-exists(cadmin-grid-breakpoints),
+					$cadmin-grid-breakpoints,
+					(
+						xs: 0,
+						sm: 576px,
+						md: 768px,
+						lg: 992px,
+						xl: 1280px,
+					)
 				)
 			)
-		)
-	);
+		);
 
-	$min: breakpoint-min($name, $breakpoints);
+		$min: breakpoint-min($name, $breakpoints);
 
-	@if $min {
-		@media (min-width: $min) {
+		@if $min {
+			@media (min-width: $min) {
+				@content;
+			}
+		} @else {
 			@content;
 		}
-	} @else {
-		@content;
 	}
 }
 
@@ -42,33 +44,35 @@
 /// @param {Map} $breakpoints[$grid-breakpoints] - A map that defines the breakpoints
 
 @mixin media-breakpoint-down($name, $breakpoints: null) {
-	$breakpoints: setter(
-		$breakpoints,
-		if(
-			variable-exists(grid-breakpoints),
-			$grid-breakpoints,
+	@if ($name != c-unset) {
+		$breakpoints: setter(
+			$breakpoints,
 			if(
-				variable-exists(cadmin-grid-breakpoints),
-				$cadmin-grid-breakpoints,
-				(
-					xs: 0,
-					sm: 576px,
-					md: 768px,
-					lg: 992px,
-					xl: 1280px,
+				variable-exists(grid-breakpoints),
+				$grid-breakpoints,
+				if(
+					variable-exists(cadmin-grid-breakpoints),
+					$cadmin-grid-breakpoints,
+					(
+						xs: 0,
+						sm: 576px,
+						md: 768px,
+						lg: 992px,
+						xl: 1280px,
+					)
 				)
 			)
-		)
-	);
+		);
 
-	$max: breakpoint-max($name, $breakpoints);
+		$max: breakpoint-max($name, $breakpoints);
 
-	@if $max {
-		@media (max-width: $max) {
+		@if $max {
+			@media (max-width: $max) {
+				@content;
+			}
+		} @else {
 			@content;
 		}
-	} @else {
-		@content;
 	}
 }
 

--- a/packages/clay-css/src/scss/mixins/_menubar.scss
+++ b/packages/clay-css/src/scss/mixins/_menubar.scss
@@ -46,11 +46,16 @@
 @mixin clay-menubar-vertical-expand($map) {
 	@if (type-of($map) == 'map') {
 		$enabled: setter(map-get($map, enabled), true);
-		$breakpoint-up: setter(map-get($map, breakpoint-up), md);
-		$breakpoint-down: setter(
-			map-get($map, breakpoint-down),
-			clay-breakpoint-prev($breakpoint-up)
-		);
+		$breakpoint-up: map-get($map, breakpoint-up);
+		$breakpoint-down: setter(map-get($map, breakpoint-down), c-unset);
+
+		@if ($breakpoint-up) and ($breakpoint-up != c-unset) {
+			@warn "`breakpoint-up` is deprecated in the mixin `clay-menubar-vertical-expand`, use the key `media-breakpoint-down: (sm: ())` instead.";
+		}
+
+		@if ($breakpoint-down) and ($breakpoint-down != c-unset) {
+			@warn "`breakpoint-down` is deprecated in the mixin `clay-menubar-vertical-expand`, use the key `media-breakpoint-down: (sm: ())` instead.";
+		}
 
 		// .menubar-vertical-expand-{md}
 
@@ -312,7 +317,13 @@
 			}
 
 			.menubar-collapse {
-				@include clay-css(map-get($map, collapse));
+				$_menubar-collapse: setter(map-get($map, collapse), ());
+				$_menubar-collapse: map-deep-merge(
+					setter(map-get($map, menubar-collapse), ()),
+					$_menubar-collapse
+				);
+
+				@include clay-css($_menubar-collapse);
 
 				@include media-breakpoint-down($breakpoint-down) {
 					@include clay-css($collapse-mobile);
@@ -364,6 +375,46 @@
 						@include clay-css(
 							map-get($map, nav-nested-margins-item-mobile)
 						);
+					}
+				}
+			}
+
+			@if (map-get($map, media-breakpoint-down)) {
+				@each $breakpoint
+					in map-keys(map-get($map, media-breakpoint-down))
+				{
+					$media-breakpoint-down: map-deep-get(
+						$map,
+						media-breakpoint-down,
+						$breakpoint
+					);
+
+					@if ($breakpoint) {
+						@include media-breakpoint-down($breakpoint) {
+							@include clay-menubar-vertical-variant(
+								$media-breakpoint-down
+							);
+						}
+					}
+				}
+			}
+
+			@if (map-get($map, media-breakpoint-up)) {
+				@each $breakpoint
+					in map-keys(map-get($map, media-breakpoint-up))
+				{
+					$media-breakpoint-up: map-deep-get(
+						$map,
+						media-breakpoint-up,
+						$breakpoint
+					);
+
+					@if ($breakpoint) {
+						@include media-breakpoint-up($breakpoint) {
+							@include clay-menubar-vertical-variant(
+								$media-breakpoint-up
+							);
+						}
 					}
 				}
 			}
@@ -462,8 +513,16 @@
 
 @mixin clay-menubar-vertical-variant($map) {
 	$enable: setter(map-get($map, enable), true);
-	$breakpoint-up: setter(map-get($map, breakpoint-up), md);
-	$breakpoint-down: clay-breakpoint-prev($breakpoint-up);
+	$breakpoint-up: map-get($map, breakpoint-up);
+	$breakpoint-down: setter(map-get($map, breakpoint-down), c-unset);
+
+	@if ($breakpoint-up) and ($breakpoint-up != c-unset) {
+		@warn "`breakpoint-up` is deprecated in the mixin `clay-menubar-vertical-variant`, use the key `media-breakpoint-down: (sm: ())` instead.";
+	}
+
+	@if ($breakpoint-down) and ($breakpoint-down != c-unset) {
+		@warn "`breakpoint-down` is deprecated in the mixin `clay-menubar-vertical-variant`, use the key `media-breakpoint-down: (sm: ())` instead.";
+	}
 
 	// .menubar-vertical-expand-{md}.menubar-{variant}
 
@@ -855,7 +914,13 @@
 		}
 
 		.menubar-collapse {
-			@include clay-css(map-get($map, collapse));
+			$_menubar-collapse: setter(map-get($map, collapse), ());
+			$_menubar-collapse: map-merge(
+				setter(map-get($map, menubar-collapse), ()),
+				$_menubar-collapse
+			);
+
+			@include clay-css($_menubar-collapse);
 
 			@include media-breakpoint-down($breakpoint-down) {
 				@include clay-css($collapse-mobile);
@@ -863,9 +928,25 @@
 		}
 
 		.menubar-toggler {
+			$_menubar-toggler: setter(map-get($map, menubar-toggler), ());
+
+			@include clay-css($_menubar-toggler);
+
+			.c-inner {
+				@include clay-css(map-get($_menubar-toggler, c-inner));
+			}
+
+			.lexicon-icon {
+				@include clay-css(map-get($_menubar-toggler, lexicon-icon));
+			}
+
 			@include media-breakpoint-down($breakpoint-down) {
 				@include clay-button-variant($toggler-mobile);
 			}
+		}
+
+		.nav-nested {
+			@include clay-css(map-get($map, nav-nested));
 		}
 
 		.nav-nested-margins {
@@ -881,10 +962,50 @@
 		}
 
 		.nav-link {
-			@include clay-link($link);
+			$_nav-link: setter(map-get($map, nav-link), ());
+			$_nav-link: map-deep-merge($link, $_nav-link);
+
+			@include clay-link($_nav-link);
 
 			@include media-breakpoint-down($breakpoint-down) {
 				@include clay-link($link-mobile);
+			}
+		}
+
+		@if (map-get($map, media-breakpoint-down)) {
+			@each $breakpoint in map-keys(map-get($map, media-breakpoint-down))
+			{
+				$media-breakpoint-down: map-deep-get(
+					$map,
+					media-breakpoint-down,
+					$breakpoint
+				);
+
+				@if ($breakpoint) {
+					@include media-breakpoint-down($breakpoint) {
+						@include clay-menubar-vertical-variant(
+							$media-breakpoint-down
+						);
+					}
+				}
+			}
+		}
+
+		@if (map-get($map, media-breakpoint-up)) {
+			@each $breakpoint in map-keys(map-get($map, media-breakpoint-up)) {
+				$media-breakpoint-up: map-deep-get(
+					$map,
+					media-breakpoint-up,
+					$breakpoint
+				);
+
+				@if ($breakpoint) {
+					@include media-breakpoint-up($breakpoint) {
+						@include clay-menubar-vertical-variant(
+							$media-breakpoint-up
+						);
+					}
+				}
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/variables/_menubar.scss
@@ -4,54 +4,51 @@ $menubar-vertical-expand-md: () !default;
 $menubar-vertical-expand-md: map-deep-merge(
 	(
 		max-width: 15.625rem,
-		mobile: (
-			align-items: center,
-			display: flex,
-			flex-wrap: wrap,
-			justify-content: space-between,
-			margin-bottom: 1.5rem,
-			margin-left: math-sign($grid-gutter-width * 0.5),
-			margin-right: math-sign($grid-gutter-width * 0.5),
-		),
-		collapse: (
+		menubar-collapse: (
 			display: block,
 		),
-		collapse-mobile: (
-			border-color: transparent,
-			border-style: solid,
-			border-width: 0.0625rem,
-			display: none,
-			left: -0.0625rem,
-			position: absolute,
-			right: -0.0625rem,
-			top: 100%,
-			z-index: $zindex-menubar-vertical-expand-md-collapse-mobile,
-		),
-		collapse-nav-mobile: (
-			margin-bottom: 0.5rem,
-			margin-top: 0.5rem,
-		),
-		nav-nested-mobile: (
-			margin-bottom: 0.5rem,
-			margin-top: 0.5rem,
-		),
-		nav-nested-margins-item-mobile: (
-			margin-left: 0,
-		),
-		toggler-mobile: (
-			align-items: center,
-			border-color: transparent,
-			border-style: solid,
-			border-width: 0.0625rem,
-			display: flex,
-			height: 2rem,
-			padding-left: 0.5rem,
-			padding-right: 0.5rem,
-			c-inner: (
+		media-breakpoint-down: (
+			sm: (
+				margin-bottom: 1.5rem,
+				margin-left: math-sign($grid-gutter-width * 0.5),
+				margin-right: math-sign($grid-gutter-width * 0.5),
 				max-width: none,
-			),
-			lexicon-icon: (
-				margin-top: 0,
+				menubar-collapse: (
+					border-color: transparent,
+					border-style: solid,
+					border-width: 0.0625rem,
+					display: none,
+					position: relative,
+					top: 100%,
+					z-index: $zindex-menubar-vertical-expand-md-collapse-mobile,
+				),
+				nav-nested: (
+					margin-bottom: 0.5rem,
+					margin-top: 0.5rem,
+				),
+				nav-nested-margins: (
+					margin-bottom: 0.5rem,
+					margin-top: 0.5rem,
+				),
+				nav-nested-margins-item: (
+					margin-left: 0,
+				),
+				menubar-toggler: (
+					align-items: center,
+					border-color: transparent,
+					border-style: solid,
+					border-width: 0.0625rem,
+					display: flex,
+					height: 2rem,
+					padding-left: 0.5rem,
+					padding-right: 0.5rem,
+					c-inner: (
+						max-width: none,
+					),
+					lexicon-icon: (
+						margin-top: 0,
+					),
+				),
 			),
 		),
 	),
@@ -61,11 +58,7 @@ $menubar-vertical-expand-md: map-deep-merge(
 $menubar-vertical-transparent-md: () !default;
 $menubar-vertical-transparent-md: map-deep-merge(
 	(
-		breakpoint-up: md,
-		mobile: (
-			background-color: $gray-100,
-		),
-		link: (
+		nav-link: (
 			color: $gray-600,
 			hover: (
 				color: clay-darken($gray-600, 15),
@@ -80,38 +73,44 @@ $menubar-vertical-transparent-md: map-deep-merge(
 				color: rgba($black, 0.3),
 			),
 		),
-		link-mobile: (
-			border-radius: clay-enable-rounded(0),
-			color: $gray-900,
-			hover: (
+		media-breakpoint-down: (
+			sm: (
 				background-color: $gray-100,
-				color: clay-darken($gray-900, 5%),
+				nav-link: (
+					border-radius: clay-enable-rounded(0),
+					color: $gray-900,
+					hover: (
+						background-color: $gray-100,
+						color: clay-darken($gray-900, 5%),
+					),
+					active: (
+						background-color: $component-active-bg,
+						color: $component-active-color,
+					),
+					active-class: (
+						font-weight: $font-weight-semi-bold,
+					),
+					disabled: (
+						background-color: transparent,
+						color: $gray-600,
+					),
+					show: (
+						background-color: c-unset,
+						color: c-unset,
+						font-weight: c-unset,
+					),
+				),
+				menubar-collapse: (
+					background-color: $white,
+					border-color: $gray-300,
+					border-radius: clay-enable-rounded($border-radius),
+					box-shadow:
+						clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
+				),
+				menubar-toggler: (
+					text-decoration: none,
+				),
 			),
-			active: (
-				background-color: $component-active-bg,
-				color: $component-active-color,
-			),
-			active-class: (
-				font-weight: $font-weight-semi-bold,
-			),
-			disabled: (
-				background-color: transparent,
-				color: $gray-600,
-			),
-			show: (
-				background-color: c-unset,
-				color: c-unset,
-				font-weight: c-unset,
-			),
-		),
-		collapse-mobile: (
-			background-color: $white,
-			border-color: $gray-300,
-			border-radius: clay-enable-rounded($border-radius),
-			box-shadow: clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
-		),
-		toggler-mobile: (
-			text-decoration: none,
 		),
 	),
 	$menubar-vertical-transparent-md
@@ -169,56 +168,52 @@ $menubar-vertical-decorated-md-nav-link-after-active: map-deep-merge(
 $menubar-vertical-expand-lg: () !default;
 $menubar-vertical-expand-lg: map-deep-merge(
 	(
-		breakpoint-up: lg,
 		max-width: 15.625rem,
-		mobile: (
-			align-items: center,
-			display: flex,
-			flex-wrap: wrap,
-			justify-content: space-between,
-			margin-bottom: 1.5rem,
-			margin-left: math-sign($grid-gutter-width * 0.5),
-			margin-right: math-sign($grid-gutter-width * 0.5),
-		),
-		collapse: (
+		menubar-collapse: (
 			display: block,
 		),
-		collapse-mobile: (
-			border-color: transparent,
-			border-style: solid,
-			border-width: 0.0625rem,
-			display: none,
-			left: -0.0625rem,
-			position: absolute,
-			right: -0.0625rem,
-			top: 100%,
-			z-index: $zindex-menubar-vertical-expand-md-collapse-mobile,
-		),
-		nav-nested-mobile: (
-			margin-bottom: 0.5rem,
-			margin-top: 0.5rem,
-		),
-		nav-nested-margins-mobile: (
-			margin-bottom: 0.5rem,
-			margin-top: 0.5rem,
-		),
-		nav-nested-margins-item-mobile: (
-			margin-left: 0,
-		),
-		toggler-mobile: (
-			align-items: center,
-			border-color: transparent,
-			border-style: solid,
-			border-width: 0.0625rem,
-			display: flex,
-			height: 2rem,
-			padding-left: 0.5rem,
-			padding-right: 0.5rem,
-			c-inner: (
+		media-breakpoint-down: (
+			md: (
+				margin-bottom: 1.5rem,
+				margin-left: math-sign($grid-gutter-width * 0.5),
+				margin-right: math-sign($grid-gutter-width * 0.5),
 				max-width: none,
-			),
-			lexicon-icon: (
-				margin-top: 0,
+				menubar-collapse: (
+					border-color: transparent,
+					border-style: solid,
+					border-width: 0.0625rem,
+					display: none,
+					position: relative,
+					top: 100%,
+					z-index: $zindex-menubar-vertical-expand-md-collapse-mobile,
+				),
+				nav-nested: (
+					margin-bottom: 0.5rem,
+					margin-top: 0.5rem,
+				),
+				nav-nested-margins: (
+					margin-bottom: 0.5rem,
+					margin-top: 0.5rem,
+				),
+				nav-nested-margins-item: (
+					margin-left: 0,
+				),
+				menubar-toggler: (
+					align-items: center,
+					border-color: transparent,
+					border-style: solid,
+					border-width: 0.0625rem,
+					display: flex,
+					height: 2rem,
+					padding-left: 0.5rem,
+					padding-right: 0.5rem,
+					c-inner: (
+						max-width: none,
+					),
+					lexicon-icon: (
+						margin-top: 0,
+					),
+				),
 			),
 		),
 	),
@@ -228,11 +223,7 @@ $menubar-vertical-expand-lg: map-deep-merge(
 $menubar-vertical-transparent-lg: () !default;
 $menubar-vertical-transparent-lg: map-deep-merge(
 	(
-		breakpoint-up: lg,
-		mobile: (
-			background-color: $gray-100,
-		),
-		link: (
+		nav-link: (
 			color: $gray-600,
 			hover: (
 				color: clay-darken($gray-600, 15),
@@ -247,38 +238,44 @@ $menubar-vertical-transparent-lg: map-deep-merge(
 				color: rgba($black, 0.3),
 			),
 		),
-		link-mobile: (
-			border-radius: clay-enable-rounded(0),
-			color: $gray-900,
-			hover: (
+		media-breakpoint-down: (
+			md: (
 				background-color: $gray-100,
-				color: clay-darken($gray-900, 5%),
+				nav-link: (
+					border-radius: clay-enable-rounded(0),
+					color: $gray-900,
+					hover: (
+						background-color: $gray-100,
+						color: clay-darken($gray-900, 5%),
+					),
+					active: (
+						background-color: $component-active-bg,
+						color: $component-active-color,
+					),
+					active-class: (
+						font-weight: $font-weight-semi-bold,
+					),
+					disabled: (
+						background-color: transparent,
+						color: $gray-600,
+					),
+					show: (
+						background-color: c-unset,
+						color: c-unset,
+						font-weight: c-unset,
+					),
+				),
+				menubar-collapse: (
+					background-color: $white,
+					border-color: $gray-300,
+					border-radius: clay-enable-rounded($border-radius),
+					box-shadow:
+						clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
+				),
+				menubar-toggler: (
+					text-decoration: none,
+				),
 			),
-			active: (
-				background-color: $component-active-bg,
-				color: $component-active-color,
-			),
-			active-class: (
-				font-weight: $font-weight-semi-bold,
-			),
-			disabled: (
-				background-color: transparent,
-				color: $gray-600,
-			),
-			show: (
-				background-color: c-unset,
-				color: c-unset,
-				font-weight: c-unset,
-			),
-		),
-		collapse-mobile: (
-			background-color: $white,
-			border-color: $gray-300,
-			border-radius: clay-enable-rounded($border-radius),
-			box-shadow: clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
-		),
-		toggler-mobile: (
-			text-decoration: none,
 		),
 	),
 	$menubar-vertical-transparent-lg

--- a/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -48,7 +48,7 @@ exports[`ClayNavigationBar collapses the previously expanded dropdown when trigg
 exports[`ClayNavigationBar renders 1`] = `
 <div>
   <nav
-    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
+    class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
   >
     <div
       class="container-fluid container-fluid-max-xl"
@@ -136,7 +136,7 @@ exports[`ClayNavigationBar renders 1`] = `
 exports[`ClayNavigationBar renders a custom item 1`] = `
 <div>
   <nav
-    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
+    class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
   >
     <div
       class="container-fluid container-fluid-max-xl"
@@ -236,7 +236,7 @@ exports[`ClayNavigationBar renders a dropdown when clicking the trigger element 
 exports[`ClayNavigationBar renders when passing more than one active item 1`] = `
 <div>
   <nav
-    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
+    class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
   >
     <div
       class="container-fluid container-fluid-max-xl"
@@ -324,7 +324,7 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
 exports[`ClayNavigationBar renders with a single item 1`] = `
 <div>
   <nav
-    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
+    class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
   >
     <div
       class="container-fluid container-fluid-max-xl"
@@ -384,7 +384,7 @@ exports[`ClayNavigationBar renders with a single item 1`] = `
 exports[`ClayNavigationBar throws a warning when passing more than one active prop to child 1`] = `
 <div>
   <nav
-    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
+    class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
   >
     <div
       class="container-fluid container-fluid-max-xl"

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -77,7 +77,7 @@ function ClayNavigationBar({
 			className={classNames(
 				className,
 				'navbar',
-				'navbar-collapse-absolute',
+				'navbar-collapse-relative',
 				'navbar-expand-md',
 				'navbar-underline',
 				'navigation-bar',


### PR DESCRIPTION
fixes #5397

![menubar-mobile](https://user-images.githubusercontent.com/788266/223579872-c67f672f-5a1b-4b82-abb9-9520787406ea.jpg)


@marcoscv-work There's nothing I can do for [Navigation Bar](https://clayui.com/docs/components/navigation-bar.html). It's already at 100% width. The container it's in is the limitation. We could add some JS that re-calculates the `left` and `right` positions when the  screen size changes, but I'm not sure if we want that.