### PR TITLE
fix(@clayui/date-picker): fix focus bug in date picker

### DIFF
--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -131,8 +131,10 @@ export const useCalendarNavigation = ({
 				}).toDateString()}"]`
 			);
 
-		nextFocusElement!.focus();
-		setLastItemFocused(String(day.date.getDate()));
+		if (nextFocusElement) {
+			nextFocusElement!.focus();
+			setLastItemFocused(String(day.date.getDate()));
+		}
 	}, []);
 
 	const onKeyDown = useCallback(


### PR DESCRIPTION
Fixes #5324

This PR fixes the bug of recovering focus in case of date range when selecting a date in another month.