### PR TITLE
chore(@clayui/core): hide Dnd text for SR

### DIFF
--- a/packages/clay-core/src/tree-view/DragAndDrop.tsx
+++ b/packages/clay-core/src/tree-view/DragAndDrop.tsx
@@ -348,7 +348,11 @@ export const DragAndDropProvider = ({
 			{dragAndDrop && (
 				<>
 					{createPortal(
-						<div id={dragDescribedBy} style={{display: 'none'}}>
+						<div
+							aria-hidden="true"
+							id={dragDescribedBy}
+							style={{display: 'none'}}
+						>
 							{messages.dragDescriptionKeyboard}
 						</div>,
 						document.body
@@ -358,6 +362,7 @@ export const DragAndDropProvider = ({
 						<>
 							{createPortal(
 								<div
+									aria-hidden="true"
 									id={dragDropDescribedBy}
 									style={{display: 'none'}}
 								>
@@ -367,6 +372,7 @@ export const DragAndDropProvider = ({
 							)}
 							{createPortal(
 								<div
+									aria-hidden="true"
 									id={dragCancelDescribedBy}
 									style={{display: 'none'}}
 								>


### PR DESCRIPTION
Just a complement and a bug I found while investigating issue #5385 where JAWS was focusing on support text for TreeView DnD indicators.