### PR TITLE
fix(@clayui/date-picker): updateDate is memoized without dateFormat dependency

### DIFF
--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -512,7 +512,7 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 					}
 				}
 			},
-			[dateFormat]
+			[dateFormat, use12Hours, time, years, yearsCheck]
 		);
 
 		/**

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -470,44 +470,50 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			setValue(daysSelectedToString);
 		};
 
-		const updateDate = useCallback((value: string) => {
-			if (!value) {
-				changeMonth(initialMonth);
+		const updateDate = useCallback(
+			(value: string) => {
+				if (!value) {
+					changeMonth(initialMonth);
 
-				setDaysSelected([initialMonth, initialMonth]);
-
-				if (time) {
-					setCurrentTime('--', '--', undefined);
-				}
-			} else {
-				const days = hasDaysSelected({
-					checkRangeYears: yearsCheck,
-					dateFormat,
-					is12Hours: use12Hours,
-					isTime: time,
-					value,
-					years,
-				});
-
-				if (days) {
-					const [startDate, endDate] = days;
-
-					changeMonth(startDate);
-
-					setDaysSelected([startDate, endDate]);
+					setDaysSelected([initialMonth, initialMonth]);
 
 					if (time) {
-						setCurrentTime(
-							startDate.getHours(),
-							startDate.getMinutes(),
-							use12Hours
-								? (formatDate(startDate, 'a') as Input['ampm'])
-								: undefined
-						);
+						setCurrentTime('--', '--', undefined);
+					}
+				} else {
+					const days = hasDaysSelected({
+						checkRangeYears: yearsCheck,
+						dateFormat,
+						is12Hours: use12Hours,
+						isTime: time,
+						value,
+						years,
+					});
+
+					if (days) {
+						const [startDate, endDate] = days;
+
+						changeMonth(startDate);
+
+						setDaysSelected([startDate, endDate]);
+
+						if (time) {
+							setCurrentTime(
+								startDate.getHours(),
+								startDate.getMinutes(),
+								use12Hours
+									? (formatDate(
+											startDate,
+											'a'
+									  ) as Input['ampm'])
+									: undefined
+							);
+						}
 					}
 				}
-			}
-		}, []);
+			},
+			[dateFormat]
+		);
 
 		/**
 		 * Control the value of the input propagating with the call


### PR DESCRIPTION
Fixes: #5404

The root cause of the issue was the memoized updateDate, where I had to include the dateFormat in the dependancy array, as changing this value has an effect on the result.
I also made another commit, where I included every dependancy for the useCallback memoization, I left it in a separate commit in case you don't want to merge that.

Please review my changes.

Thanks