### PR TITLE
feat(@clayui/core): Vertical Bar adds resizing to VerticalBar.Panel

### DIFF
--- a/packages/clay-core/src/vertical-bar/Panel.tsx
+++ b/packages/clay-core/src/vertical-bar/Panel.tsx
@@ -8,6 +8,7 @@ import React, {useContext, useEffect, useRef} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
 import {ContentContext} from './Content';
+import {Resizer} from './Resizer';
 import {VerticalBarContext} from './context';
 
 function useIsFirstRender(): boolean {
@@ -41,10 +42,19 @@ type Props = {
 };
 
 export function Panel({children, keyValue, tabIndex}: Props) {
-	const {activePanel, id} = useContext(VerticalBarContext);
+	const {
+		activePanel,
+		id,
+		internalPanelWidth,
+		panelWidthMax,
+		panelWidthMin,
+		resize,
+	} = useContext(VerticalBarContext);
 	const {displayType} = useContext(ContentContext);
 
 	const isFirst = useIsFirstRender();
+
+	const nodeRef = useRef<HTMLDivElement | null>(null);
 
 	const previousActivePanelRef = useRef<React.Key | null>(null);
 
@@ -68,6 +78,7 @@ export function Panel({children, keyValue, tabIndex}: Props) {
 			}}
 			id={`${id}-tabpanel-${keyValue}`}
 			in={activePanel === keyValue}
+			nodeRef={nodeRef}
 			role="tabpanel"
 			tabIndex={tabIndex}
 			timeout={
@@ -80,7 +91,26 @@ export function Panel({children, keyValue, tabIndex}: Props) {
 			}
 			unmountOnExit
 		>
-			<div>{children}</div>
+			<div
+				ref={nodeRef}
+				style={{
+					width: internalPanelWidth,
+				}}
+			>
+				{children}
+
+				{resize && (
+					<Resizer
+						aria-controls={`${id}-tabpanel-${keyValue}`}
+						aria-orientation="vertical"
+						aria-valuemax={panelWidthMax}
+						aria-valuemin={panelWidthMin}
+						aria-valuenow={internalPanelWidth}
+						className="c-horizontal-resizer"
+						nodeRef={nodeRef}
+					/>
+				)}
+			</div>
 		</CSSTransition>
 	);
 }

--- a/packages/clay-core/src/vertical-bar/Panel.tsx
+++ b/packages/clay-core/src/vertical-bar/Panel.tsx
@@ -42,14 +42,8 @@ type Props = {
 };
 
 export function Panel({children, keyValue, tabIndex}: Props) {
-	const {
-		activePanel,
-		id,
-		internalPanelWidth,
-		panelWidthMax,
-		panelWidthMin,
-		resize,
-	} = useContext(VerticalBarContext);
+	const {activePanel, id, panelWidth, panelWidthMax, panelWidthMin, resize} =
+		useContext(VerticalBarContext);
 	const {displayType} = useContext(ContentContext);
 
 	const isFirst = useIsFirstRender();
@@ -94,7 +88,7 @@ export function Panel({children, keyValue, tabIndex}: Props) {
 			<div
 				ref={nodeRef}
 				style={{
-					width: internalPanelWidth,
+					width: panelWidth,
 				}}
 			>
 				{children}
@@ -105,7 +99,7 @@ export function Panel({children, keyValue, tabIndex}: Props) {
 						aria-orientation="vertical"
 						aria-valuemax={panelWidthMax}
 						aria-valuemin={panelWidthMin}
-						aria-valuenow={internalPanelWidth}
+						aria-valuenow={panelWidth}
 						className="c-horizontal-resizer"
 						nodeRef={nodeRef}
 					/>

--- a/packages/clay-core/src/vertical-bar/Resizer.tsx
+++ b/packages/clay-core/src/vertical-bar/Resizer.tsx
@@ -24,8 +24,8 @@ let keyDownCounter = 0;
 
 export function Resizer({nodeRef, ...otherProps}: Props) {
 	const {
-		internalPanelWidth,
 		onPanelWidthChange,
+		panelWidth,
 		panelWidthMax,
 		panelWidthMin,
 		position,
@@ -39,7 +39,7 @@ export function Resizer({nodeRef, ...otherProps}: Props) {
 
 	const decreasePanelWidth = (delta = 1, startWidth = getStartWidth()) => {
 		const width =
-			internalPanelWidth - delta < panelWidthMin
+			panelWidth - delta < panelWidthMin
 				? panelWidthMin
 				: startWidth - delta;
 
@@ -48,7 +48,7 @@ export function Resizer({nodeRef, ...otherProps}: Props) {
 
 	const increasePanelWidth = (delta = 1, startWidth = getStartWidth()) => {
 		const width =
-			internalPanelWidth + delta > panelWidthMax
+			panelWidth + delta > panelWidthMax
 				? panelWidthMax
 				: startWidth + delta;
 
@@ -137,6 +137,6 @@ export function Resizer({nodeRef, ...otherProps}: Props) {
 			}}
 			role="separator"
 			tabIndex={0}
-		></div>
+		/>
 	);
 }

--- a/packages/clay-core/src/vertical-bar/Resizer.tsx
+++ b/packages/clay-core/src/vertical-bar/Resizer.tsx
@@ -38,21 +38,25 @@ export function Resizer({nodeRef, ...otherProps}: Props) {
 	};
 
 	const decreasePanelWidth = (delta = 1, startWidth = getStartWidth()) => {
-		const width =
-			panelWidth - delta < panelWidthMin
-				? panelWidthMin
-				: startWidth - delta;
+		if (panelWidth >= panelWidthMin) {
+			const width =
+				panelWidth - delta < panelWidthMin
+					? panelWidthMin
+					: startWidth - delta;
 
-		onPanelWidthChange(Math.round(width));
+			onPanelWidthChange(Math.round(width));
+		}
 	};
 
 	const increasePanelWidth = (delta = 1, startWidth = getStartWidth()) => {
-		const width =
-			panelWidth + delta > panelWidthMax
-				? panelWidthMax
-				: startWidth + delta;
+		if (panelWidth <= panelWidthMax) {
+			const width =
+				panelWidth + delta > panelWidthMax
+					? panelWidthMax
+					: startWidth + delta;
 
-		onPanelWidthChange(Math.round(width));
+			onPanelWidthChange(Math.round(width));
+		}
 	};
 
 	return (

--- a/packages/clay-core/src/vertical-bar/Resizer.tsx
+++ b/packages/clay-core/src/vertical-bar/Resizer.tsx
@@ -20,6 +20,8 @@ type Props = {
 	nodeRef?: React.RefObject<HTMLDivElement>;
 };
 
+const MAIN_MOUSE_BUTTON = 0;
+
 let keyDownCounter = 0;
 
 export function Resizer({nodeRef, ...otherProps}: Props) {
@@ -133,7 +135,7 @@ export function Resizer({nodeRef, ...otherProps}: Props) {
 					);
 				}
 
-				if (event.button === 0) {
+				if (event.button === MAIN_MOUSE_BUTTON) {
 					document.addEventListener('pointermove', onResizerMove);
 
 					document.addEventListener('pointerup', removeResizerEvents);

--- a/packages/clay-core/src/vertical-bar/Resizer.tsx
+++ b/packages/clay-core/src/vertical-bar/Resizer.tsx
@@ -1,0 +1,142 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {Keys} from '@clayui/shared';
+import React, {useContext} from 'react';
+
+import {VerticalBarContext} from './context';
+
+type Props = {
+	/**
+	 * Sets the CSS className for the component.
+	 */
+	className?: string;
+
+	/**
+	 * Reference to Panel
+	 */
+	nodeRef?: React.RefObject<HTMLDivElement>;
+};
+
+let keyDownCounter = 0;
+
+export function Resizer({nodeRef, ...otherProps}: Props) {
+	const {
+		internalPanelWidth,
+		onPanelWidthChange,
+		panelWidthMax,
+		panelWidthMin,
+		position,
+	} = useContext(VerticalBarContext);
+
+	const positionLeft = position === 'left';
+
+	const getStartWidth = () => {
+		return nodeRef?.current?.offsetWidth || 320;
+	};
+
+	const decreasePanelWidth = (delta = 1, startWidth = getStartWidth()) => {
+		const width =
+			internalPanelWidth - delta < panelWidthMin
+				? panelWidthMin
+				: startWidth - delta;
+
+		onPanelWidthChange(Math.round(width));
+	};
+
+	const increasePanelWidth = (delta = 1, startWidth = getStartWidth()) => {
+		const width =
+			internalPanelWidth + delta > panelWidthMax
+				? panelWidthMax
+				: startWidth + delta;
+
+		onPanelWidthChange(Math.round(width));
+	};
+
+	return (
+		<div
+			{...otherProps}
+			onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+				const delta = keyDownCounter > 7 ? 10 : 1;
+
+				keyDownCounter++;
+
+				switch (event.key) {
+					case Keys.Down: {
+						decreasePanelWidth(delta);
+
+						break;
+					}
+					case Keys.Left: {
+						if (positionLeft) {
+							decreasePanelWidth(delta);
+						} else {
+							increasePanelWidth(delta);
+						}
+
+						break;
+					}
+					case Keys.Right: {
+						if (positionLeft) {
+							increasePanelWidth(delta);
+						} else {
+							decreasePanelWidth(delta);
+						}
+
+						break;
+					}
+					case Keys.Up: {
+						increasePanelWidth(delta);
+
+						break;
+					}
+					default: {
+						break;
+					}
+				}
+			}}
+			onKeyUp={() => {
+				keyDownCounter = 0;
+			}}
+			onPointerDown={(event) => {
+				const startWidth = getStartWidth();
+				const startXPos = event.pageX;
+
+				function onResizerMove(event: any) {
+					const delta = Math.abs(event.pageX - startXPos);
+
+					if (
+						(event.pageX >= startXPos && positionLeft) ||
+						(event.pageX < startXPos && !positionLeft)
+					) {
+						increasePanelWidth(delta, startWidth);
+					} else if (
+						(event.pageX < startXPos && positionLeft) ||
+						(event.pageX >= startXPos && !positionLeft)
+					) {
+						decreasePanelWidth(delta, startWidth);
+					}
+				}
+
+				function removeResizerEvents() {
+					document.removeEventListener('pointermove', onResizerMove);
+
+					document.removeEventListener(
+						'pointerup',
+						removeResizerEvents
+					);
+				}
+
+				if (event.button === 0) {
+					document.addEventListener('pointermove', onResizerMove);
+
+					document.addEventListener('pointerup', removeResizerEvents);
+				}
+			}}
+			role="separator"
+			tabIndex={0}
+		></div>
+	);
+}

--- a/packages/clay-core/src/vertical-bar/Resizer.tsx
+++ b/packages/clay-core/src/vertical-bar/Resizer.tsx
@@ -25,13 +25,8 @@ const MAIN_MOUSE_BUTTON = 0;
 let keyDownCounter = 0;
 
 export function Resizer({nodeRef, ...otherProps}: Props) {
-	const {
-		onPanelWidthChange,
-		panelWidth,
-		panelWidthMax,
-		panelWidthMin,
-		position,
-	} = useContext(VerticalBarContext);
+	const {onPanelWidthChange, panelWidthMax, panelWidthMin, position} =
+		useContext(VerticalBarContext);
 
 	const positionLeft = position === 'left';
 
@@ -40,24 +35,22 @@ export function Resizer({nodeRef, ...otherProps}: Props) {
 	};
 
 	const decreasePanelWidth = (delta = 1, startWidth = getStartWidth()) => {
-		if (panelWidth >= panelWidthMin) {
-			const width =
-				panelWidth - delta < panelWidthMin
-					? panelWidthMin
-					: startWidth - delta;
+		const width = Math.round(startWidth - delta);
 
-			onPanelWidthChange(Math.round(width));
+		if (width > panelWidthMin - 100 && width < panelWidthMin) {
+			onPanelWidthChange(panelWidthMin);
+		} else if (width > panelWidthMin) {
+			onPanelWidthChange(width);
 		}
 	};
 
 	const increasePanelWidth = (delta = 1, startWidth = getStartWidth()) => {
-		if (panelWidth <= panelWidthMax) {
-			const width =
-				panelWidth + delta > panelWidthMax
-					? panelWidthMax
-					: startWidth + delta;
+		const width = Math.round(startWidth + delta);
 
-			onPanelWidthChange(Math.round(width));
+		if (width > panelWidthMax && width < panelWidthMax + 100) {
+			onPanelWidthChange(panelWidthMax);
+		} else if (width < panelWidthMax) {
+			onPanelWidthChange(width);
 		}
 	};
 

--- a/packages/clay-core/src/vertical-bar/VerticalBar.tsx
+++ b/packages/clay-core/src/vertical-bar/VerticalBar.tsx
@@ -40,6 +40,11 @@ type Props = {
 	className?: string;
 
 	/**
+	 * Panel width initial value (uncontrolled).
+	 */
+	defaultPanelWidth?: number;
+
+	/**
 	 * Sets the position of the vertical bar.
 	 */
 	position?: 'left' | 'right';
@@ -60,7 +65,12 @@ type Props = {
 	onActiveChange?: InternalDispatch<React.Key | null>;
 
 	/**
-	 * Sets a custom width on the sidebar panel.
+	 * Callback called when panel width changes (controlled).
+	 */
+	onPanelWidthChange?: InternalDispatch<number>;
+
+	/**
+	 * Sets a custom width on the sidebar panel (controlled).
 	 */
 	panelWidth?: number;
 
@@ -94,8 +104,10 @@ export function VerticalBar({
 	children,
 	className,
 	defaultActive = null,
+	defaultPanelWidth = 320,
 	onActiveChange,
-	panelWidth = 320,
+	onPanelWidthChange,
+	panelWidth: externalPanelWidth,
 	panelWidthMax = 500,
 	panelWidthMin = 280,
 	position = 'right',
@@ -112,8 +124,14 @@ export function VerticalBar({
 
 	const id = useId();
 
-	const [internalPanelWidth, setInternalPanelWidth] =
-		React.useState(panelWidth);
+	const [panelWidth, setPanelWidth] = useInternalState({
+		defaultName: 'defaultPanelWidth',
+		defaultValue: defaultPanelWidth,
+		handleName: 'onPanelWidthChange',
+		name: 'panelWidth',
+		onChange: onPanelWidthChange,
+		value: externalPanelWidth,
+	});
 
 	return (
 		<div
@@ -129,9 +147,9 @@ export function VerticalBar({
 					activation,
 					activePanel,
 					id: `${id}-verticalbar`,
-					internalPanelWidth,
 					onActivePanel: setActivePanel,
-					onPanelWidthChange: setInternalPanelWidth,
+					onPanelWidthChange: setPanelWidth,
+					panelWidth,
 					panelWidthMax,
 					panelWidthMin,
 					position,

--- a/packages/clay-core/src/vertical-bar/VerticalBar.tsx
+++ b/packages/clay-core/src/vertical-bar/VerticalBar.tsx
@@ -58,6 +58,26 @@ type Props = {
 	 * Callback is called when the active state changes (controlled).
 	 */
 	onActiveChange?: InternalDispatch<React.Key | null>;
+
+	/**
+	 * Sets a custom width on the sidebar panel.
+	 */
+	panelWidth?: number;
+
+	/**
+	 * Sets a maximum width on the sidebar panel.
+	 */
+	panelWidthMax?: number;
+
+	/**
+	 * Sets a minimum width on the sidebar panel.
+	 */
+	panelWidthMin?: number;
+
+	/**
+	 * Flag to enable resizing the sidebar panel.
+	 */
+	resize?: boolean;
 };
 
 export function VerticalBar(props: Props): JSX.Element & {
@@ -75,7 +95,11 @@ export function VerticalBar({
 	className,
 	defaultActive = null,
 	onActiveChange,
+	panelWidth = 320,
+	panelWidthMax = 500,
+	panelWidthMin = 280,
 	position = 'right',
+	resize = false,
 }: Props) {
 	const [activePanel, setActivePanel] = useInternalState<React.Key | null>({
 		defaultName: 'defaultItems',
@@ -87,6 +111,9 @@ export function VerticalBar({
 	});
 
 	const id = useId();
+
+	const [internalPanelWidth, setInternalPanelWidth] =
+		React.useState(panelWidth);
 
 	return (
 		<div
@@ -102,7 +129,13 @@ export function VerticalBar({
 					activation,
 					activePanel,
 					id: `${id}-verticalbar`,
+					internalPanelWidth,
 					onActivePanel: setActivePanel,
+					onPanelWidthChange: setInternalPanelWidth,
+					panelWidthMax,
+					panelWidthMin,
+					position,
+					resize,
 				}}
 			>
 				{children}

--- a/packages/clay-core/src/vertical-bar/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/vertical-bar/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -353,6 +353,7 @@ exports[`VerticalBar basic rendering renders the component with the active panel
       class="sidebar c-slideout-show sidebar-light"
       id="clay-id-6-verticalbar-tabpanel-$.0"
       role="tabpanel"
+      style="width: 320px;"
     >
       Tag
     </div>

--- a/packages/clay-core/src/vertical-bar/context.ts
+++ b/packages/clay-core/src/vertical-bar/context.ts
@@ -12,7 +12,13 @@ type Context = {
 	activation?: 'manual' | 'automatic';
 	activePanel: Key | null;
 	id: string;
+	internalPanelWidth: number;
 	onActivePanel: InternalDispatch<React.Key | null>;
+	onPanelWidthChange: (value: number) => void;
+	panelWidthMax: number;
+	panelWidthMin: number;
+	position: string;
+	resize: boolean;
 };
 
 export const VerticalBarContext = createContext<Context>({} as Context);

--- a/packages/clay-core/src/vertical-bar/context.ts
+++ b/packages/clay-core/src/vertical-bar/context.ts
@@ -12,9 +12,9 @@ type Context = {
 	activation?: 'manual' | 'automatic';
 	activePanel: Key | null;
 	id: string;
-	internalPanelWidth: number;
 	onActivePanel: InternalDispatch<React.Key | null>;
-	onPanelWidthChange: (value: number) => void;
+	onPanelWidthChange: InternalDispatch<number>;
+	panelWidth: number;
 	panelWidthMax: number;
 	panelWidthMin: number;
 	position: string;

--- a/packages/clay-core/stories/VerticalBar.stories.tsx
+++ b/packages/clay-core/stories/VerticalBar.stories.tsx
@@ -23,6 +23,10 @@ export default {
 			control: {type: 'select'},
 			options: [null, 'light', 'dark'],
 		},
+		enableResize: {
+			control: {type: 'select'},
+			options: [true, false],
+		},
 	},
 	component: VerticalBar,
 	title: 'Design System/Components/VerticalBar',
@@ -31,7 +35,11 @@ export default {
 export const Default = (args: any) => {
 	return (
 		<>
-			<VerticalBar activation={args.activation} position="left">
+			<VerticalBar
+				activation={args.activation}
+				position="left"
+				resize={args.enableResize}
+			>
 				<VerticalBar.Bar displayType={args.barDisplayType}>
 					<VerticalBar.Item>
 						<Button aria-label="Tag tab" displayType={null}>
@@ -75,7 +83,11 @@ export const Default = (args: any) => {
 				</VerticalBar.Content>
 			</VerticalBar>
 
-			<VerticalBar activation={args.activation} position="right">
+			<VerticalBar
+				activation={args.activation}
+				position="right"
+				resize={args.enableResize}
+			>
 				<VerticalBar.Content displayType={args.contentDisplayType}>
 					<VerticalBar.Panel tabIndex={0}>
 						<div className="sidebar-header">

--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -19,6 +19,7 @@
 
 @import 'components/_aspect-ratio';
 @import 'components/_buttons';
+@import 'components/_resizer';
 @import 'components/_transitions';
 
 @import 'components/_grid';

--- a/packages/clay-css/src/scss/_variables.scss
+++ b/packages/clay-css/src/scss/_variables.scss
@@ -10,6 +10,7 @@
 @import 'variables/_spinners';
 
 @import 'variables/_buttons';
+@import 'variables/_resizer';
 
 @import 'variables/_alerts';
 @import 'variables/_badges';

--- a/packages/clay-css/src/scss/cadmin.scss
+++ b/packages/clay-css/src/scss/cadmin.scss
@@ -24,6 +24,7 @@ html#{$cadmin-selector} {
 
 		@import 'cadmin/components/_aspect-ratio';
 		@import 'cadmin/components/_buttons';
+		@import 'cadmin/components/_resizer';
 		@import 'cadmin/components/_transitions';
 
 		@import 'cadmin/components/_grid';

--- a/packages/clay-css/src/scss/cadmin/_variables.scss
+++ b/packages/clay-css/src/scss/cadmin/_variables.scss
@@ -5,6 +5,7 @@
 @import 'variables/_images';
 
 @import 'variables/_buttons';
+@import 'variables/_resizer';
 
 @import 'variables/_alerts';
 @import 'variables/_badges';

--- a/packages/clay-css/src/scss/cadmin/components/_resizer.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_resizer.scss
@@ -1,0 +1,11 @@
+.c-horizontal-resizer {
+	@include clay-css($cadmin-c-horizontal-resizer);
+
+	&:hover {
+		@include clay-css(map-get($cadmin-c-horizontal-resizer, hover));
+	}
+
+	&:focus {
+		@include clay-css(map-get($cadmin-c-horizontal-resizer, focus));
+	}
+}

--- a/packages/clay-css/src/scss/cadmin/variables/_resizer.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_resizer.scss
@@ -1,0 +1,21 @@
+$cadmin-c-horizontal-resizer: () !default;
+$cadmin-c-horizontal-resizer: map-merge(
+	(
+		background-color: transparent,
+		bottom: 0,
+		cursor: ew-resize,
+		margin-right: -0.25rem,
+		position: absolute,
+		right: 0,
+		top: 0,
+		width: 0.5rem,
+		z-index: 10,
+		hover: (
+			background-color: $cadmin-primary-l1,
+		),
+		focus: (
+			background-color: $cadmin-primary-l1,
+		),
+	),
+	$cadmin-c-horizontal-resizer
+);

--- a/packages/clay-css/src/scss/cadmin/variables/_slideout.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_slideout.scss
@@ -64,6 +64,9 @@ $cadmin-c-slideout: map-deep-merge(
 		),
 		sidebar-c-slideout-transition: (
 			display: block,
+			c-horizontal-resizer: (
+				display: none,
+			),
 		),
 		tbar-stacked: (
 			display: none,
@@ -163,6 +166,10 @@ $cadmin-c-slideout-end: map-deep-merge(
 		),
 		tbar-stacked-c-slideout-show: (
 			right: 0,
+		),
+		c-horizontal-resizer: (
+			left: 0,
+			right: auto,
 		),
 	),
 	$cadmin-c-slideout-end

--- a/packages/clay-css/src/scss/components/_resizer.scss
+++ b/packages/clay-css/src/scss/components/_resizer.scss
@@ -1,0 +1,11 @@
+.c-horizontal-resizer {
+	@include clay-css($c-horizontal-resizer);
+
+	&:hover {
+		@include clay-css(map-get($c-horizontal-resizer, hover));
+	}
+
+	&:focus {
+		@include clay-css(map-get($c-horizontal-resizer, focus));
+	}
+}

--- a/packages/clay-css/src/scss/mixins/_slideout.scss
+++ b/packages/clay-css/src/scss/mixins/_slideout.scss
@@ -44,7 +44,21 @@
 			}
 
 			.sidebar.c-slideout-transition {
-				@include clay-css(map-get($map, sidebar-c-slideout-transition));
+				$_sidebar-c-slideout-transition: setter(
+					map-get($map, sidebar-c-slideout-transition),
+					()
+				);
+
+				@include clay-css($_sidebar-c-slideout-transition);
+
+				.c-horizontal-resizer {
+					@include clay-css(
+						map-get(
+							$_sidebar-c-slideout-transition,
+							c-horizontal-resizer
+						)
+					);
+				}
 			}
 
 			.tbar-stacked {
@@ -59,6 +73,23 @@
 				@include clay-css(
 					map-get($map, tbar-stacked-c-slideout-transition)
 				);
+			}
+
+			.c-horizontal-resizer {
+				$_c-horizontal-resizer: setter(
+					map-get($map, c-horizontal-resizer),
+					()
+				);
+
+				@include clay-css($_c-horizontal-resizer);
+
+				&:hover {
+					@include clay-css(map-get($_c-horizontal-resizer, hover));
+				}
+
+				&:focus {
+					@include clay-css(map-get($_c-horizontal-resizer, focus));
+				}
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/variables/_resizer.scss
+++ b/packages/clay-css/src/scss/variables/_resizer.scss
@@ -8,6 +8,7 @@ $c-horizontal-resizer: map-merge(
 		position: absolute,
 		right: 0,
 		top: 0,
+		user-select: none,
 		width: 0.5rem,
 		z-index: 10,
 		hover: (

--- a/packages/clay-css/src/scss/variables/_resizer.scss
+++ b/packages/clay-css/src/scss/variables/_resizer.scss
@@ -1,0 +1,21 @@
+$c-horizontal-resizer: () !default;
+$c-horizontal-resizer: map-merge(
+	(
+		background-color: transparent,
+		bottom: 0,
+		cursor: ew-resize,
+		margin-right: -0.25rem,
+		position: absolute,
+		right: 0,
+		top: 0,
+		width: 0.5rem,
+		z-index: 10,
+		hover: (
+			background-color: $primary-l1,
+		),
+		focus: (
+			background-color: $primary-l1,
+		),
+	),
+	$c-horizontal-resizer
+);

--- a/packages/clay-css/src/scss/variables/_slideout.scss
+++ b/packages/clay-css/src/scss/variables/_slideout.scss
@@ -56,6 +56,7 @@ $c-slideout: map-deep-merge(
 		sidebar: (
 			display: none,
 			flex-shrink: 0,
+			overflow: visible,
 			position: relative,
 			width: $c-slideout-sidebar-width,
 		),
@@ -64,6 +65,9 @@ $c-slideout: map-deep-merge(
 		),
 		sidebar-c-slideout-transition: (
 			display: block,
+			c-horizontal-resizer: (
+				display: none,
+			),
 		),
 		tbar-stacked: (
 			display: none,
@@ -163,6 +167,10 @@ $c-slideout-end: map-deep-merge(
 		),
 		tbar-stacked-c-slideout-show: (
 			right: 0,
+		),
+		c-horizontal-resizer: (
+			left: 0,
+			right: auto,
 		),
 	),
 	$c-slideout-end


### PR DESCRIPTION
fixes #5348 

Putting this up for review, I added a Resizer component to VerticalBar. We can enable it with the `resize` attribute on `VerticalBar`. I also added a `panelWidth` prop so we can store the resized width in local storage and set it when rendering the component.

![resize](https://user-images.githubusercontent.com/788266/225149216-2f7e4142-0b30-40e7-9cc0-bfd31e2267b6.gif)


TODO:
- ~keyboard interactions~
- pass in custom function on resize end so we can store the new width in local storage (maybe?)
- aria attributes
- documentation