### PR TITLE
feat(@clayui/focus-trap): Add FocusTrap component

### DIFF
--- a/packages/clay-core/src/focus-trap/FocusTrap.tsx
+++ b/packages/clay-core/src/focus-trap/FocusTrap.tsx
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {FocusScope} from '@clayui/shared';
+import React from 'react';
+
+type Props<T> = {
+	/**
+	 * Flag to indicate if the focus trap is activated.
+	 */
+	active?: boolean;
+
+	/**
+	 * The elements that will receive the focus within the focus trap.
+	 */
+	children?: React.ReactNode;
+};
+
+export function FocusTrap<T>({active = false, children}: Props<T>) {
+	return (
+		<FocusScope>
+			<div>
+				{active ? (
+					<span
+						aria-hidden="true"
+						data-focus-scope-start="true"
+						tabIndex={0}
+					/>
+				) : null}
+				{children}
+				{active ? (
+					<span
+						aria-hidden="true"
+						data-focus-scope-end="true"
+						tabIndex={0}
+					/>
+				) : null}
+			</div>
+		</FocusScope>
+	);
+}

--- a/packages/clay-core/src/focus-trap/index.ts
+++ b/packages/clay-core/src/focus-trap/index.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export {FocusTrap} from './FocusTrap';

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -20,6 +20,7 @@ export {OverlayMask} from './overlay-mask';
 export {TreeView} from './tree-view';
 export {VerticalBar} from './vertical-bar';
 export {Picker, Option} from './picker';
+export {FocusTrap} from './focus-trap';
 
 // Internal dependencies not public but exposed to other Clay packages.
 export * as __NOT_PUBLIC_COLLECTION from './collection';

--- a/packages/clay-core/stories/FocusTrap.stories.tsx
+++ b/packages/clay-core/stories/FocusTrap.stories.tsx
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayButton from '@clayui/button';
+import ClayCard from '@clayui/card';
+import React, {useRef, useState} from 'react';
+
+import {FocusTrap} from '../src/focus-trap';
+
+export default {
+	component: FocusTrap,
+	title: 'Design System/Components/FocusTrap',
+};
+
+export const Default = () => {
+	const [active, setActive] = useState(false);
+	const activateTrapButton = useRef<HTMLButtonElement>(null);
+	const trapFirstButton = useRef<HTMLButtonElement>(null);
+
+	const onActivateFocusTrap = () => {
+		setActive(true);
+		trapFirstButton.current?.focus();
+	};
+
+	const onDeactivateFocusTrap = () => {
+		setActive(false);
+		activateTrapButton.current?.focus();
+	};
+
+	return (
+		<>
+			<ClayButton
+				displayType="link"
+				onClick={onActivateFocusTrap}
+				ref={activateTrapButton}
+			>
+				Activate trap
+			</ClayButton>
+			<FocusTrap active={active}>
+				<ClayCard className="mt-4">
+					<ClayButton displayType="link" ref={trapFirstButton}>
+						Button 1
+					</ClayButton>
+					<ClayButton displayType="link">Button 2</ClayButton>
+					<ClayButton
+						displayType="link"
+						onClick={onDeactivateFocusTrap}
+					>
+						Leave trap
+					</ClayButton>
+				</ClayCard>
+			</FocusTrap>
+			<ClayButton displayType="link">Button 3</ClayButton>
+		</>
+	);
+};


### PR DESCRIPTION
It fixes: https://github.com/liferay/clay/issues/5409

Hi @matuzalemsteles! Here is the draft for the new FocusTrap component. I have proposed the following: the component has an `active` props, which is in charge of activating the focus trap. In this way, it's the responsibility of the user to activate the focus trap. It could be always activated or, for example, activate it with the click of a button.

I have also added stories for Storybook to verify its behavior (video attached). What do you think?

https://user-images.githubusercontent.com/9701095/225909042-b83020b4-b500-41c0-9dbe-11f2ec4d833d.mov


