### PR TITLE
feat(@clayui/focus-trap): Add FocusTrap component

### DIFF
--- a/packages/clay-core/docs/api-focus-trap.mdx
+++ b/packages/clay-core/docs/api-focus-trap.mdx
@@ -1,0 +1,9 @@
+---
+title: 'FocusTrap'
+description: "Focus Trap holds the user's focus inside its children components."
+mainTabURL: 'docs/components/focus-trap.html'
+---
+
+## FocusTrap
+
+<div>[APITable "clay-core/src/focus-trap/FocusTrap.tsx"]</div>

--- a/packages/clay-core/docs/focus-trap.js
+++ b/packages/clay-core/docs/focus-trap.js
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Editor from '$clayui.com/src/components/Editor';
+import {Button, FocusTrap} from '@clayui/core';
+import React, {useRef, useState} from 'react';
+
+const exampleImports = `import {Button, FocusTrap} from '@clayui/core';
+import React, {useState, useRef} from 'react';`;
+
+const exampleCode = `const FocusTrapTrigger = () => {
+    const [active, setActive] = useState(false);
+	const activateButtonRef = useRef(null);
+
+	const onDeactivateFocusTrap = () => {
+		setActive(false);
+
+		if (activateButtonRef.current) {
+			activateButtonRef.current.focus();
+		}
+	};
+
+	return (
+		<>
+			<Button onClick={() => setActive(true)} ref={activateButtonRef}>
+				Activate trap
+			</Button>
+			{active && (
+				<FocusTrap active={active}>
+                <div className="sheet c-mt-2 c-p-4">
+                    <Button displayType="link">Button 1</Button>
+                    <Button displayType="link">Button 2</Button>
+                    <div className="c-mt-4">
+                        <Button onClick={onDeactivateFocusTrap}>
+                            Leave trap
+                        </Button>
+                    </div>
+            </div>
+				</FocusTrap>
+			)}
+		</>
+	);
+};
+
+render(<FocusTrapTrigger/>)`;
+
+const FocusTrapExample = () => {
+	const scope = {Button, FocusTrap, useRef, useState};
+
+	return <Editor code={exampleCode} imports={exampleImports} scope={scope} />;
+};
+
+export {FocusTrapExample};

--- a/packages/clay-core/docs/focus-trap.mdx
+++ b/packages/clay-core/docs/focus-trap.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Focus Trap'
+description: "Focus Trap holds the user's focus inside its children components."
+packageNpm: '@clayui/core'
+packageStatus: 'Beta'
+storybookPath: 'design-system-components-focus-trap'
+---
+
+import {FocusTrapExample} from '$packages/clay-core/docs/focus-trap';
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Introduction](#introduction)
+-   [Example](#example)
+
+</div>
+</div>
+
+## Introduction
+
+Focus Trap is a component that wraps elements in the DOM and prevents focus from escaping from its child components when the user navigates with Tab or Shift + Tab.
+
+It definitely is used when trying to build accessible components, blocking all interactions outside of it while Focus Trap is active.
+
+<div class="clay-site-alert alert alert-warning">
+	It's the responsibility of the user to add an escape method for the focus
+	trap, either with a button or the escape key.
+</div>
+
+## Example
+
+<FocusTrapExample />

--- a/packages/clay-core/src/focus-trap/FocusTrap.tsx
+++ b/packages/clay-core/src/focus-trap/FocusTrap.tsx
@@ -4,6 +4,7 @@
  */
 
 import {FOCUSABLE_ELEMENTS, FocusScope} from '@clayui/shared';
+import {hideOthers, supportsInert, suppressOthers} from 'aria-hidden';
 import React, {useEffect, useRef} from 'react';
 
 type Props = {
@@ -48,6 +49,19 @@ export function FocusTrap({active = false, children, focusElementRef}: Props) {
 
 			if (focusableElements) {
 				(focusableElements[0] as HTMLDivElement).focus();
+			}
+		}
+	}, [active]);
+
+	useEffect(() => {
+		if (childrenRef.current && active) {
+			// Inert is a new native feature to better handle DOM arias that are not
+			// assertive to a SR or that should ignore any user interaction.
+			// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+			if (supportsInert()) {
+				return suppressOthers(childrenRef.current);
+			} else {
+				return hideOthers(childrenRef.current);
 			}
 		}
 	}, [active]);

--- a/packages/clay-core/src/focus-trap/FocusTrap.tsx
+++ b/packages/clay-core/src/focus-trap/FocusTrap.tsx
@@ -16,6 +16,11 @@ type Props = {
 	 * The elements that will receive the focus within the focus trap.
 	 */
 	children: React.ReactNode;
+
+	/**
+	 * Ref of the element that receives the focus when the focus trap is activated.
+	 */
+	focusElementRef?: React.RefObject<HTMLElement>;
 };
 
 const getFocusableElements = (childrenRef: React.RefObject<HTMLDivElement>) => {
@@ -28,11 +33,17 @@ const getFocusableElements = (childrenRef: React.RefObject<HTMLDivElement>) => {
 	].filter((element) => !element.getAttribute('aria-hidden'));
 };
 
-export function FocusTrap({active = false, children}: Props) {
+export function FocusTrap({active = false, children, focusElementRef}: Props) {
 	const childrenRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		if (active) {
+			if (focusElementRef?.current) {
+				focusElementRef.current.focus();
+
+				return;
+			}
+
 			const focusableElements = getFocusableElements(childrenRef);
 
 			if (focusableElements) {

--- a/packages/clay-core/src/focus-trap/FocusTrap.tsx
+++ b/packages/clay-core/src/focus-trap/FocusTrap.tsx
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {FOCUSABLE_ELEMENTS, FocusScope} from '@clayui/shared';
+import React, {useEffect, useRef} from 'react';
+
+type Props = {
+	/**
+	 * Flag to indicate if the focus trap is activated.
+	 */
+	active: boolean;
+
+	/**
+	 * The elements that will receive the focus within the focus trap.
+	 */
+	children: React.ReactNode;
+};
+
+const getFocusableElements = (childrenRef: React.RefObject<HTMLDivElement>) => {
+	if (!childrenRef.current) {
+		return null;
+	}
+
+	return [
+		...childrenRef.current.querySelectorAll(FOCUSABLE_ELEMENTS.join(',')),
+	].filter((element) => !element.getAttribute('aria-hidden'));
+};
+
+export function FocusTrap({active = false, children}: Props) {
+	const childrenRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (active) {
+			const focusableElements = getFocusableElements(childrenRef);
+
+			if (focusableElements) {
+				(focusableElements[0] as HTMLDivElement).focus();
+			}
+		}
+	}, [active]);
+
+	return (
+		<FocusScope>
+			<div ref={childrenRef}>
+				{active ? (
+					<span
+						aria-hidden="true"
+						data-focus-scope-start="true"
+						tabIndex={0}
+					/>
+				) : null}
+
+				{children}
+
+				{active ? (
+					<span
+						aria-hidden="true"
+						data-focus-scope-end="true"
+						tabIndex={0}
+					/>
+				) : null}
+			</div>
+		</FocusScope>
+	);
+}

--- a/packages/clay-core/src/focus-trap/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/focus-trap/__tests__/BasicRendering.tsx
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import {Button, FocusTrap} from '../../';
+
+describe('FocusTrap basic rendering', () => {
+	afterEach(cleanup);
+
+	it('render static content when focus trap is actived', () => {
+		render(
+			<FocusTrap active>
+				<Button>Apple</Button>
+			</FocusTrap>
+		);
+
+		expect(document.body).toMatchSnapshot();
+	});
+
+	it('render static content when focus trap is not actived', () => {
+		render(
+			<FocusTrap active={false}>
+				<Button>Apple</Button>
+			</FocusTrap>
+		);
+
+		expect(document.body).toMatchSnapshot();
+	});
+});

--- a/packages/clay-core/src/focus-trap/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/focus-trap/__tests__/IncrementalInteractions.tsx
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, {useRef, useState} from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {Button, FocusTrap} from '../../';
+
+describe('FocusTrap incremental interactions', () => {
+	afterEach(cleanup);
+
+	it('click trigger to activate the focus trap', () => {
+		function FocusTrapTrigger() {
+			const [active, setActive] = useState(false);
+
+			return (
+				<>
+					<Button
+						data-testid="activeButton"
+						onClick={() => setActive(true)}
+					>
+						Active Trap
+					</Button>
+					<FocusTrap active={active}>
+						<Button data-testid="firstButton">Button</Button>
+					</FocusTrap>
+				</>
+			);
+		}
+
+		const {container, getByTestId} = render(<FocusTrapTrigger />);
+
+		expect(
+			container.querySelector('[data-focus-scope-start="true"]')
+		).not.toBeInTheDocument();
+
+		userEvent.click(getByTestId('activeButton'));
+
+		expect(
+			container.querySelector('[data-focus-scope-start="true"]')
+		).toBeInTheDocument();
+	});
+
+	it('focus in the first focusable element when the focus trap is active', () => {
+		function FocusTrapTrigger() {
+			return (
+				<>
+					<FocusTrap active>
+						<Button data-testid="firstButton">Button</Button>
+						<Button>Button</Button>
+					</FocusTrap>
+				</>
+			);
+		}
+
+		const {getByTestId} = render(<FocusTrapTrigger />);
+
+		expect(getByTestId('firstButton')).toHaveFocus();
+	});
+
+	it('focus an specific focusable element when the focus trap is active', () => {
+		function FocusTrapTrigger() {
+			const secondButtonRef = useRef(null);
+
+			return (
+				<>
+					<FocusTrap active focusElementRef={secondButtonRef}>
+						<Button>Button</Button>
+						<Button
+							data-testid="secondButton"
+							ref={secondButtonRef}
+						>
+							Button
+						</Button>
+					</FocusTrap>
+				</>
+			);
+		}
+
+		const {getByTestId} = render(<FocusTrapTrigger />);
+
+		expect(getByTestId('secondButton')).toHaveFocus();
+	});
+});

--- a/packages/clay-core/src/focus-trap/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/focus-trap/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FocusTrap basic rendering render static content when focus trap is actived 1`] = `
+<body>
+  <div>
+    <div>
+      <span
+        aria-hidden="true"
+        data-focus-scope-start="true"
+        tabindex="0"
+      />
+      <button
+        class="btn btn-primary"
+        type="button"
+      >
+        Apple
+      </button>
+      <span
+        aria-hidden="true"
+        data-focus-scope-end="true"
+        tabindex="0"
+      />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`FocusTrap basic rendering render static content when focus trap is not actived 1`] = `
+<body>
+  <div>
+    <div>
+      <button
+        class="btn btn-primary"
+        type="button"
+      >
+        Apple
+      </button>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/clay-core/src/focus-trap/index.ts
+++ b/packages/clay-core/src/focus-trap/index.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export {FocusTrap} from './FocusTrap';

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -20,6 +20,7 @@ export {OverlayMask} from './overlay-mask';
 export {TreeView} from './tree-view';
 export {VerticalBar} from './vertical-bar';
 export {Picker, Option} from './picker';
+export {FocusTrap} from './focus-trap';
 
 // Internal dependencies not public but exposed to other Clay packages.
 export * as __NOT_PUBLIC_COLLECTION from './collection';

--- a/packages/clay-core/stories/FocusTrap.stories.tsx
+++ b/packages/clay-core/stories/FocusTrap.stories.tsx
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayButton from '@clayui/button';
+import ClayCard from '@clayui/card';
+import React, {useRef, useState} from 'react';
+
+import {FocusTrap} from '../src/focus-trap';
+
+export default {
+	component: FocusTrap,
+	title: 'Design System/Components/FocusTrap',
+};
+
+export const Default = () => {
+	const [active, setActive] = useState(false);
+	const activateButtonRef = useRef<HTMLButtonElement>(null);
+
+	const onDeactivateFocusTrap = () => {
+		setActive(false);
+
+		if (activateButtonRef.current) {
+			activateButtonRef.current.focus();
+		}
+	};
+
+	return (
+		<>
+			<ClayButton onClick={() => setActive(true)} ref={activateButtonRef}>
+				Activate trap
+			</ClayButton>
+			{active && (
+				<FocusTrap active={active}>
+					<ClayCard className="mt-4 p-4">
+						<ClayButton displayType="link">Button 1</ClayButton>
+						<ClayButton displayType="link">Button 2</ClayButton>
+						<div className="mt-4">
+							<ClayButton onClick={onDeactivateFocusTrap}>
+								Leave trap
+							</ClayButton>
+						</div>
+					</ClayCard>
+				</FocusTrap>
+			)}
+		</>
+	);
+};

--- a/packages/clay-core/stories/FocusTrap.stories.tsx
+++ b/packages/clay-core/stories/FocusTrap.stories.tsx
@@ -47,3 +47,41 @@ export const Default = () => {
 		</>
 	);
 };
+
+export const FocusOnSpecificElement = () => {
+	const [active, setActive] = useState(false);
+	const activateButtonRef = useRef<HTMLButtonElement>(null);
+	const thirdButtonRef = useRef<HTMLButtonElement>(null);
+
+	const onDeactivateFocusTrap = () => {
+		setActive(false);
+
+		if (activateButtonRef.current) {
+			activateButtonRef.current.focus();
+		}
+	};
+
+	return (
+		<>
+			<ClayButton onClick={() => setActive(true)} ref={activateButtonRef}>
+				Activate trap
+			</ClayButton>
+			{active && (
+				<FocusTrap active={active} focusElementRef={thirdButtonRef}>
+					<ClayCard className="mt-4 p-4">
+						<ClayButton displayType="link">Button 1</ClayButton>
+						<ClayButton displayType="link">Button 2</ClayButton>
+						<ClayButton displayType="link" ref={thirdButtonRef}>
+							Button 3
+						</ClayButton>
+						<div className="mt-4">
+							<ClayButton onClick={onDeactivateFocusTrap}>
+								Leave trap
+							</ClayButton>
+						</div>
+					</ClayCard>
+				</FocusTrap>
+			)}
+		</>
+	);
+};


### PR DESCRIPTION
It fixes: [#5409](https://github.com/liferay/clay/issues/5409)

Hi [@matuzalemsteles](https://github.com/matuzalemsteles)! Here is the draft for the new FocusTrap component. I have proposed the following: the component has an active props, which is in charge of activating the focus trap. In this way, it's the responsibility of the user to activate the focus trap. It could be always activated or, for example, activate it with the click of a button.

I have also added stories for Storybook to verify its behavior (video attached). What do you think?

https://user-images.githubusercontent.com/9701095/225911367-b8e9843c-96b6-4a31-b706-e170c076330c.mov

---
**TO DO:**
- tests
- doc
