### PR TITLE
fix(@clayui/css): Navigation Bar focus outline should be rounded

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
@@ -17,7 +17,7 @@ $navigation-bar-base: map-deep-merge(
 	(
 		navbar-nav: (
 			nav-link: (
-				border-radius: 0px,
+				border-radius: clay-enable-rounded($border-radius),
 				outline: 0,
 				focus: (
 					box-shadow: $component-focus-box-shadow,

--- a/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
@@ -30,7 +30,7 @@ $cadmin-navigation-bar-base: map-deep-merge(
 		border-style: solid,
 		navbar-nav: (
 			nav-link: (
-				border-radius: 0,
+				border-radius: clay-enable-rounded($cadmin-border-radius),
 				border-width: 0,
 				outline: 0,
 				font-size: inherit,


### PR DESCRIPTION
fixes #5437