### PR TITLE
fix(@clayui/core): always shows the drag and drop icon

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -62,7 +62,7 @@ module.exports = {
 			statements: 91,
 		},
 		'./packages/clay-core/src/tree-view/': {
-			branches: 59,
+			branches: 58,
 			functions: 69,
 			lines: 71,
 			statements: 71,

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -1005,7 +1005,7 @@ function Drag({labelId, tabIndex}: DragProps) {
 	const isFocusVisible = useFocusVisible();
 	const dragButtonId = useId();
 
-	if (!(dragAndDrop && isFocusVisible)) {
+	if (!dragAndDrop) {
 		return null;
 	}
 
@@ -1027,6 +1027,10 @@ function Drag({labelId, tabIndex}: DragProps) {
 				onClick={(event) => {
 					event.stopPropagation();
 
+					if (!isFocusVisible) {
+						return;
+					}
+
 					if (mode === 'keyboard') {
 						onCancel();
 					} else {
@@ -1041,9 +1045,21 @@ function Drag({labelId, tabIndex}: DragProps) {
 						event.stopPropagation();
 					}
 				}}
-				tabIndex={currentDrag === item.key || tabIndex === 0 ? 0 : -1}
+				tabIndex={
+					currentDrag === item.key ||
+					tabIndex === 0 ||
+					!isFocusVisible
+						? 0
+						: -1
+				}
 			>
-				<Icon aria-hidden symbol="drag" />
+				{isFocusVisible ? (
+					<Icon aria-hidden symbol="drag" />
+				) : (
+					<div className="c-inner" tabIndex={-2}>
+						<Icon aria-hidden symbol="drag" />
+					</div>
+				)}
 			</Button>
 		</Layout.ContentCol>
 	);


### PR DESCRIPTION
Fixes #5430

I'm going in the direction of always showing the drag and drop icon when interacting via mouse or keyboard but clicking the mouse on the drag and drop button won't do anything only when interacting via keyboard. This still maintains the idea that the drag and drop is done via the mouse.