### PR TITLE
feat(@clayui/css): Cadmin and Clay adds btn-beta and badge-beta variants

### DIFF
--- a/packages/clay-badge/docs/badge.mdx
+++ b/packages/clay-badge/docs/badge.mdx
@@ -5,7 +5,18 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/badges/'
 packageNpm: '@clayui/badge'
 ---
 
-import {Badge} from '$packages/clay-badge/docs/index';
+import {Badge, BadgeBeta} from '$packages/clay-badge/docs/index';
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Display Types](#display-types)
+-   [Beta](#badge-beta)
+
+</div>
+</div>
+
+## Display Types(#display-types)
 
 Badges are not used for non-numeric values. If you have a non-numeric value, use labels instead. Badges work for exact numbers up to 999.
 For numbers greater than 999, use K to indicate Thousands (5K for 5.231) and M to indicate Millions (2M for 2.100.523).
@@ -13,3 +24,9 @@ For numbers greater than 999, use K to indicate Thousands (5K for 5.231) and M t
 <Badge />
 
 We recommend that you review the use cases in the <a href="https://storybook.clayui.com/?path=/story/design-system-components-badge--default">Storybook</a>.
+
+## Beta(#badge-beta)
+
+A component to indicate beta features in DXP. The `badge-beta` variant doesn’t have any interaction. It just informs the user. It uses a Badge component with custom visual states.
+
+<BadgeBeta />

--- a/packages/clay-badge/docs/index.js
+++ b/packages/clay-badge/docs/index.js
@@ -75,3 +75,44 @@ export const Badge = () => {
 
 	return <Editor code={codeSnippets} scope={scope} />;
 };
+
+//
+
+const badgeBetaImportsCode = `import ClayBadge from '@clayui/badge';`;
+
+const BadgeBetaCode = `const Component = () => {
+    return (
+        <>
+            <ClayBadge displayType="beta" label="Beta" />
+        </>
+    );
+}
+
+render(<Component />);`;
+
+const badgeBetaJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
+
+const BadgeBetaJSPCode = `<clay:badge
+    displayType="beta"
+    label="Beta" 
+/>`;
+
+export const BadgeBeta = () => {
+	const scope = {ClayBadge};
+
+	const codeSnippets = [
+		{
+			imports: badgeBetaImportsCode,
+			name: 'React',
+			value: BadgeBetaCode,
+		},
+		{
+			disabled: true,
+			imports: badgeBetaJSPImportsCode,
+			name: 'JSP',
+			value: BadgeBetaJSPCode,
+		},
+	];
+
+	return <Editor code={codeSnippets} scope={scope} />;
+};

--- a/packages/clay-badge/src/index.tsx
+++ b/packages/clay-badge/src/index.tsx
@@ -12,7 +12,8 @@ type DisplayType =
 	| 'info'
 	| 'danger'
 	| 'success'
-	| 'warning';
+	| 'warning'
+	| 'beta';
 
 interface IProps extends React.HTMLAttributes<HTMLSpanElement> {
 	/**

--- a/packages/clay-button/docs/button.mdx
+++ b/packages/clay-button/docs/button.mdx
@@ -6,6 +6,7 @@ packageNpm: '@clayui/button'
 ---
 
 import {
+	ButtonBeta,
 	ButtonDisplayTypes,
 	ButtonGroup,
 	ButtonIcon,
@@ -17,6 +18,7 @@ import {
 -   [Display Types](#display-types)
 -   [Group](#group)
 -   [Icon](#icon)
+-   [Beta](#btn-beta)
 
 </div>
 </div>
@@ -44,3 +46,9 @@ Use the [`spaced`](#api-spaced) property to create spacing between buttons.
 You can use the high-level component `ClayButtonWithIcon` to create a button with only an icon. If you need an icon and text, you need to compose with `ClayIcon`
 
 <ButtonIcon />
+
+## Beta
+
+A component to indicate beta features in DXP. The Button variant should be used when the component can be placed close to a non-interactive UI element, such as a title or a section. Also, a default popover is shown if the user interacts with it.
+
+<ButtonBeta />

--- a/packages/clay-button/docs/index.js
+++ b/packages/clay-button/docs/index.js
@@ -132,13 +132,13 @@ const ButtonIcon = () => {
 	return <Editor code={code} imports={buttonIconImportsCode} scope={scope} />;
 };
 
-const buttonBetaImportsCode = `import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
-import ClayIcon from '@clayui/icon;`;
+const buttonBetaImportsCode = `import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon;'`;
 
 const ButtonBetaCode = `const Component = () => {
 	return (
 		<>
-			<ClayButton className="btn-beta btn-xs rounded-circle" displayType={null}>
+			<ClayButton className="rounded-circle" displayType="beta" size="xs">
 				<span className="inline-item">
 					{'Beta'}
 				</span>

--- a/packages/clay-button/docs/index.js
+++ b/packages/clay-button/docs/index.js
@@ -132,4 +132,32 @@ const ButtonIcon = () => {
 	return <Editor code={code} imports={buttonIconImportsCode} scope={scope} />;
 };
 
-export {ButtonDisplayTypes, ButtonGroup, ButtonIcon};
+const buttonBetaImportsCode = `import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import ClayIcon from '@clayui/icon;`;
+
+const ButtonBetaCode = `const Component = () => {
+	return (
+		<>
+			<ClayButton className="btn-beta btn-xs rounded-circle" displayType={null}>
+				<span className="inline-item">
+					{'Beta'}
+				</span>
+
+				<span className="inline-item inline-item-after">
+					<ClayIcon spritemap={spritemap} symbol="info-panel-open" />
+				</span>
+			</ClayButton>
+		</>
+	);
+}
+
+render(<Component />);`;
+
+const ButtonBeta = () => {
+	const scope = {ClayButton, ClayButtonWithIcon, ClayIcon};
+	const code = ButtonBetaCode;
+
+	return <Editor code={code} imports={buttonBetaImportsCode} scope={scope} />;
+};
+
+export {ButtonDisplayTypes, ButtonGroup, ButtonIcon, ButtonBeta};

--- a/packages/clay-button/src/Button.tsx
+++ b/packages/clay-button/src/Button.tsx
@@ -18,6 +18,7 @@ export type DisplayType =
 	| 'warning'
 	| 'danger'
 	| 'info'
+	| 'beta'
 	| 'unstyled';
 
 export interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/packages/clay-css/src/scss/cadmin/components/_badges.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_badges.scss
@@ -66,7 +66,11 @@
 			starts-with($color, '#') or
 			starts-with($color, '%'),
 		$color,
-		str-insert($color, '.badge-', 1)
+		if(
+			starts-with($color, 'badge'),
+			str-insert($color, '.', 1),
+			str-insert($color, '.badge-', 1)
+		)
 	);
 
 	@if (starts-with($color, '%') or map-get($value, extend)) {

--- a/packages/clay-css/src/scss/cadmin/variables/_badges.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_badges.scss
@@ -466,6 +466,11 @@ $cadmin-badge-palette: map-deep-merge(
 		danger: $cadmin-badge-danger,
 		light: $cadmin-badge-light,
 		dark: $cadmin-badge-dark,
+		badge-beta: (
+			background-color: $cadmin-gray-100,
+			color: $cadmin-info,
+			text-transform: uppercase,
+		),
 	),
 	$cadmin-badge-palette
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_badges.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_badges.scss
@@ -467,8 +467,8 @@ $cadmin-badge-palette: map-deep-merge(
 		light: $cadmin-badge-light,
 		dark: $cadmin-badge-dark,
 		badge-beta: (
-			background-color: $cadmin-gray-100,
-			color: $cadmin-info,
+			background-color: $cadmin-light-l1,
+			color: $cadmin-info-d1,
 			text-transform: uppercase,
 		),
 	),

--- a/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
@@ -702,16 +702,16 @@ $cadmin-btn-palette: map-deep-merge(
 		dark: $cadmin-btn-dark,
 		link: $cadmin-btn-link,
 		btn-beta: (
-			background-color: $cadmin-gray-100,
-			color: $cadmin-info,
+			background-color: $cadmin-light-l1,
+			color: $cadmin-info-d1,
 			text-transform: uppercase,
 			hover: (
-				background-color: $cadmin-gray-200,
-				color: $cadmin-info,
+				background-color: $cadmin-light,
+				color: $cadmin-info-d1,
 			),
 			focus: (
-				background-color: $cadmin-gray-200,
-				color: $cadmin-info,
+				background-color: $cadmin-light,
+				color: $cadmin-info-d1,
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
@@ -203,7 +203,7 @@ $cadmin-btn-sizes: map-deep-merge(
 			padding-top: 0.125rem,
 			inline-item: (
 				font-size: inherit,
-				margin-top: -3px,
+				margin-top: -0.16em,
 			),
 			inline-item-before: (
 				margin-right: 0.25rem,

--- a/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
@@ -701,6 +701,19 @@ $cadmin-btn-palette: map-deep-merge(
 		light: $cadmin-btn-light,
 		dark: $cadmin-btn-dark,
 		link: $cadmin-btn-link,
+		btn-beta: (
+			background-color: $cadmin-gray-100,
+			color: $cadmin-info,
+			text-transform: uppercase,
+			hover: (
+				background-color: $cadmin-gray-200,
+				color: $cadmin-info,
+			),
+			focus: (
+				background-color: $cadmin-gray-200,
+				color: $cadmin-info,
+			),
+		),
 	),
 	$cadmin-btn-palette
 );

--- a/packages/clay-css/src/scss/components/_badges.scss
+++ b/packages/clay-css/src/scss/components/_badges.scss
@@ -113,7 +113,11 @@
 			starts-with($color, '#') or
 			starts-with($color, '%'),
 		$color,
-		str-insert($color, '.badge-', 1)
+		if(
+			starts-with($color, 'badge'),
+			str-insert($color, '.', 1),
+			str-insert($color, '.badge-', 1)
+		)
 	);
 
 	@if (starts-with($color, '%') or map-get($value, extend)) {

--- a/packages/clay-css/src/scss/variables/_badges.scss
+++ b/packages/clay-css/src/scss/variables/_badges.scss
@@ -495,8 +495,8 @@ $badge-palette: map-deep-merge(
 		light: $badge-light,
 		dark: $badge-dark,
 		badge-beta: (
-			background-color: $gray-100,
-			color: $info,
+			background-color: $light-l1,
+			color: $info-d1,
 			text-transform: uppercase,
 		),
 	),

--- a/packages/clay-css/src/scss/variables/_badges.scss
+++ b/packages/clay-css/src/scss/variables/_badges.scss
@@ -494,6 +494,11 @@ $badge-palette: map-deep-merge(
 		danger: $badge-danger,
 		light: $badge-light,
 		dark: $badge-dark,
+		badge-beta: (
+			background-color: $gray-100,
+			color: $info,
+			text-transform: uppercase,
+		),
 	),
 	$badge-palette
 );

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -893,16 +893,16 @@ $btn-palette: map-deep-merge(
 		dark: $btn-dark,
 		link: $btn-link,
 		btn-beta: (
-			background-color: $gray-100,
-			color: $info,
+			background-color: $light-l1,
+			color: $info-d1,
 			text-transform: uppercase,
 			hover: (
-				background-color: $gray-200,
-				color: $info,
+				background-color: $light,
+				color: $info-d1,
 			),
 			focus: (
-				background-color: $gray-200,
-				color: $info,
+				background-color: $light,
+				color: $info-d1,
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -203,7 +203,7 @@ $btn-sizes: map-deep-merge(
 			padding-top: 0.125rem,
 			inline-item: (
 				font-size: inherit,
-				margin-top: -3px,
+				margin-top: -0.16em,
 			),
 			inline-item-before: (
 				margin-right: 0.25rem,

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -892,6 +892,19 @@ $btn-palette: map-deep-merge(
 		light: $btn-light,
 		dark: $btn-dark,
 		link: $btn-link,
+		btn-beta: (
+			background-color: $gray-100,
+			color: $info,
+			text-transform: uppercase,
+			hover: (
+				background-color: $gray-200,
+				color: $info,
+			),
+			focus: (
+				background-color: $gray-200,
+				color: $info,
+			),
+		),
 	),
 	$btn-palette
 );


### PR DESCRIPTION
fixes #5446

One thing I forgot to ask is whether `btn-beta` and `btn-badge` will be used in admin only components. Should we remove this from Clay used on sites?

Also @matuzalemsteles you think it's a good idea to add these to the ClayButton and ClayBadge apis?

/cc @ethib137 @marcoscv-work @drakonux 