### PR TITLE
refactor(@clayui/core): changes the implementation of the over on the DnD indicators of the TreeView component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -62,10 +62,10 @@ module.exports = {
 			statements: 91,
 		},
 		'./packages/clay-core/src/tree-view/': {
-			branches: 58,
-			functions: 69,
-			lines: 71,
-			statements: 71,
+			branches: 56,
+			functions: 65,
+			lines: 70,
+			statements: 69,
 		},
 		'./packages/clay-data-provider/src/': {
 			branches: 69,

--- a/packages/clay-core/src/collection/index.ts
+++ b/packages/clay-core/src/collection/index.ts
@@ -5,5 +5,5 @@
 
 export {getKey, excludeProps} from './utils';
 export {Collection} from './Collection';
-export {useCollection} from './useCollection';
+export {useCollection, useCollectionKeys} from './useCollection';
 export type {ChildrenFunction, ICollectionProps} from './types';

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -36,6 +36,8 @@ const exclude = new Set([
 	'itemRef',
 	'key',
 	'parentItemRef',
+	'prevKey',
+	'nextKey',
 ]);
 
 const ItemContainer = ({

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -242,12 +242,8 @@ export const TreeViewItem = React.forwardRef<
 							disabled:
 								itemStackProps.disabled || nodeProps.disabled,
 							focus,
-							'treeview-dropping-bottom':
-								overTarget && overPosition === 'bottom',
 							'treeview-dropping-middle':
 								overTarget && overPosition === 'middle',
-							'treeview-dropping-top':
-								overTarget && overPosition === 'top',
 							'treeview-no-hover':
 								itemStackProps.noHover || nodeProps.noHover,
 						}
@@ -950,6 +946,7 @@ function ItemIndicator({labelId, target}: ItemIndicatorProps) {
 
 	useEffect(() => {
 		if (
+			mode === 'keyboard' &&
 			indicatorRef.current &&
 			currentTarget === target.key &&
 			target.dropPosition === position
@@ -962,8 +959,30 @@ function ItemIndicator({labelId, target}: ItemIndicatorProps) {
 		return null;
 	}
 
+	if (mode === 'mouse') {
+		return (
+			<div
+				aria-hidden="true"
+				className={classNames({
+					'treeview-dropping-indicator-bottom':
+						target.dropPosition === 'bottom',
+					'treeview-dropping-indicator-over':
+						currentTarget === target.key &&
+						target.dropPosition === position,
+					'treeview-dropping-indicator-top':
+						target.dropPosition === 'top',
+				})}
+				ref={indicatorRef}
+				role="button"
+				tabIndex={-1}
+			/>
+		);
+	}
+
+	const Component = target.dropPosition !== 'middle' ? 'div' : VisuallyHidden;
+
 	return (
-		<VisuallyHidden
+		<Component
 			aria-describedby={dragDropDescribedBy}
 			aria-hidden={mode !== 'keyboard' ? true : undefined}
 			aria-label={classNames({
@@ -973,6 +992,15 @@ function ItemIndicator({labelId, target}: ItemIndicatorProps) {
 			})}
 			aria-labelledby={`${id} ${labelId}`}
 			aria-roledescription={messages.dropIndicator}
+			className={classNames({
+				'treeview-dropping-indicator-bottom':
+					target.dropPosition === 'bottom',
+				'treeview-dropping-indicator-over':
+					currentTarget === target.key &&
+					target.dropPosition === position,
+				'treeview-dropping-indicator-top':
+					target.dropPosition === 'top',
+			})}
 			id={id}
 			ref={indicatorRef}
 			role="button"
@@ -1034,7 +1062,7 @@ function Drag({labelId, tabIndex}: DragProps) {
 					if (mode === 'keyboard') {
 						onCancel();
 					} else {
-						onDragStart(item.key);
+						onDragStart('keyboard', item.key);
 					}
 				}}
 				onKeyDown={(event) => {

--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -171,18 +171,26 @@
 	}
 }
 
+.treeview-dropping-indicator-top {
+	@include clay-link(
+		map-deep-get($cadmin-treeview, treeview-dropping-indicator-top)
+	);
+}
+
+.treeview-dropping-indicator-bottom {
+	@include clay-link(
+		map-deep-get($cadmin-treeview, treeview-dropping-indicator-bottom)
+	);
+}
+
+.treeview-dropping-indicator-over {
+	@include clay-link(
+		map-deep-get($cadmin-treeview, treeview-dropping-indicator-over)
+	);
+}
+
 .treeview-link {
 	@include clay-link(map-get($cadmin-treeview, treeview-link));
-
-	&.treeview-dropping-bottom {
-		@include clay-link(
-			map-deep-get(
-				$cadmin-treeview,
-				treeview-link,
-				treeview-dropping-bottom
-			)
-		);
-	}
 
 	&.treeview-dropping-middle {
 		@include clay-link(
@@ -191,12 +199,6 @@
 				treeview-link,
 				treeview-dropping-middle
 			)
-		);
-	}
-
-	&.treeview-dropping-top {
-		@include clay-link(
-			map-deep-get($cadmin-treeview, treeview-link, treeview-dropping-top)
 		);
 	}
 

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -61,6 +61,25 @@ $cadmin-treeview: map-merge(
 				box-shadow: none,
 			),
 		),
+		treeview-dropping-indicator-top: (
+			background-color: transparent,
+			display: block,
+			height: 2px,
+			margin-top: -2px,
+			outline: none,
+			width: 100%,
+		),
+		treeview-dropping-indicator-bottom: (
+			background-color: transparent,
+			display: block,
+			height: 2px,
+			margin-bottom: -2px,
+			outline: none,
+			width: 100%,
+		),
+		treeview-dropping-indicator-over: (
+			background-color: $cadmin-primary-l0,
+		),
 		treeview-link: (
 			background-color: transparent,
 			cursor: pointer,
@@ -75,15 +94,9 @@ $cadmin-treeview: map-merge(
 			position: relative,
 			text-align: left,
 			user-select: none,
-			treeview-dropping-bottom: (
-				box-shadow: 0 2px 0 0 $cadmin-primary-l0,
-			),
 			treeview-dropping-middle: (
 				background-color: $cadmin-primary-l3,
 				border-color: $cadmin-primary-l0,
-			),
-			treeview-dropping-top: (
-				box-shadow: 0 -2px 0 0 $cadmin-primary-l0,
 			),
 			hover: (
 				text-decoration: none,

--- a/packages/clay-css/src/scss/components/_treeview.scss
+++ b/packages/clay-css/src/scss/components/_treeview.scss
@@ -162,24 +162,30 @@
 	}
 }
 
+.treeview-dropping-indicator-top {
+	@include clay-link(
+		map-deep-get($treeview, treeview-dropping-indicator-top)
+	);
+}
+
+.treeview-dropping-indicator-bottom {
+	@include clay-link(
+		map-deep-get($treeview, treeview-dropping-indicator-bottom)
+	);
+}
+
+.treeview-dropping-indicator-over {
+	@include clay-link(
+		map-deep-get($treeview, treeview-dropping-indicator-over)
+	);
+}
+
 .treeview-link {
 	@include clay-link(map-get($treeview, treeview-link));
-
-	&.treeview-dropping-bottom {
-		@include clay-link(
-			map-deep-get($treeview, treeview-link, treeview-dropping-bottom)
-		);
-	}
 
 	&.treeview-dropping-middle {
 		@include clay-link(
 			map-deep-get($treeview, treeview-link, treeview-dropping-middle)
-		);
-	}
-
-	&.treeview-dropping-top {
-		@include clay-link(
-			map-deep-get($treeview, treeview-link, treeview-dropping-top)
 		);
 	}
 

--- a/packages/clay-css/src/scss/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/variables/_treeview.scss
@@ -61,6 +61,25 @@ $treeview: map-merge(
 				box-shadow: none,
 			),
 		),
+		treeview-dropping-indicator-top: (
+			background-color: transparent,
+			display: block,
+			height: 2px,
+			margin-top: -2px,
+			outline: none,
+			width: 100%,
+		),
+		treeview-dropping-indicator-bottom: (
+			background-color: transparent,
+			display: block,
+			height: 2px,
+			margin-bottom: -2px,
+			outline: none,
+			width: 100%,
+		),
+		treeview-dropping-indicator-over: (
+			background-color: $primary-l0,
+		),
 		treeview-link: (
 			background-color: transparent,
 			cursor: pointer,
@@ -75,15 +94,9 @@ $treeview: map-merge(
 			position: relative,
 			text-align: left,
 			user-select: none,
-			treeview-dropping-bottom: (
-				box-shadow: 0 2px 0 0 $primary-l0,
-			),
 			treeview-dropping-middle: (
 				background-color: $primary-l3,
 				border-color: $primary-l0,
-			),
-			treeview-dropping-top: (
-				box-shadow: 0 -2px 0 0 $primary-l0,
 			),
 			hover: (
 				text-decoration: none,


### PR DESCRIPTION
Fixes #5383

This is a different strategy compared to the implementation in #5428, instead of adding the `useDrop` directly to each indicator it adds to each item and just uses the indicator to display visually.