### PR TITLE
feat(@clayui/breadcrumb): improve breadcrumb accessibility

### DIFF
--- a/packages/clay-breadcrumb/src/Item.tsx
+++ b/packages/clay-breadcrumb/src/Item.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayButton from '@clayui/button';
 import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
@@ -37,34 +36,20 @@ const Item = ({active, href, label, onClick, ...otherProps}: IItem) => (
 		})}
 		{...otherProps}
 	>
-		{!active && href ? (
-			<ClayLink
-				className="breadcrumb-link"
-				data-testid={`testId${label}`}
-				href={href}
-				role="button"
-			>
-				<span className="breadcrumb-text-truncate">{label}</span>
-			</ClayLink>
-		) : !active && onClick ? (
-			<ClayButton
-				className="breadcrumb-link"
-				data-testid={`testId${label}`}
-				displayType="unstyled"
-				onClick={onClick}
-				title={label}
-			>
-				<span className="breadcrumb-text-truncate">{label}</span>
-			</ClayButton>
-		) : (
-			<span
-				className="breadcrumb-text-truncate"
-				data-testid={`testId${label}`}
-				title={label}
-			>
-				{label}
-			</span>
-		)}
+		<ClayLink
+			aria-current={active ? 'page' : undefined}
+			className="breadcrumb-link"
+			data-testid={`testId${label}`}
+			href={href}
+			onClick={(event) => {
+				if (onClick) {
+					event.preventDefault();
+					onClick(event);
+				}
+			}}
+		>
+			{label}
+		</ClayLink>
 	</li>
 );
 

--- a/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
@@ -2,285 +2,261 @@
 
 exports[`ClayBreadcrumb calls callback when an item is clicked 1`] = `
 <div>
-  <ol
-    class="breadcrumb"
+  <nav
+    aria-label="Breadcrumb"
   >
-    <li
-      class="breadcrumb-item active"
+    <ol
+      class="breadcrumb"
     >
-      <span
-        class="breadcrumb-text-truncate"
-        data-testid="testId1"
-        title="1"
+      <li
+        class="breadcrumb-item active"
       >
-        1
-      </span>
-    </li>
-    <li
-      class="breadcrumb-item"
-    >
-      <button
-        class="breadcrumb-link btn btn-unstyled"
-        data-testid="testId2"
-        title="2"
-        type="button"
+        <a
+          aria-current="page"
+          class="breadcrumb-link"
+          data-testid="testId1"
+        >
+          1
+        </a>
+      </li>
+      <li
+        class="breadcrumb-item"
       >
-        <span
-          class="breadcrumb-text-truncate"
+        <a
+          class="breadcrumb-link"
+          data-testid="testId2"
         >
           2
-        </span>
-      </button>
-    </li>
-    <li
-      class="dropdown breadcrumb-item"
-    >
-      <button
-        aria-controls="clay-dropdown-menu-3"
-        aria-expanded="false"
-        aria-haspopup="true"
-        class="dropdown-toggle breadcrumb-link btn btn-unstyled"
-        data-testid="breadcrumbDropdownTrigger"
-        type="button"
+        </a>
+      </li>
+      <li
+        class="dropdown breadcrumb-item"
       >
-        <svg
-          class="lexicon-icon lexicon-icon-ellipsis-h"
-          role="presentation"
+        <button
+          aria-controls="clay-dropdown-menu-3"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle breadcrumb-link btn btn-unstyled"
+          data-testid="breadcrumbDropdownTrigger"
+          type="button"
         >
-          <use
-            xlink:href="path/to/spritemap#ellipsis-h"
-          />
-        </svg>
-        <svg
-          class="lexicon-icon lexicon-icon-caret-bottom"
-          role="presentation"
-        >
-          <use
-            xlink:href="path/to/spritemap#caret-bottom"
-          />
-        </svg>
-      </button>
-    </li>
-    <li
-      class="breadcrumb-item"
-    >
-      <button
-        class="breadcrumb-link btn btn-unstyled"
-        data-testid="testId5"
-        title="5"
-        type="button"
+          <svg
+            class="lexicon-icon lexicon-icon-ellipsis-h"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#ellipsis-h"
+            />
+          </svg>
+          <svg
+            class="lexicon-icon lexicon-icon-caret-bottom"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#caret-bottom"
+            />
+          </svg>
+        </button>
+      </li>
+      <li
+        class="breadcrumb-item"
       >
-        <span
-          class="breadcrumb-text-truncate"
+        <a
+          class="breadcrumb-link"
+          data-testid="testId5"
         >
           5
-        </span>
-      </button>
-    </li>
-  </ol>
+        </a>
+      </li>
+    </ol>
+  </nav>
 </div>
 `;
 
 exports[`ClayBreadcrumb renders 1`] = `
 <div>
-  <ol
-    class="breadcrumb"
+  <nav
+    aria-label="Breadcrumb"
   >
-    <li
-      class="breadcrumb-item active"
+    <ol
+      class="breadcrumb"
     >
-      <span
-        class="breadcrumb-text-truncate"
-        data-testid="testId1"
-        title="1"
+      <li
+        class="breadcrumb-item active"
       >
-        1
-      </span>
-    </li>
-    <li
-      class="breadcrumb-item"
-    >
-      <a
-        class="breadcrumb-link"
-        data-testid="testId2"
-        href="#2"
-        role="button"
+        <a
+          aria-current="page"
+          class="breadcrumb-link"
+          data-testid="testId1"
+          href="#1"
+        >
+          1
+        </a>
+      </li>
+      <li
+        class="breadcrumb-item"
       >
-        <span
-          class="breadcrumb-text-truncate"
+        <a
+          class="breadcrumb-link"
+          data-testid="testId2"
+          href="#2"
         >
           2
-        </span>
-      </a>
-    </li>
-    <li
-      class="dropdown breadcrumb-item"
-    >
-      <button
-        aria-controls="clay-dropdown-menu-1"
-        aria-expanded="false"
-        aria-haspopup="true"
-        class="dropdown-toggle breadcrumb-link btn btn-unstyled"
-        data-testid="breadcrumbDropdownTrigger"
-        type="button"
+        </a>
+      </li>
+      <li
+        class="dropdown breadcrumb-item"
       >
-        <svg
-          class="lexicon-icon lexicon-icon-ellipsis-h"
-          role="presentation"
+        <button
+          aria-controls="clay-dropdown-menu-1"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle breadcrumb-link btn btn-unstyled"
+          data-testid="breadcrumbDropdownTrigger"
+          type="button"
         >
-          <use
-            xlink:href="path/to/spritemap#ellipsis-h"
-          />
-        </svg>
-        <svg
-          class="lexicon-icon lexicon-icon-caret-bottom"
-          role="presentation"
-        >
-          <use
-            xlink:href="path/to/spritemap#caret-bottom"
-          />
-        </svg>
-      </button>
-    </li>
-    <li
-      class="breadcrumb-item"
-    >
-      <a
-        class="breadcrumb-link"
-        data-testid="testId5"
-        href="#5"
-        role="button"
+          <svg
+            class="lexicon-icon lexicon-icon-ellipsis-h"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#ellipsis-h"
+            />
+          </svg>
+          <svg
+            class="lexicon-icon lexicon-icon-caret-bottom"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#caret-bottom"
+            />
+          </svg>
+        </button>
+      </li>
+      <li
+        class="breadcrumb-item"
       >
-        <span
-          class="breadcrumb-text-truncate"
+        <a
+          class="breadcrumb-link"
+          data-testid="testId5"
+          href="#5"
         >
           5
-        </span>
-      </a>
-    </li>
-  </ol>
+        </a>
+      </li>
+    </ol>
+  </nav>
 </div>
 `;
 
 exports[`ClayBreadcrumb renders with properties passed by \`ellipsisProps\` 1`] = `
 <div>
-  <ol
-    class="breadcrumb"
+  <nav
+    aria-label="Breadcrumb"
   >
-    <li
-      class="breadcrumb-item active"
+    <ol
+      class="breadcrumb"
     >
-      <span
-        class="breadcrumb-text-truncate"
-        data-testid="testId1"
-        title="1"
+      <li
+        class="breadcrumb-item active"
       >
-        1
-      </span>
-    </li>
-    <li
-      class="breadcrumb-item"
-    >
-      <a
-        class="breadcrumb-link"
-        data-testid="testId2"
-        href="#2"
-        role="button"
+        <a
+          aria-current="page"
+          class="breadcrumb-link"
+          data-testid="testId1"
+          href="#1"
+        >
+          1
+        </a>
+      </li>
+      <li
+        class="breadcrumb-item"
       >
-        <span
-          class="breadcrumb-text-truncate"
+        <a
+          class="breadcrumb-link"
+          data-testid="testId2"
+          href="#2"
         >
           2
-        </span>
-      </a>
-    </li>
-    <li
-      class="dropdown breadcrumb-item"
-      style="font-size: 15px;"
-    >
-      <button
-        aria-controls="clay-dropdown-menu-2"
-        aria-expanded="false"
-        aria-haspopup="true"
-        class="dropdown-toggle breadcrumb-link btn btn-unstyled"
-        data-testid="breadcrumbDropdownTrigger"
-        type="button"
+        </a>
+      </li>
+      <li
+        class="dropdown breadcrumb-item"
+        style="font-size: 15px;"
       >
-        <svg
-          class="lexicon-icon lexicon-icon-ellipsis-h"
-          role="presentation"
+        <button
+          aria-controls="clay-dropdown-menu-2"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle breadcrumb-link btn btn-unstyled"
+          data-testid="breadcrumbDropdownTrigger"
+          type="button"
         >
-          <use
-            xlink:href="path/to/spritemap#ellipsis-h"
-          />
-        </svg>
-        <svg
-          class="lexicon-icon lexicon-icon-caret-bottom"
-          role="presentation"
-        >
-          <use
-            xlink:href="path/to/spritemap#caret-bottom"
-          />
-        </svg>
-      </button>
-    </li>
-    <li
-      class="breadcrumb-item"
-    >
-      <a
-        class="breadcrumb-link"
-        data-testid="testId5"
-        href="#5"
-        role="button"
+          <svg
+            class="lexicon-icon lexicon-icon-ellipsis-h"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#ellipsis-h"
+            />
+          </svg>
+          <svg
+            class="lexicon-icon lexicon-icon-caret-bottom"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#caret-bottom"
+            />
+          </svg>
+        </button>
+      </li>
+      <li
+        class="breadcrumb-item"
       >
-        <span
-          class="breadcrumb-text-truncate"
+        <a
+          class="breadcrumb-link"
+          data-testid="testId5"
+          href="#5"
         >
           5
-        </span>
-      </a>
-    </li>
-  </ol>
+        </a>
+      </li>
+    </ol>
+  </nav>
 </div>
 `;
 
 exports[`ClayBreadcrumb throws a warning when not passing \`active\` to any \`items\` 1`] = `
 <div>
-  <ol
-    class="breadcrumb"
+  <nav
+    aria-label="Breadcrumb"
   >
-    <li
-      class="breadcrumb-item"
+    <ol
+      class="breadcrumb"
     >
-      <a
-        class="breadcrumb-link"
-        data-testid="testId1"
-        href="#1"
-        role="button"
+      <li
+        class="breadcrumb-item"
       >
-        <span
-          class="breadcrumb-text-truncate"
+        <a
+          class="breadcrumb-link"
+          data-testid="testId1"
+          href="#1"
         >
           1
-        </span>
-      </a>
-    </li>
-    <li
-      class="breadcrumb-item"
-    >
-      <a
-        class="breadcrumb-link"
-        data-testid="testId2"
-        href="#2"
-        role="button"
+        </a>
+      </li>
+      <li
+        class="breadcrumb-item"
       >
-        <span
-          class="breadcrumb-text-truncate"
+        <a
+          class="breadcrumb-link"
+          data-testid="testId2"
+          href="#2"
         >
           2
-        </span>
-      </a>
-    </li>
-  </ol>
+        </a>
+      </li>
+    </ol>
+  </nav>
 </div>
 `;

--- a/packages/clay-breadcrumb/src/index.tsx
+++ b/packages/clay-breadcrumb/src/index.tsx
@@ -44,6 +44,7 @@ const findActiveItems = (items: TItems) => {
 };
 
 const ClayBreadcrumb = ({
+	'aria-label': ariaLabel = 'Breadcrumb',
 	className,
 	ellipsisBuffer = 1,
 	ellipsisProps = {},
@@ -72,21 +73,24 @@ const ClayBreadcrumb = ({
 		: items;
 
 	return (
-		<ol {...otherProps} className={classNames('breadcrumb', className)}>
-			{breadCrumbItems.map((item: TItem | React.ReactNode, i: number) =>
-				React.isValidElement(item) ? (
-					React.cloneElement(item, {key: `ellipsis${i}`})
-				) : (
-					<Item
-						active={(item as TItem).active}
-						href={(item as TItem).href}
-						key={`breadcrumbItem${i}`}
-						label={(item as TItem).label}
-						onClick={(item as TItem).onClick}
-					/>
-				)
-			)}
-		</ol>
+		<nav aria-label={ariaLabel}>
+			<ol {...otherProps} className={classNames('breadcrumb', className)}>
+				{breadCrumbItems.map(
+					(item: TItem | React.ReactNode, i: number) =>
+						React.isValidElement(item) ? (
+							React.cloneElement(item, {key: `ellipsis${i}`})
+						) : (
+							<Item
+								active={(item as TItem).active}
+								href={(item as TItem).href}
+								key={`breadcrumbItem${i}`}
+								label={(item as TItem).label}
+								onClick={(item as TItem).onClick}
+							/>
+						)
+				)}
+			</ol>
+		</nav>
 	);
 };
 

--- a/packages/clay-breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/clay-breadcrumb/stories/Breadcrumb.stories.tsx
@@ -18,7 +18,6 @@ export const Default = (args: any) => (
 		ellipsisProps={{'aria-label': 'More', title: 'More'}}
 		items={[
 			{
-				active: true,
 				href: '#1',
 				label: 'Home',
 			},
@@ -59,6 +58,7 @@ export const Default = (args: any) => (
 				label: 'Ten',
 			},
 			{
+				active: true,
 				href: '#11',
 				label: 'Eleven',
 			},
@@ -79,7 +79,6 @@ export const Buttons = (args: any) => {
 			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			items={[
 				{
-					active: true,
 					label: 'Home',
 					onClick: onItemClick,
 				},
@@ -120,6 +119,7 @@ export const Buttons = (args: any) => {
 					onClick: onItemClick,
 				},
 				{
+					active: true,
 					label: 'Eleven',
 					onClick: onItemClick,
 				},
@@ -133,7 +133,7 @@ Buttons.args = {
 };
 
 export const ActiveState = () => {
-	const [active, setActive] = useState<number>(0);
+	const [active, setActive] = useState<number>(4);
 
 	const items = [
 		{


### PR DESCRIPTION
Closes #5441

It is still a draft, it remains to modify the ellipse to use the collapse, it still remains to understand what the rules are for how the collapse will work. This PR modifies that it will always render the Link even when it is active, when the `onClick` method is added, we ignore the default behavior of the link so that the behavior is similar to the button but is accessible.