### PR TITLE
fix(@clayui/core): prevents JS from breaking component implementation

### DIFF
--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -244,6 +244,10 @@ export function Picker<T>({
 		) {
 			const value = collection.getItem(activeDescendant);
 
+			if (!value) {
+				return;
+			}
+
 			announcerAPI.current.announce(
 				selectedKey === activeDescendant
 					? sub(messages.itemSelected, [value])


### PR DESCRIPTION
Fixes #5456

This just prevents the implementation from crashing when it doesn't find the item in the collection, the error actually is that the defined key value doesn't exist in the items, so the component tries to find the value that doesn't exist. 

The error of this bug is because the selected value defined in the component does not exist in the `items` options. So this is just a fix to avoid breaking the JS but it also needs to be fixed on the DXP side.