### PR TITLE
fix(clayui.com): Change tab navigation to navigation bar

### DIFF
--- a/clayui.com/src/styles/_guide.scss
+++ b/clayui.com/src/styles/_guide.scss
@@ -58,6 +58,10 @@
 			}
 		}
 
+		.navbar .container-fluid {
+			padding: 0;
+		}
+
 		.docs-title {
 			font-weight: 500;
 			margin: 0;
@@ -68,6 +72,22 @@
 			font-size: 22px;
 			font-weight: 400;
 			margin: 0 0 20px;
+		}
+
+		.docs-table {
+			color: #6b6c7e;
+			margin-bottom: 20px;
+			width: auto;
+
+			td,
+			th {
+				border-color: transparent;
+				padding: 0.55rem;
+			}
+
+			th {
+				padding-left: 0;
+			}
 		}
 
 		.docs-description {

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {Heading} from '@clayui/core';
 import {ClayIconSpriteContext} from '@clayui/icon/src';
 import ClayLink, {ClayLinkContext} from '@clayui/link';
 import NavigationBar from '@clayui/navigation-bar';
@@ -257,15 +258,9 @@ export default function Documentation(props) {
 											<div className="clay-site-container container-fluid">
 												<div className="row">
 													<div className="col-12">
-														<h1 className="docs-title">
+														<Heading level={1}>
 															{frontmatter.title}
-														</h1>
-
-														{frontmatter.packageNpm && (
-															<p className="docs-subtitle">
-																{`yarn add ${frontmatter.packageNpm}`}
-															</p>
-														)}
+														</Heading>
 
 														{frontmatter.description && (
 															<p className="docs-subtitle">
@@ -273,6 +268,32 @@ export default function Documentation(props) {
 																	frontmatter.description
 																}
 															</p>
+														)}
+
+														{frontmatter.packageNpm && (
+															<table className="docs-table table">
+																<tbody>
+																	<tr>
+																		<th>
+																			install
+																		</th>
+																		<td>{`yarn add ${frontmatter.packageNpm}`}</td>
+																	</tr>
+
+																	{fields.packageVersion && (
+																		<tr>
+																			<th>
+																				version
+																			</th>
+																			<td>
+																				{
+																					fields.packageVersion
+																				}
+																			</td>
+																		</tr>
+																	)}
+																</tbody>
+															</table>
 														)}
 													</div>
 													<div className="col-12">
@@ -292,7 +313,9 @@ export default function Documentation(props) {
 																				name
 																			}
 																		>
-																			<ClayLink href={`/${href}`}>
+																			<ClayLink
+																				href={`/${href}`}
+																			>
 																				{
 																					name
 																				}

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -4,8 +4,8 @@
  */
 
 import {ClayIconSpriteContext} from '@clayui/icon/src';
-import {ClayLinkContext} from '@clayui/link';
-import ClayTabs from '@clayui/tabs';
+import ClayLink, {ClayLinkContext} from '@clayui/link';
+import NavigationBar from '@clayui/navigation-bar';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import {MDXProvider} from '@mdx-js/react';
 import {Link, graphql} from 'gatsby';
@@ -277,34 +277,30 @@ export default function Documentation(props) {
 													</div>
 													<div className="col-12">
 														{tabs.length > 0 && (
-															<ClayTabs>
+															<NavigationBar>
 																{tabs.map(
 																	({
 																		href,
 																		name,
 																	}) => (
-																		<ClayTabs.Item
+																		<NavigationBar.Item
 																			active={
 																				`/${href}` ===
 																				location.pathname
 																			}
-																			href={`/${href}`}
 																			key={
 																				name
 																			}
 																		>
-																			<span
-																				className="c-inner"
-																				tabIndex="-1"
-																			>
+																			<ClayLink href={`/${href}`}>
 																				{
 																					name
 																				}
-																			</span>
-																		</ClayTabs.Item>
+																			</ClayLink>
+																		</NavigationBar.Item>
 																	)
 																)}
-															</ClayTabs>
+															</NavigationBar>
 														)}
 													</div>
 												</div>


### PR DESCRIPTION
Fixes #5464

This PR changes the use of the component from ClayTabs to ClayNavigationBar, I also made some changes in the header to adjust the look to improve the weight of the fonts and spacing to visually improve the reading.

| Before | After |
|--------|--------|
| ![Screenshot 2023-04-11 at 16 15 48](https://user-images.githubusercontent.com/13750819/231289998-62bf6fd1-9ea7-4c5b-b608-a4c7e85fc839.png) | ![Screenshot 2023-04-11 at 16 15 15](https://user-images.githubusercontent.com/13750819/231289899-2fbd5d3e-547a-41df-871e-962b71b2a9e9.png) |
