### PR TITLE
fix(@clayui/css): Mixins clay-button-variant adds ability to style :l…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -616,6 +616,66 @@
 				@include clay-css(map-get($map, after));
 			}
 
+			&:link {
+				$_link: setter(map-get($map, link), ());
+
+				@include clay-css($_link);
+
+				&::before {
+					@include clay-css(map-get($_link, before));
+				}
+
+				&::after {
+					@include clay-css(map-get($_link, after));
+				}
+
+				.inline-item {
+					@include clay-css(map-get($_link, inline-item));
+				}
+
+				.inline-item-before {
+					@include clay-css(map-get($_link, inline-item-before));
+				}
+
+				.inline-item-middle {
+					@include clay-css(map-get($_link, inline-item-middle));
+				}
+
+				.inline-item-after {
+					@include clay-css(map-get($_link, inline-item-after));
+				}
+			}
+
+			&:visited {
+				$_visited: setter(map-get($map, visited), ());
+
+				@include clay-css($_visited);
+
+				&::before {
+					@include clay-css(map-get($_visited, before));
+				}
+
+				&::after {
+					@include clay-css(map-get($_visited, after));
+				}
+
+				.inline-item {
+					@include clay-css(map-get($_visited, inline-item));
+				}
+
+				.inline-item-before {
+					@include clay-css(map-get($_visited, inline-item-before));
+				}
+
+				.inline-item-middle {
+					@include clay-css(map-get($_visited, inline-item-middle));
+				}
+
+				.inline-item-after {
+					@include clay-css(map-get($_visited, inline-item-after));
+				}
+			}
+
 			&:hover {
 				@include clay-css($hover);
 

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -549,6 +549,42 @@
 		@if ($enabled) {
 			@include clay-css($base);
 
+			&:link {
+				$_link: setter(map-get($map, link), ());
+
+				@include clay-css($_link);
+
+				&::before {
+					@include clay-css(map-get($_link, before));
+				}
+
+				&::after {
+					@include clay-css(map-get($_link, after));
+				}
+
+				.c-kbd-inline {
+					@include clay-css(map-get($_link, c-kbd-inline));
+				}
+			}
+
+			&:visited {
+				$_visited: setter(map-get($map, visited), ());
+
+				@include clay-css($_visited);
+
+				&::before {
+					@include clay-css(map-get($_visited, before));
+				}
+
+				&::after {
+					@include clay-css(map-get($_visited, after));
+				}
+
+				.c-kbd-inline {
+					@include clay-css(map-get($_visited, c-kbd-inline));
+				}
+			}
+
 			&:hover,
 			&.hover {
 				@include clay-css($hover);


### PR DESCRIPTION
…ink and :visited pseudo classes

fix(@clayui/css): Mixins clay-dropdown-item-variant adds ability to style :link and :visited pseudo classes

fixes #5470
fixes #5472