### PR TITLE
fix(@clayui/css): Exclude variant styles from being output when using c-unset

### DIFF
--- a/packages/clay-css/src/scss/components/_alerts.scss
+++ b/packages/clay-css/src/scss/components/_alerts.scss
@@ -372,31 +372,33 @@
 // Alert Variants
 
 @each $color, $value in $alert-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.alert-', 1)
-	);
-
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-alert-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%alert-#{$color}'
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.alert-', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-alert-variant($value);
-		}
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-alert-variant($value);
+			}
+		} @else {
+			$placeholder: if(
+				starts-with($color, '.') or starts-with($color, '#'),
+				'%#{str-slice($color, 2)}',
+				'%alert-#{$color}'
+			);
 
-		#{$selector} {
-			@extend %alert-#{$color} !optional;
+			#{$placeholder} {
+				@include clay-alert-variant($value);
+			}
+
+			#{$selector} {
+				@extend %alert-#{$color} !optional;
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_aspect-ratio.scss
+++ b/packages/clay-css/src/scss/components/_aspect-ratio.scss
@@ -161,41 +161,43 @@
 // aspect-ratio-#-to-#
 
 @each $selector, $value in $aspect-ratio-sizes {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
-
-	@if (starts-with($selector, '%')) {
-		#{$selector} {
-			@include clay-aspect-ratio(
-				map-get($value, width),
-				map-get($value, height)
-			);
-		}
-	} @else if (map-get($value, extend)) {
-		#{$selector} {
-			@include clay-css($value);
-		}
-	} @else {
-		$placeholder: str-insert(
-			str-slice($selector, 2, str-length($selector)),
-			'%',
-			1
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-aspect-ratio(
-				map-get($value, width),
-				map-get($value, height)
+		@if (starts-with($selector, '%')) {
+			#{$selector} {
+				@include clay-aspect-ratio(
+					map-get($value, width),
+					map-get($value, height)
+				);
+			}
+		} @else if (map-get($value, extend)) {
+			#{$selector} {
+				@include clay-css($value);
+			}
+		} @else {
+			$placeholder: str-insert(
+				str-slice($selector, 2, str-length($selector)),
+				'%',
+				1
 			);
-		}
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-aspect-ratio(
+					map-get($value, width),
+					map-get($value, height)
+				);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_badges.scss
+++ b/packages/clay-css/src/scss/components/_badges.scss
@@ -108,35 +108,37 @@
 // Badge Variants
 
 @each $color, $value in $badge-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		if(
-			starts-with($color, 'badge'),
-			str-insert($color, '.', 1),
-			str-insert($color, '.badge-', 1)
-		)
-	);
-
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-badge-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%badge-#{$color}'
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			if(
+				starts-with($color, 'badge'),
+				str-insert($color, '.', 1),
+				str-insert($color, '.badge-', 1)
+			)
 		);
 
-		#{$placeholder} {
-			@include clay-badge-variant($value);
-		}
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-badge-variant($value);
+			}
+		} @else {
+			$placeholder: if(
+				starts-with($color, '.') or starts-with($color, '#'),
+				'%#{str-slice($color, 2)}',
+				'%badge-#{$color}'
+			);
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-badge-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -19,29 +19,31 @@ fieldset:disabled a.btn {
 // Button Sizes
 
 @each $size, $value in $btn-sizes {
-	$selector: if(
-		starts-with($size, 'btn-'),
-		clay-str-replace($size, 'btn-', '.btn-'),
-		$size
-	);
-
-	@if (starts-with($size, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-button-variant($value);
-		}
-	} @else {
-		$placeholder: if(
+	@if not clay-is-map-unset($value) {
+		$selector: if(
 			starts-with($size, 'btn-'),
-			'%clay-#{$size}',
-			'%#{str-slice($size, 2)}'
+			clay-str-replace($size, 'btn-', '.btn-'),
+			$size
 		);
 
-		#{$placeholder} {
-			@include clay-button-variant($value);
-		}
+		@if (starts-with($size, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
+		} @else {
+			$placeholder: if(
+				starts-with($size, 'btn-'),
+				'%clay-#{$size}',
+				'%#{str-slice($size, 2)}'
+			);
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-button-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 		}
 	}
 }
@@ -80,33 +82,35 @@ input[type='button'] {
 // Button Monospaced
 
 @each $size, $value in $btn-monospaced-sizes {
-	$selector: if(
-		starts-with($size, 'btn-monospaced-'),
-		clay-str-replace($size, 'btn-monospaced', '.btn-monospaced.btn'),
-		if(
-			$size == 'btn-monospaced',
-			clay-str-replace($size, 'btn-monospaced', '.btn-monospaced'),
-			$size
-		)
-	);
-
-	@if (starts-with($size, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-button-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($size, 'btn-monospaced'),
-			'%clay-#{$size}',
-			'%#{str-slice($size, 2)}'
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($size, 'btn-monospaced-'),
+			clay-str-replace($size, 'btn-monospaced', '.btn-monospaced.btn'),
+			if(
+				$size == 'btn-monospaced',
+				clay-str-replace($size, 'btn-monospaced', '.btn-monospaced'),
+				$size
+			)
 		);
 
-		#{$placeholder} {
-			@include clay-button-variant($value);
-		}
+		@if (starts-with($size, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
+		} @else {
+			$placeholder: if(
+				starts-with($size, 'btn-monospaced'),
+				'%clay-#{$size}',
+				'%#{str-slice($size, 2)}'
+			);
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-button-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 		}
 	}
 }
@@ -114,37 +118,39 @@ input[type='button'] {
 // Button Variants
 
 @each $color, $value in $btn-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		if(
-			starts-with($color, 'btn'),
-			str-insert($color, '.', 1),
-			str-insert($color, '.btn-', 1)
-		)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			if(
+				starts-with($color, 'btn'),
+				str-insert($color, '.', 1),
+				str-insert($color, '.btn-', 1)
+			)
+		);
 
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-button-variant($value);
-		}
-	} @else {
-		$placeholder: '%#{str-slice($selector, 2)}';
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
+		} @else {
+			$placeholder: '%#{str-slice($selector, 2)}';
 
-		$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
+			$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
 
-		#{$placeholder} {
-			@include clay-button-variant($value);
-		}
+			#{$placeholder} {
+				@include clay-button-variant($value);
+			}
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
-		}
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 
-		#{$placeholder-focus} {
-			@include clay-button-variant(map-get($value, focus));
+			#{$placeholder-focus} {
+				@include clay-button-variant(map-get($value, focus));
+			}
 		}
 	}
 }
@@ -152,37 +158,39 @@ input[type='button'] {
 // Button Outline Variants
 
 @each $color, $value in $btn-outline-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		if(
-			starts-with($color, 'btn'),
-			str-insert($color, '.', 1),
-			str-insert($color, '.btn-outline-', 1)
-		)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			if(
+				starts-with($color, 'btn'),
+				str-insert($color, '.', 1),
+				str-insert($color, '.btn-outline-', 1)
+			)
+		);
 
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-button-variant($value);
-		}
-	} @else {
-		$placeholder: '%#{str-slice($selector, 2)}';
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
+		} @else {
+			$placeholder: '%#{str-slice($selector, 2)}';
 
-		$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
+			$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
 
-		#{$placeholder} {
-			@include clay-button-variant($value);
-		}
+			#{$placeholder} {
+				@include clay-button-variant($value);
+			}
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
-		}
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 
-		#{$placeholder-focus} {
-			@include clay-button-variant(map-get($value, focus));
+			#{$placeholder-focus} {
+				@include clay-button-variant(map-get($value, focus));
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -124,14 +124,16 @@
 // Dropdown Menu Variants
 
 @each $key, $value in $dropdown-menu-palette {
-	$selector: if(
-		starts-with($key, '.') or starts-with($key, '#'),
-		$key,
-		str-insert($key, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($key, '.') or starts-with($key, '#'),
+			$key,
+			str-insert($key, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-dropdown-menu-variant($value);
+		#{$selector} {
+			@include clay-dropdown-menu-variant($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -158,14 +158,16 @@ fieldset[disabled] .form-control {
 }
 
 @each $key, $value in $input-palette {
-	$selector: if(
-		starts-with($key, '.') or starts-with($key, '#'),
-		$key,
-		str-insert($key, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($key, '.') or starts-with($key, '#'),
+			$key,
+			str-insert($key, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-form-control-variant($value);
+		#{$selector} {
+			@include clay-form-control-variant($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_labels.scss
+++ b/packages/clay-css/src/scss/components/_labels.scss
@@ -89,31 +89,33 @@
 // Label Sizes
 
 @each $selector, $value in $label-sizes {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
-
-	@if (starts-with($selector, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-label-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($selector, '.') or starts-with($selector, '#'),
-			'%#{str-slice($selector, 2)}',
-			'%#{$selector}'
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-label-variant($value);
-		}
+		@if (starts-with($selector, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-label-variant($value);
+			}
+		} @else {
+			$placeholder: if(
+				starts-with($selector, '.') or starts-with($selector, '#'),
+				'%#{str-slice($selector, 2)}',
+				'%#{$selector}'
+			);
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-label-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 		}
 	}
 }
@@ -121,31 +123,33 @@
 // Label Variants
 
 @each $color, $value in $label-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.label-', 1)
-	);
-
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-label-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%label-#{$color}'
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.label-', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-label-variant($value);
-		}
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-label-variant($value);
+			}
+		} @else {
+			$placeholder: if(
+				starts-with($color, '.') or starts-with($color, '#'),
+				'%#{str-slice($color, 2)}',
+				'%label-#{$color}'
+			);
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-label-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_list-group.scss
+++ b/packages/clay-css/src/scss/components/_list-group.scss
@@ -410,20 +410,22 @@
 // List Group Item Variants
 
 @each $color, $value in $list-group-item-theme-colors {
-	.list-group-item-#{$color} {
-		@include clay-css($value);
+	@if not clay-is-map-unset($value) {
+		.list-group-item-#{$color} {
+			@include clay-css($value);
 
-		&.list-group-item-action {
-			&:hover {
-				@include clay-css(map-get($value, hover));
-			}
+			&.list-group-item-action {
+				&:hover {
+					@include clay-css(map-get($value, hover));
+				}
 
-			&:focus {
-				@include clay-css(map-get($value, focus));
-			}
+				&:focus {
+					@include clay-css(map-get($value, focus));
+				}
 
-			&.active {
-				@include clay-css(map-get($value, active));
+				&.active {
+					@include clay-css(map-get($value, active));
+				}
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/components/_loaders.scss
+++ b/packages/clay-css/src/scss/components/_loaders.scss
@@ -79,31 +79,35 @@
 // Loading Animation Sizes
 
 @each $selector, $value in $loading-animation-sizes {
-	$_selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$_selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$_selector} {
-		@include clay-spinner-variant($value);
+		#{$_selector} {
+			@include clay-spinner-variant($value);
+		}
 	}
 }
 
 // Loading Animation Variants
 
 @each $selector, $value in $loading-animation-palette {
-	$_selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$_selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$_selector} {
-		@include clay-spinner-variant($value);
+		#{$_selector} {
+			@include clay-spinner-variant($value);
+		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_modals.scss
+++ b/packages/clay-css/src/scss/components/_modals.scss
@@ -490,8 +490,10 @@
 // Modal Variants
 
 @each $color, $value in $modal-palette {
-	.modal-#{$color} {
-		@include clay-modal-variant($value);
+	@if not clay-is-map-unset($value) {
+		.modal-#{$color} {
+			@include clay-modal-variant($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_navs.scss
+++ b/packages/clay-css/src/scss/components/_navs.scss
@@ -189,13 +189,15 @@
 // Nav Variants
 
 @each $key, $value in $nav-palette {
-	$selector: if(
-		starts-with($key, '.') or starts-with($key, '#'),
-		$key,
-		str-insert($key, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($key, '.') or starts-with($key, '#'),
+			$key,
+			str-insert($key, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-nav-variant($value);
+		#{$selector} {
+			@include clay-nav-variant($value);
+		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_popovers.scss
+++ b/packages/clay-css/src/scss/components/_popovers.scss
@@ -1,16 +1,18 @@
 // Popovers
 
 @each $selector, $value in $popovers {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-popover-variant($value);
+		#{$selector} {
+			@include clay-popover-variant($value);
+		}
 	}
 }
 
@@ -150,32 +152,36 @@
 // Popover Headers
 
 @each $selector, $value in $popover-headers {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-popover-header-variant($value);
+		#{$selector} {
+			@include clay-popover-header-variant($value);
+		}
 	}
 }
 
 // Popover Bodies
 
 @each $selector, $value in $popover-bodies {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-popover-header-variant($value);
+		#{$selector} {
+			@include clay-popover-header-variant($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_progress-bars.scss
+++ b/packages/clay-css/src/scss/components/_progress-bars.scss
@@ -122,40 +122,42 @@
 // Progress Variants
 
 @each $color, $value in $progress-palette {
-	.progress-#{$color} {
-		.progress-bar {
-			$progress-bar: setter(map-get($value, progress-bar), ());
-			$progress-bar: map-merge(
-				$progress-bar,
-				(
-					background-color:
-						setter(
-							map-get($progress-bar, background-color),
-							map-get($value, bar-bg)
-						),
-				)
-			);
+	@if not clay-is-map-unset($value) {
+		.progress-#{$color} {
+			.progress-bar {
+				$progress-bar: setter(map-get($value, progress-bar), ());
+				$progress-bar: map-merge(
+					$progress-bar,
+					(
+						background-color:
+							setter(
+								map-get($progress-bar, background-color),
+								map-get($value, bar-bg)
+							),
+					)
+				);
 
-			@include clay-css($progress-bar);
-		}
+				@include clay-css($progress-bar);
+			}
 
-		.progress-group-feedback {
-			$progress-group-feedback: setter(
-				map-get($value, progress-group-feedback),
-				()
-			);
-			$progress-group-feedback: map-merge(
-				$progress-group-feedback,
-				(
-					color:
-						setter(
-							map-get($progress-group-feedback, color),
-							map-get($value, group-feedback-color)
-						),
-				)
-			);
+			.progress-group-feedback {
+				$progress-group-feedback: setter(
+					map-get($value, progress-group-feedback),
+					()
+				);
+				$progress-group-feedback: map-merge(
+					$progress-group-feedback,
+					(
+						color:
+							setter(
+								map-get($progress-group-feedback, color),
+								map-get($value, group-feedback-color)
+							),
+					)
+				);
 
-			@include clay-css($progress-group-feedback);
+				@include clay-css($progress-group-feedback);
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_sidebar.scss
+++ b/packages/clay-css/src/scss/components/_sidebar.scss
@@ -105,15 +105,17 @@
 // Sidebar Variants
 
 @each $color, $value in $sidebar-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-sidebar-variant($value);
+		#{$selector} {
+			@include clay-sidebar-variant($value);
+		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_stickers.scss
+++ b/packages/clay-css/src/scss/components/_stickers.scss
@@ -54,31 +54,33 @@
 // Sticker Sizes
 
 @each $selector, $value in $sticker-sizes {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
-
-	@if (starts-with($selector, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-sticker-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($selector, '.') or starts-with($selector, '#'),
-			'%#{str-slice($selector, 2)}',
-			'%#{$selector}'
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-sticker-variant($value);
-		}
+		@if (starts-with($selector, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-sticker-variant($value);
+			}
+		} @else {
+			$placeholder: if(
+				starts-with($selector, '.') or starts-with($selector, '#'),
+				'%#{str-slice($selector, 2)}',
+				'%#{$selector}'
+			);
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-sticker-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 		}
 	}
 }
@@ -86,31 +88,33 @@
 // Sticker Variants
 
 @each $color, $value in $sticker-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.sticker-', 1)
-	);
-
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-sticker-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%sticker-#{$color}'
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.sticker-', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-sticker-variant($value);
-		}
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-sticker-variant($value);
+			}
+		} @else {
+			$placeholder: if(
+				starts-with($color, '.') or starts-with($color, '#'),
+				'%#{str-slice($color, 2)}',
+				'%sticker-#{$color}'
+			);
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-sticker-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -78,44 +78,46 @@ caption {
 // Table Row Backgrounds
 
 @each $color, $value in $table-row-theme-colors {
-	.table {
-		.table-#{$color} {
-			$table-row: setter($value, ());
+	@if not clay-is-map-unset($value) {
+		.table {
+			.table-#{$color} {
+				$table-row: setter($value, ());
 
-			&,
-			> th,
-			> td {
-				@include clay-css($table-row);
+				&,
+				> th,
+				> td {
+					@include clay-css($table-row);
 
-				.table-title {
-					@include clay-text-typography(
-						map-get($table-row, table-title)
-					);
+					.table-title {
+						@include clay-text-typography(
+							map-get($table-row, table-title)
+						);
+					}
+				}
+
+				th,
+				td,
+				thead th,
+				tbody + tbody {
+					border-color: map-get($table-row, border-color);
 				}
 			}
-
-			th,
-			td,
-			thead th,
-			tbody + tbody {
-				border-color: map-get($table-row, border-color);
-			}
 		}
-	}
 
-	// Hover states for `.table-hover`
-	// Note: this is not available for cells or rows within `thead` or `tfoot`.
+		// Hover states for `.table-hover`
+		// Note: this is not available for cells or rows within `thead` or `tfoot`.
 
-	.table-hover {
-		$hover: setter(map-get($value, hover), ());
+		.table-hover {
+			$hover: setter(map-get($value, hover), ());
 
-		.table-#{$color} {
-			&:hover {
-				@include clay-css($hover);
+			.table-#{$color} {
+				&:hover {
+					@include clay-css($hover);
 
-				> td,
-				> th {
-					background-color: map-get($hover, background-color);
+					> td,
+					> th {
+						background-color: map-get($hover, background-color);
+					}
 				}
 			}
 		}

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -25,31 +25,35 @@
 // Background
 
 @each $color, $value in $bg-theme-colors {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.bg-', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.bg-', 1)
+		);
 
-	#{$selector} {
-		@include clay-css($value);
-	}
+		#{$selector} {
+			@include clay-css($value);
+		}
 
-	a#{$selector},
-	button#{$selector} {
-		&:hover,
-		&:focus {
-			@include clay-css(map-get($value, hover));
+		a#{$selector},
+		button#{$selector} {
+			&:hover,
+			&:focus {
+				@include clay-css(map-get($value, hover));
+			}
 		}
 	}
 }
 
 @if $enable-gradients {
 	@each $color, $value in $bg-gradient-theme-colors {
-		.bg-gradient-#{$color} {
-			@include clay-css($value);
+		@if not clay-is-map-unset($value) {
+			.bg-gradient-#{$color} {
+				@include clay-css($value);
+			}
 		}
 	}
 }
@@ -97,16 +101,18 @@
 }
 
 @each $color, $value in $border-theme-colors {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.border-', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.border-', 1)
+		);
 
-	#{$selector} {
-		@include clay-css($value);
+		#{$selector} {
+			@include clay-css($value);
+		}
 	}
 }
 
@@ -732,16 +738,18 @@
 // Font Sizes
 
 @each $selector, $value in $font-sizes {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-css($value);
+		#{$selector} {
+			@include clay-css($value);
+		}
 	}
 }
 
@@ -752,22 +760,24 @@
 }
 
 @each $color, $value in $text-theme-colors {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.text-', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.text-', 1)
+		);
 
-	#{$selector} {
-		@include clay-css($value);
-	}
+		#{$selector} {
+			@include clay-css($value);
+		}
 
-	a#{$selector} {
-		&:hover,
-		&:focus {
-			@include clay-css(map-get($value, hover));
+		a#{$selector} {
+			&:hover,
+			&:focus {
+				@include clay-css(map-get($value, hover));
+			}
 		}
 	}
 }
@@ -783,16 +793,18 @@
 }
 
 @each $key, $value in $text-decorations {
-	$selector: if(
-		starts-with($key, '.') or
-			starts-with($key, '#') or
-			starts-with($key, '%'),
-		$key,
-		str-insert($key, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($key, '.') or
+				starts-with($key, '#') or
+				starts-with($key, '%'),
+			$key,
+			str-insert($key, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-link($value);
+		#{$selector} {
+			@include clay-link($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -8,6 +8,13 @@
 @import '_lx-icons-generated.scss';
 @import '_type-conversion-functions.scss';
 
+/// A function that checks if the value contains the key word `c-unset` or `clay-unset`
+/// @param {Any} $value The value to check
+
+@function clay-is-map-unset($value) {
+	@return if(($value == c-unset) or ($value == clay-unset), true, false);
+}
+
 /// A helper function that calculates text-indent of data-label-on and data-label-off in a `.toggle-switch`.
 /// @param {Number} $toggle-switch-width - Width of switch bar
 /// @param {Number} $toggle-switch-padding - Space between button and bar
@@ -52,6 +59,10 @@
 /// @param {Map, Null} $map2[()]
 
 @function map-deep-merge($map1: (), $map2: ()) {
+	// @if ($map1 == c-unset or $map2 == c-unset) or ($map1 == clay-unset or $map2 == clay-unset) {
+	// 	@return null;
+	// }
+
 	@if (type-of($map1) == 'list' and length($map1) == 0) or
 		(type-of($map1) == 'null')
 	{

--- a/packages/clay-css/src/scss/mixins/_alerts.scss
+++ b/packages/clay-css/src/scss/mixins/_alerts.scss
@@ -236,15 +236,17 @@
 			}
 
 			@each $key, $properties in map-get($map, custom-selectors) {
-				@if ($key) {
-					$selector: if(
-						starts-with($key, '.') or starts-with($key, '#'),
-						$key,
-						str-insert($key, '.', 1)
-					);
+				@if not clay-is-map-unset($properties) {
+					@if ($key) {
+						$selector: if(
+							starts-with($key, '.') or starts-with($key, '#'),
+							$key,
+							str-insert($key, '.', 1)
+						);
 
-					#{$selector} {
-						@include clay-button-variant($properties);
+						#{$selector} {
+							@include clay-button-variant($properties);
+						}
 					}
 				}
 			}

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -852,14 +852,16 @@
 
 			@if ($c-link-variants) {
 				@each $key, $value in $c-link-variants {
-					$selector: if(
-						starts-with($key, '.') or starts-with($key, '#'),
-						$key,
-						str-insert($key, '.', 1)
-					);
+					@if not clay-is-map-unset($value) {
+						$selector: if(
+							starts-with($key, '.') or starts-with($key, '#'),
+							$key,
+							str-insert($key, '.', 1)
+						);
 
-					&#{$selector} {
-						@include clay-link($value);
+						&#{$selector} {
+							@include clay-link($value);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
fixes #5471

We can prevent variant styles from being output with this pattern:

```scss
$alert-palette: (
    primary: c-unset,
);

$btn-sizes: (
    btn-xs: c-unset,
);

$btn-monospaced-sizes: (
    btn-xs: c-unset,
);
```

previously it would throw an error.