### PR TITLE
fix(@clayui/css): c-prefers-reduced-motion should completely remove transitions and animations

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_drilldown.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_drilldown.scss
@@ -13,7 +13,7 @@
 // Drilldown Transition Classes
 
 .drilldown-transition {
-	transition: $cadmin-drilldown-transition;
+	@include transition($cadmin-drilldown-transition);
 }
 
 .drilldown-item.transitioning {

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -373,7 +373,7 @@ textarea.form-control-plaintext,
 
 	&::-webkit-slider-thumb {
 		border-radius: 100px;
-		transition: $cadmin-input-transition;
+		@include transition($cadmin-input-transition);
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
@@ -174,7 +174,8 @@
 		margin-bottom: 0;
 		padding-left: $cadmin-input-group-inset-item-padding-left;
 		padding-right: $cadmin-input-group-inset-item-padding-right;
-		transition: $cadmin-input-transition;
+
+		@include transition($cadmin-input-transition);
 
 		.btn {
 			@include clay-button-size($cadmin-input-group-inset-item-btn);

--- a/packages/clay-css/src/scss/cadmin/components/_multi-step-nav.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_multi-step-nav.scss
@@ -264,7 +264,9 @@
 	padding-left: $cadmin-multi-step-icon-padding-left;
 	padding-right: $cadmin-multi-step-icon-padding-right;
 	padding-top: $cadmin-multi-step-icon-padding-top;
-	transition: $cadmin-multi-step-icon-transition;
+
+	@include transition($cadmin-multi-step-icon-transition);
+
 	width: $cadmin-multi-step-icon-size;
 
 	&:hover {

--- a/packages/clay-css/src/scss/cadmin/components/_side-navigation.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_side-navigation.scss
@@ -91,7 +91,7 @@
 	.sidenav-content,
 	.sidenav-menu,
 	.sidenav-menu-slider {
-		transition: $cadmin-sidenav-transition;
+		@include transition($cadmin-sidenav-transition);
 	}
 }
 
@@ -99,7 +99,7 @@
 
 .sidenav-transition,
 &.sidenav-transition {
-	transition: $cadmin-sidenav-transition;
+	@include transition($cadmin-sidenav-transition);
 }
 
 // Simple Sidenav

--- a/packages/clay-css/src/scss/components/_drilldown.scss
+++ b/packages/clay-css/src/scss/components/_drilldown.scss
@@ -13,7 +13,7 @@
 // Drilldown Transition Classes
 
 .drilldown-transition {
-	transition: $drilldown-transition;
+	@include transition($drilldown-transition);
 }
 
 .drilldown-item.transitioning {

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -343,7 +343,8 @@ textarea.form-control-plaintext,
 
 	&::-webkit-slider-thumb {
 		border-radius: 100px;
-		transition: $input-transition;
+
+		@include transition($input-transition);
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -226,7 +226,8 @@
 		margin-bottom: 0;
 		padding-left: $input-group-inset-item-padding-left;
 		padding-right: $input-group-inset-item-padding-right;
-		transition: $input-transition;
+
+		@include transition($input-transition);
 
 		.btn {
 			@include clay-button-size($input-group-inset-item-btn);

--- a/packages/clay-css/src/scss/components/_multi-step-nav.scss
+++ b/packages/clay-css/src/scss/components/_multi-step-nav.scss
@@ -275,7 +275,9 @@
 	padding-left: $multi-step-icon-padding-left;
 	padding-right: $multi-step-icon-padding-right;
 	padding-top: $multi-step-icon-padding-top;
-	transition: $multi-step-icon-transition;
+
+	@include transition($multi-step-icon-transition);
+
 	width: $multi-step-icon-size;
 
 	&:hover {

--- a/packages/clay-css/src/scss/components/_progress-bars.scss
+++ b/packages/clay-css/src/scss/components/_progress-bars.scss
@@ -61,6 +61,10 @@
 				animation: none;
 			}
 		}
+
+		.c-prefers-reduced-motion & {
+			animation: none;
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_side-navigation.scss
+++ b/packages/clay-css/src/scss/components/_side-navigation.scss
@@ -91,14 +91,14 @@
 	.sidenav-content,
 	.sidenav-menu,
 	.sidenav-menu-slider {
-		transition: $sidenav-transition;
+		@include transition($sidenav-transition);
 	}
 }
 
 // Simple Sidenav Transition
 
 .sidenav-transition {
-	transition: $sidenav-transition;
+	@include transition($sidenav-transition);
 }
 
 // Simple Sidenav

--- a/packages/clay-css/src/scss/components/_spinners.scss
+++ b/packages/clay-css/src/scss/components/_spinners.scss
@@ -17,6 +17,16 @@
 		height: $spinner-height;
 		vertical-align: text-bottom;
 		width: $spinner-width;
+
+		@if $enable-prefers-reduced-motion-media-query {
+			@media (prefers-reduced-motion: reduce) {
+				animation: none;
+			}
+		}
+
+		.c-prefers-reduced-motion & {
+			animation: none;
+		}
 	}
 
 	.spinner-border-sm {
@@ -45,6 +55,16 @@
 		opacity: 0;
 		vertical-align: text-bottom;
 		width: $spinner-width;
+
+		@if $enable-prefers-reduced-motion-media-query {
+			@media (prefers-reduced-motion: reduce) {
+				animation: none;
+			}
+		}
+
+		.c-prefers-reduced-motion & {
+			animation: none;
+		}
 	}
 
 	.spinner-grow-sm {

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -140,7 +140,20 @@
 	@return nth($selector-list, length($selector-list));
 }
 
-/// A function that inserts a CSS selector at a specific place (e.g., clay-insert-at('.container', '#content ', '#wrapper .container .row')) will return `#wrapper #content .container .row`.
+/// A function that appends to a specific place in a CSS selector (e.g., clay-insert-after('.container ', '.myselector ', '.container .row .col-md-12')) will return `.container .myselector .row .col-md-12`.
+/// @param {String} $location - The string to target
+/// @param {String} $insert - The string to insert after the location
+/// @param {String} $selector - The full selector
+
+@function clay-insert-after($location, $insert, $selector: &) {
+	@return clay-str-replace(
+		'#{$selector}',
+		'#{$location}',
+		'#{$location}#{$insert}'
+	);
+}
+
+/// A function that prepends to a specific place in a CSS selector (e.g., clay-insert-before('.container ', '.myselector ', '.container .row .col-md-12')) will return `.myselector .container .row .col-md-12`.
 /// @param {String} $location - The string to target
 /// @param {String} $insert - The string to insert before the location
 /// @param {String} $selector - The full selector

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -260,6 +260,25 @@
 					}
 
 					appearance: $value;
+				} @else if ($key == 'animation') {
+					animation: $value;
+
+					@if ($value != 'none' and $value != null) {
+						@at-root {
+							$selector: if(
+								variable-exists(cadmin-selector),
+								clay-insert-after(
+									'.cadmin ',
+									'.c-prefers-reduced-motion '
+								),
+								'.c-prefers-reduced-motion &'
+							);
+
+							#{$selector} {
+								animation: none;
+							}
+						}
+					}
 				} @else if ($key == 'content') {
 					content: $value;
 				} @else if ($key == 'word-wrap') {
@@ -277,7 +296,16 @@
 						}
 
 						@at-root {
-							.c-prefers-reduced-motion & {
+							$selector: if(
+								variable-exists(cadmin-selector),
+								clay-insert-after(
+									'.cadmin ',
+									'.c-prefers-reduced-motion '
+								),
+								'.c-prefers-reduced-motion &'
+							);
+
+							#{$selector} {
 								transition: none;
 							}
 						}

--- a/packages/clay-css/src/scss/mixins/_transition.scss
+++ b/packages/clay-css/src/scss/mixins/_transition.scss
@@ -34,7 +34,13 @@
 		}
 
 		@at-root {
-			.c-prefers-reduced-motion & {
+			$selector: if(
+				variable-exists(cadmin-selector),
+				clay-insert-after('.cadmin ', '.c-prefers-reduced-motion '),
+				'.c-prefers-reduced-motion &'
+			);
+
+			#{$selector} {
 				transition: none;
 			}
 		}


### PR DESCRIPTION
fixes #5476

This should remove all the transitions and animations I missed from the last update when using `c-prefers-reduced-motion`.  I also had to update the selectors for Cadmin, it was outputting something inconsistent.