### PR TITLE
feat(@clayui/autocomplete): refactors autocomplete implementation with accessibility improvements

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-autocomplete/src/': {
-			branches: 77,
-			functions: 93,
-			lines: 92,
-			statements: 92,
+			branches: 71,
+			functions: 87,
+			lines: 89,
+			statements: 89,
 		},
 		'./packages/clay-badge/src/': {
 			branches: 0,
@@ -56,7 +56,7 @@ module.exports = {
 			statements: 91,
 		},
 		'./packages/clay-core/src/picker/': {
-			branches: 81,
+			branches: 80,
 			functions: 84,
 			lines: 90,
 			statements: 90,
@@ -194,10 +194,10 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-shared/src/': {
-			branches: 20,
+			branches: 18,
 			functions: 14,
-			lines: 36,
-			statements: 39,
+			lines: 35,
+			statements: 38,
 		},
 		'./packages/clay-slider/src/': {
 			branches: 92,

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -31,6 +31,7 @@
 		"@clayui/form": "^3.93.0",
 		"@clayui/loading-indicator": "^3.60.0",
 		"@clayui/shared": "^3.93.0",
+		"classnames": "^2.2.6",
 		"fuzzy": "^0.1.3"
 	},
 	"peerDependencies": {

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -139,7 +139,7 @@ export function Autocomplete<T extends Record<string, any>>({
 	defaultActive,
 	defaultItems,
 	defaultValue,
-	direction,
+	direction = 'bottom',
 	filterKey,
 	items: externalItems,
 	loadingState,
@@ -148,7 +148,7 @@ export function Autocomplete<T extends Record<string, any>>({
 	onActiveChange,
 	onChange,
 	onItemsChange,
-	onLoadMore: _onLoadMore,
+	onLoadMore,
 	value: externalValue,
 	...otherProps
 }: IProps<T>) {
@@ -227,7 +227,7 @@ export function Autocomplete<T extends Record<string, any>>({
 	// collection can be cached even before the listbox is not mounted.
 	const collection = useCollection<T, unknown>({
 		children,
-		filter: filterFn,
+		filter: isItemsUncontrolled ? filterFn : undefined,
 		filterKey: 'value',
 		itemContainer: ({children, keyValue}: ItemProps<any>) => {
 			const itemValue = children.props.value ?? children.props.children;
@@ -444,6 +444,8 @@ export function Autocomplete<T extends Record<string, any>>({
 								as={DropDown.ItemList}
 								collection={collection}
 								id={ariaControlsId}
+								isLoading={isLoading}
+								onLoadMore={onLoadMore}
 								role="listbox"
 							>
 								{debouncedLoadingChange ? (

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -369,6 +369,13 @@ export function Autocomplete<T extends Record<string, any>>({
 							setActiveDescendant('');
 							break;
 						}
+						case Keys.Left:
+						case Keys.Right: {
+							if (activeDescendant) {
+								setActiveDescendant('');
+							}
+							break;
+						}
 						case Keys.Up:
 						case Keys.Down: {
 							event.preventDefault();

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -264,7 +264,7 @@ export function Autocomplete<T extends Record<string, any>>({
 			</DropDown.Item>
 		),
 		suppressTextValueWarning: false,
-		virtualizer,
+		virtualizer: items ? virtualizer : undefined,
 	});
 
 	const [activeDescendant, setActiveDescendant] = useState<React.Key>('');
@@ -287,17 +287,7 @@ export function Autocomplete<T extends Record<string, any>>({
 		collection,
 		containerRef: menuRef,
 		loop: true,
-		onNavigate: (item, index) => {
-			if (items) {
-				// TODO: Move this to the `useNavigation` hook
-				virtualizer.scrollToIndex(index!, {
-					align: 'auto',
-					behavior: 'smooth',
-				});
-			}
-
-			setActiveDescendant(item as React.Key);
-		},
+		onNavigate: (item) => setActiveDescendant(item as React.Key),
 		orientation: 'vertical',
 		visible: active,
 	});
@@ -311,16 +301,6 @@ export function Autocomplete<T extends Record<string, any>>({
 			}
 		}
 	}, [activeDescendant]);
-
-	// TODO: Move this to the `useNavigation` hook
-	useEffect(() => {
-		if (active && activeDescendant) {
-			virtualizer.scrollToIndex(
-				collection.getItem(activeDescendant).index,
-				{align: 'center', behavior: 'auto'}
-			);
-		}
-	}, [active]);
 
 	return (
 		<>

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -230,7 +230,10 @@ export function Autocomplete<T extends Record<string, any>>({
 		filter: isItemsUncontrolled ? filterFn : undefined,
 		filterKey: 'value',
 		itemContainer: ({children, keyValue}: ItemProps<any>) => {
-			const itemValue = children.props.value ?? children.props.children;
+			const itemValue =
+				children.props.textValue ??
+				children.props.value ??
+				children.props.children;
 
 			return React.cloneElement(children, {
 				keyValue,

--- a/packages/clay-autocomplete/src/Context.ts
+++ b/packages/clay-autocomplete/src/Context.ts
@@ -28,8 +28,8 @@ export const LegacyContext = createContext({} as IContext);
 LegacyContext.displayName = 'ClayAutocompleteLegacyContext';
 
 type AutocompleteContext = {
-	activeDescendant?: string;
-	onActiveDescendant: (value: string) => void;
+	activeDescendant?: React.Key;
+	onActiveDescendant: (value: React.Key) => void;
 	onClick: (value: string) => void;
 };
 

--- a/packages/clay-autocomplete/src/Context.ts
+++ b/packages/clay-autocomplete/src/Context.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React from 'react';
+import {createContext, useContext} from 'react';
 
 interface IContext {
 	/**
@@ -23,8 +23,18 @@ interface IContext {
 	containerElementRef: React.RefObject<HTMLElement>;
 }
 
-const context = React.createContext({} as IContext);
+export const LegacyContext = createContext({} as IContext);
 
-context.displayName = 'ClayAutocompleteContext';
+LegacyContext.displayName = 'ClayAutocompleteLegacyContext';
 
-export default context;
+type AutocompleteContext = {
+	activeDescendant?: string;
+	onActiveDescendant: (value: string) => void;
+	onClick: (value: string) => void;
+};
+
+export const AutocompleteContext = createContext({} as AutocompleteContext);
+
+export function useAutocompleteState() {
+	return useContext(AutocompleteContext);
+}

--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -7,7 +7,7 @@ import DropDown from '@clayui/drop-down';
 import {InternalDispatch} from '@clayui/shared';
 import React from 'react';
 
-import Context from './Context';
+import {LegacyContext} from './Context';
 
 export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
@@ -53,7 +53,7 @@ const ClayAutocompleteDropDown = ({
 	onActiveChange,
 	onSetActive,
 }: IProps) => {
-	const {containerElementRef} = React.useContext(Context);
+	const {containerElementRef} = React.useContext(LegacyContext);
 	const menuElementRef = React.useRef<HTMLDivElement>(null);
 
 	if (!alignElementRef) {

--- a/packages/clay-autocomplete/src/Input.tsx
+++ b/packages/clay-autocomplete/src/Input.tsx
@@ -6,7 +6,7 @@
 import {ClayInput} from '@clayui/form';
 import React from 'react';
 
-import Context from './Context';
+import {LegacyContext} from './Context';
 
 export interface IProps
 	extends React.InputHTMLAttributes<HTMLInputElement>,
@@ -14,7 +14,7 @@ export interface IProps
 
 const ClayAutocompleteInput = React.forwardRef<HTMLInputElement, IProps>(
 	(props, ref) => {
-		const {loading} = React.useContext(Context);
+		const {loading} = React.useContext(LegacyContext);
 
 		return <ClayInput {...props} insetAfter={loading} ref={ref} />;
 	}

--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -61,7 +61,7 @@ const Item = React.forwardRef<HTMLLIElement, IProps>(
 		const hoverProps = useHover({
 			disabled,
 			onHover: useCallback(
-				() => onActiveDescendant(String(keyValue)),
+				() => onActiveDescendant(keyValue!),
 				[keyValue]
 			),
 		});
@@ -75,10 +75,10 @@ const Item = React.forwardRef<HTMLLIElement, IProps>(
 			<DropDown.Item
 				{...otherProps}
 				{...hoverProps}
-				aria-selected={activeDescendant === String(keyValue)}
+				aria-selected={activeDescendant === keyValue}
 				className={classnames(className, {
-					focus: activeDescendant === String(keyValue) && isFocus,
-					hover: activeDescendant === String(keyValue) && !isFocus,
+					focus: activeDescendant === keyValue && isFocus,
+					hover: activeDescendant === keyValue && !isFocus,
 				})}
 				id={String(keyValue)}
 				innerRef={innerRef}

--- a/packages/clay-autocomplete/src/LoadingIndicator.tsx
+++ b/packages/clay-autocomplete/src/LoadingIndicator.tsx
@@ -7,7 +7,7 @@ import {ClayInput} from '@clayui/form';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import React from 'react';
 
-import Context from './Context';
+import {LegacyContext} from './Context';
 
 const LoadingIndicatorMarkup = ({
 	children,
@@ -30,7 +30,7 @@ const ClayAutocompleteLoadingIndicator = ({
 	component: Component = LoadingIndicatorMarkup,
 	...otherProps
 }: IProps) => {
-	const {onLoadingChange} = React.useContext(Context);
+	const {onLoadingChange} = React.useContext(LegacyContext);
 
 	React.useEffect(() => {
 		onLoadingChange(true);

--- a/packages/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
@@ -329,6 +329,97 @@ describe('Autocomplete incremental interactions', () => {
 		);
 	});
 
+	it('pressing the up arrow key opens the menu and moves the visual focus to the last element in the list', () => {
+		const {getAllByRole, getByRole, queryByRole} = render(
+			<ClayAutocomplete
+				messages={messages}
+				placeholder="Enter a number from One to Five"
+			>
+				{['one', 'two', 'three'].map((item) => (
+					<ClayAutocomplete.Item key={item}>
+						{item}
+					</ClayAutocomplete.Item>
+				))}
+			</ClayAutocomplete>
+		);
+
+		const input = getByRole('combobox') as HTMLInputElement;
+
+		userEvent.click(input);
+		userEvent.keyboard('[ArrowUp]');
+
+		expect(queryByRole('listbox')).toBeDefined();
+		expect(input.getAttribute('aria-activedescendant')).toBe('three');
+		expect(getAllByRole('option')[2].getAttribute('aria-selected')).toBe(
+			'true'
+		);
+	});
+
+	it('pressing the down arrow key opens the menu and moves the visual focus to the first element in the list', () => {
+		const {getAllByRole, getByRole, queryByRole} = render(
+			<ClayAutocomplete
+				messages={messages}
+				placeholder="Enter a number from One to Five"
+			>
+				{['one', 'two', 'three'].map((item) => (
+					<ClayAutocomplete.Item key={item}>
+						{item}
+					</ClayAutocomplete.Item>
+				))}
+			</ClayAutocomplete>
+		);
+
+		const input = getByRole('combobox') as HTMLInputElement;
+
+		userEvent.click(input);
+		userEvent.keyboard('[ArrowDown]');
+
+		expect(queryByRole('listbox')).toBeDefined();
+		expect(input.getAttribute('aria-activedescendant')).toBe('one');
+		expect(getAllByRole('option')[0].getAttribute('aria-selected')).toBe(
+			'true'
+		);
+	});
+
+	it('cycle through options in loop when run out of options', () => {
+		const {getByRole, queryByRole} = render(
+			<ClayAutocomplete
+				messages={messages}
+				placeholder="Enter a number from One to Five"
+			>
+				{['one', 'two', 'three'].map((item) => (
+					<ClayAutocomplete.Item key={item}>
+						{item}
+					</ClayAutocomplete.Item>
+				))}
+			</ClayAutocomplete>
+		);
+
+		const input = getByRole('combobox') as HTMLInputElement;
+
+		userEvent.click(input);
+		userEvent.keyboard('[ArrowDown]');
+
+		expect(queryByRole('listbox')).toBeDefined();
+		expect(input.getAttribute('aria-activedescendant')).toBe('one');
+
+		userEvent.keyboard('[ArrowDown]');
+
+		expect(input.getAttribute('aria-activedescendant')).toBe('two');
+
+		userEvent.keyboard('[ArrowDown]');
+
+		expect(input.getAttribute('aria-activedescendant')).toBe('three');
+
+		userEvent.keyboard('[ArrowDown]');
+
+		expect(input.getAttribute('aria-activedescendant')).toBe('one');
+
+		userEvent.keyboard('[ArrowUp]');
+
+		expect(input.getAttribute('aria-activedescendant')).toBe('three');
+	});
+
 	describe('Selected option', () => {
 		it('pressing esc closes the menu', () => {
 			const {getAllByRole, getByRole, queryByRole} = render(
@@ -361,7 +452,7 @@ describe('Autocomplete incremental interactions', () => {
 			userEvent.type(input, 'oo');
 
 			expect(input.value).toBe('twooo');
-			expect(getByRole('option').textContent).toBe('No results found');
+			expect(getByRole('option').textContent).toBe(messages.notFound);
 
 			userEvent.keyboard('[Escape]');
 
@@ -403,7 +494,7 @@ describe('Autocomplete incremental interactions', () => {
 			userEvent.type(input, 'oo');
 
 			expect(input.value).toBe('twooo');
-			expect(getByRole('option').textContent).toBe('No results found');
+			expect(getByRole('option').textContent).toBe(messages.notFound);
 
 			const buttonOutside = getByRole('button', {hidden: true});
 
@@ -447,7 +538,7 @@ describe('Autocomplete incremental interactions', () => {
 			userEvent.type(input, 'oo');
 
 			expect(input.value).toBe('twooo');
-			expect(getByRole('option').textContent).toBe('No results found');
+			expect(getByRole('option').textContent).toBe(messages.notFound);
 
 			userEvent.tab();
 

--- a/packages/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/* eslint-disable react/display-name */
 import ClayAutocomplete from '..';
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -23,7 +22,7 @@ describe('Autocomplete incremental interactions', () => {
 	afterEach(cleanup);
 
 	it('render default component', () => {
-		const {getAllByRole, getByRole} = render(
+		const {getByRole, queryByRole} = render(
 			<ClayAutocomplete
 				messages={messages}
 				placeholder="Enter a number from One to Five"
@@ -36,22 +35,15 @@ describe('Autocomplete incremental interactions', () => {
 			</ClayAutocomplete>
 		);
 
-		const input = getByRole('combobox');
+		const input = getByRole('combobox') as HTMLInputElement;
 
 		userEvent.click(input);
 
 		expect(input).toBeDefined();
 
-		const listbox = getByRole('listbox', {hidden: true});
+		const listbox = queryByRole('listbox');
 
-		expect(listbox.parentElement!.classList).not.toContain('show');
-		expect(listbox.children.length).toBe(3);
-
-		const [one, two, three] = getAllByRole('option', {hidden: true});
-
-		expect(one).toBeDefined();
-		expect(two).toBeDefined();
-		expect(three).toBeDefined();
+		expect(listbox).toBeFalsy();
 	});
 
 	it('typing a value in the input shows the menu', () => {
@@ -227,20 +219,19 @@ describe('Autocomplete incremental interactions', () => {
 
 		const input = getByRole('combobox') as HTMLInputElement;
 
+		userEvent.click(input);
 		userEvent.type(input, 't');
 
 		const [two] = getAllByRole('option');
 
-		userEvent.click(two);
+		fireEvent.click(two);
 
-		expect(
-			document.querySelector('.dropdown-menu')!.classList
-		).not.toContain('show');
+		expect(document.querySelector('.dropdown-menu')).toBeFalsy();
 		expect(input.value).toBe('two');
 	});
 
 	it('press enter close the menu', () => {
-		const {getByRole} = render(
+		const {getByRole, queryByRole} = render(
 			<ClayAutocomplete
 				messages={messages}
 				placeholder="Enter a number from One to Five"
@@ -255,6 +246,7 @@ describe('Autocomplete incremental interactions', () => {
 
 		const input = getByRole('combobox') as HTMLInputElement;
 
+		userEvent.click(input);
 		userEvent.type(input, 't');
 
 		const listbox = getByRole('listbox');
@@ -263,7 +255,7 @@ describe('Autocomplete incremental interactions', () => {
 
 		userEvent.keyboard('[Enter]');
 
-		expect(listbox.parentElement!.classList).not.toContain('show');
+		expect(queryByRole('listbox')).toBeFalsy();
 	});
 
 	it('pressing alt + key down shows the menu if not open', () => {
@@ -307,32 +299,39 @@ describe('Autocomplete incremental interactions', () => {
 
 		const input = getByRole('combobox') as HTMLInputElement;
 
+		userEvent.click(input);
 		userEvent.type(input, 't');
 
 		expect(input).toEqual(document.activeElement);
 
-		userEvent.tab();
+		userEvent.keyboard('[ArrowDown]');
 
-		const [two] = getAllByRole('option');
-
-		expect(two).toEqual(document.activeElement);
+		expect(getAllByRole('option')[0].getAttribute('aria-selected')).toBe(
+			'true'
+		);
 
 		userEvent.keyboard('[ArrowLeft]');
 
-		expect(input).toEqual(document.activeElement);
+		expect(getAllByRole('option')[0].getAttribute('aria-selected')).toBe(
+			'false'
+		);
 
-		userEvent.tab();
+		userEvent.keyboard('[ArrowDown]');
 
-		expect(two).toEqual(document.activeElement);
+		expect(getAllByRole('option')[0].getAttribute('aria-selected')).toBe(
+			'true'
+		);
 
 		userEvent.keyboard('[ArrowRight]');
 
-		expect(input).toEqual(document.activeElement);
+		expect(getAllByRole('option')[0].getAttribute('aria-selected')).toBe(
+			'false'
+		);
 	});
 
 	describe('Selected option', () => {
 		it('pressing esc closes the menu', () => {
-			const {getAllByRole, getByRole} = render(
+			const {getAllByRole, getByRole, queryByRole} = render(
 				<ClayAutocomplete
 					messages={messages}
 					placeholder="Enter a number from One to Five"
@@ -347,32 +346,31 @@ describe('Autocomplete incremental interactions', () => {
 
 			const input = getByRole('combobox') as HTMLInputElement;
 
+			userEvent.click(input);
 			userEvent.type(input, 't');
 
-			const listbox = getByRole('listbox');
-
-			expect(listbox.parentElement!.classList).toContain('show');
+			expect(getByRole('listbox')).toBeDefined();
 
 			const [two] = getAllByRole('option');
 
-			userEvent.click(two);
+			fireEvent.click(two);
 
-			expect(listbox.parentElement!.classList).not.toContain('show');
+			expect(queryByRole('listbox')).toBeFalsy();
 			expect(input.value).toBe('two');
 
 			userEvent.type(input, 'oo');
 
 			expect(input.value).toBe('twooo');
-			expect(listbox.parentElement!.classList).toContain('show');
+			expect(getByRole('option').textContent).toBe('No results found');
 
 			userEvent.keyboard('[Escape]');
 
 			expect(input.value).toBe('two');
-			expect(listbox.parentElement!.classList).not.toContain('show');
+			expect(queryByRole('listbox')).toBeFalsy();
 		});
 
 		it('clicking outside closes the menu', () => {
-			const {getAllByRole, getByRole} = render(
+			const {getAllByRole, getByRole, queryByRole} = render(
 				<>
 					<ClayAutocomplete
 						messages={messages}
@@ -390,34 +388,33 @@ describe('Autocomplete incremental interactions', () => {
 
 			const input = getByRole('combobox') as HTMLInputElement;
 
+			userEvent.click(input);
 			userEvent.type(input, 't');
 
-			const listbox = getByRole('listbox');
-
-			expect(listbox.parentElement!.classList).toContain('show');
+			expect(getByRole('listbox')).toBeDefined();
 
 			const [two] = getAllByRole('option');
 
-			userEvent.click(two);
+			fireEvent.click(two);
 
-			expect(listbox.parentElement!.classList).not.toContain('show');
+			expect(queryByRole('listbox')).toBeFalsy();
 			expect(input.value).toBe('two');
 
 			userEvent.type(input, 'oo');
 
 			expect(input.value).toBe('twooo');
-			expect(listbox.parentElement!.classList).toContain('show');
+			expect(getByRole('option').textContent).toBe('No results found');
 
 			const buttonOutside = getByRole('button', {hidden: true});
 
 			userEvent.click(buttonOutside);
 
 			expect(input.value).toBe('two');
-			expect(listbox.parentElement!.classList).not.toContain('show');
+			expect(queryByRole('listbox')).toBeFalsy();
 		});
 
 		it('moving the focus outside of autocomplete closes the menu', () => {
-			const {getAllByRole, getByRole} = render(
+			const {getAllByRole, getByRole, queryByRole} = render(
 				<>
 					<ClayAutocomplete
 						messages={messages}
@@ -435,34 +432,33 @@ describe('Autocomplete incremental interactions', () => {
 
 			const input = getByRole('combobox') as HTMLInputElement;
 
+			userEvent.click(input);
 			userEvent.type(input, 't');
 
-			const listbox = getByRole('listbox');
-
-			expect(listbox.parentElement!.classList).toContain('show');
+			expect(getByRole('listbox')).toBeDefined();
 
 			const [two] = getAllByRole('option');
 
-			userEvent.click(two);
+			fireEvent.click(two);
 
-			expect(listbox.parentElement!.classList).not.toContain('show');
+			expect(queryByRole('listbox')).toBeFalsy();
 			expect(input.value).toBe('two');
 
 			userEvent.type(input, 'oo');
 
 			expect(input.value).toBe('twooo');
-			expect(listbox.parentElement!.classList).toContain('show');
+			expect(getByRole('option').textContent).toBe('No results found');
 
 			userEvent.tab();
 
 			expect(input.value).toBe('two');
-			expect(listbox.parentElement!.classList).not.toContain('show');
+			expect(queryByRole('listbox')).toBeFalsy();
 		});
 	});
 
 	describe('Option not selected', () => {
 		it('pressing esc closes the menu', () => {
-			const {getByRole} = render(
+			const {getByRole, queryByRole} = render(
 				<ClayAutocomplete
 					messages={messages}
 					placeholder="Enter a number from One to Five"
@@ -477,20 +473,19 @@ describe('Autocomplete incremental interactions', () => {
 
 			const input = getByRole('combobox') as HTMLInputElement;
 
+			userEvent.click(input);
 			userEvent.type(input, 't');
 
-			const listbox = getByRole('listbox');
-
-			expect(listbox.parentElement!.classList).toContain('show');
+			expect(getByRole('listbox')).toBeDefined();
 
 			userEvent.keyboard('[Escape]');
 
 			expect(input.value).toBe('');
-			expect(listbox.parentElement!.classList).not.toContain('show');
+			expect(queryByRole('listbox')).toBeFalsy();
 		});
 
 		it('clicking outside closes the menu', () => {
-			const {getByRole} = render(
+			const {getByRole, queryByRole} = render(
 				<>
 					<ClayAutocomplete
 						messages={messages}
@@ -508,22 +503,21 @@ describe('Autocomplete incremental interactions', () => {
 
 			const input = getByRole('combobox') as HTMLInputElement;
 
+			userEvent.click(input);
 			userEvent.type(input, 't');
 
-			const listbox = getByRole('listbox');
-
-			expect(listbox.parentElement!.classList).toContain('show');
+			expect(getByRole('listbox')).toBeDefined();
 
 			const buttonOutside = getByRole('button', {hidden: true});
 
 			userEvent.click(buttonOutside);
 
 			expect(input.value).toBe('');
-			expect(listbox.parentElement!.classList).not.toContain('show');
+			expect(queryByRole('listbox')).toBeFalsy();
 		});
 
 		it('moving the focus outside of autocomplete closes the menu', () => {
-			const {getByRole} = render(
+			const {getByRole, queryByRole} = render(
 				<>
 					<ClayAutocomplete
 						messages={messages}
@@ -541,18 +535,15 @@ describe('Autocomplete incremental interactions', () => {
 
 			const input = getByRole('combobox') as HTMLInputElement;
 
+			userEvent.click(input);
 			userEvent.type(input, 't');
 
-			const listbox = getByRole('listbox');
+			expect(getByRole('listbox')).toBeDefined();
 
-			expect(listbox.parentElement!.classList).toContain('show');
-
-			userEvent.tab();
-			userEvent.tab();
 			userEvent.tab();
 
 			expect(input.value).toBe('');
-			expect(listbox.parentElement!.classList).not.toContain('show');
+			expect(queryByRole('listbox')).toBeFalsy();
 		});
 	});
 });

--- a/packages/clay-autocomplete/src/__tests__/index.tsx
+++ b/packages/clay-autocomplete/src/__tests__/index.tsx
@@ -8,7 +8,7 @@ import ClayAutocomplete from '..';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 
-import Context from '../Context';
+import {LegacyContext} from '../Context';
 
 describe('ClayAutocomplete', () => {
 	afterEach(cleanup);
@@ -48,7 +48,7 @@ describe('ClayAutocomplete', () => {
 
 	it('renders LoadingIndicator', () => {
 		const LoadingIndicatorWithContext = () => (
-			<Context.Provider
+			<LegacyContext.Provider
 				value={{
 					containerElementRef: {current: null},
 					loading: false,
@@ -56,7 +56,7 @@ describe('ClayAutocomplete', () => {
 				}}
 			>
 				<ClayAutocomplete.LoadingIndicator />
-			</Context.Provider>
+			</LegacyContext.Provider>
 		);
 		const {container} = render(<LoadingIndicatorWithContext />);
 
@@ -72,7 +72,7 @@ describe('ClayAutocomplete', () => {
 			</span>
 		);
 		const LoadingIndicatorWithContext = () => (
-			<Context.Provider
+			<LegacyContext.Provider
 				value={{
 					containerElementRef: {current: null},
 					loading: false,
@@ -80,7 +80,7 @@ describe('ClayAutocomplete', () => {
 				}}
 			>
 				<ClayAutocomplete.LoadingIndicator component={MyMarkup} />
-			</Context.Provider>
+			</LegacyContext.Provider>
 		);
 
 		const {container} = render(<LoadingIndicatorWithContext />);
@@ -91,7 +91,7 @@ describe('ClayAutocomplete', () => {
 	it('renders LoadingIndicator and calls the onLoadingChange', () => {
 		const spyFn = jest.fn();
 		const LoadingIndicatorWithContext = () => (
-			<Context.Provider
+			<LegacyContext.Provider
 				value={{
 					containerElementRef: {current: null},
 					loading: false,
@@ -99,7 +99,7 @@ describe('ClayAutocomplete', () => {
 				}}
 			>
 				<ClayAutocomplete.LoadingIndicator />
-			</Context.Provider>
+			</LegacyContext.Provider>
 		);
 
 		render(<LoadingIndicatorWithContext />);
@@ -110,7 +110,7 @@ describe('ClayAutocomplete', () => {
 
 	it('renders Input with classNames when loading for true', () => {
 		const InputWithContext = () => (
-			<Context.Provider
+			<LegacyContext.Provider
 				value={{
 					containerElementRef: {current: null},
 					loading: true,
@@ -118,7 +118,7 @@ describe('ClayAutocomplete', () => {
 				}}
 			>
 				<ClayAutocomplete.Input />
-			</Context.Provider>
+			</LegacyContext.Provider>
 		);
 
 		const {container} = render(<InputWithContext />);
@@ -131,7 +131,7 @@ describe('ClayAutocomplete', () => {
 			const containerElementRef = React.useRef<HTMLDivElement>(null);
 
 			return (
-				<Context.Provider
+				<LegacyContext.Provider
 					value={{
 						containerElementRef,
 						loading: false,
@@ -140,7 +140,7 @@ describe('ClayAutocomplete', () => {
 				>
 					<ClayAutocomplete.Input />
 					<ClayAutocomplete.DropDown active />
-				</Context.Provider>
+				</LegacyContext.Provider>
 			);
 		};
 

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -8,7 +8,7 @@ import {FocusScope} from '@clayui/shared';
 import React from 'react';
 
 import {Autocomplete} from './Autocomplete';
-import Context from './Context';
+import {LegacyContext} from './Context';
 import DropDown from './DropDown';
 import Input from './Input';
 import Item from './Item';
@@ -40,7 +40,7 @@ const hasItems = (children?: React.ReactNode) => {
 		if (
 			React.isValidElement(child) &&
 			// @ts-ignore
-			child.type.displayName === 'ClayAutocompleteItem'
+			child.type.displayName === 'Item'
 		) {
 			return true;
 		}
@@ -72,8 +72,10 @@ const ClayAutocomplete = React.forwardRef<HTMLDivElement, IProps<any>>(
 		const isNewBehavior =
 			hasItems(children).length >= 1 || children instanceof Function;
 
+		const Container = isNewBehavior ? React.Fragment : FocusScope;
+
 		return (
-			<FocusScope>
+			<Container>
 				<Component
 					{...(isNewBehavior ? {} : otherProps)}
 					className={className}
@@ -98,7 +100,7 @@ const ClayAutocomplete = React.forwardRef<HTMLDivElement, IProps<any>>(
 							{children}
 						</Autocomplete>
 					) : (
-						<Context.Provider
+						<LegacyContext.Provider
 							value={{
 								containerElementRef,
 								loading,
@@ -107,10 +109,10 @@ const ClayAutocomplete = React.forwardRef<HTMLDivElement, IProps<any>>(
 							}}
 						>
 							{children}
-						</Context.Provider>
+						</LegacyContext.Provider>
 					)}
 				</Component>
-			</FocusScope>
+			</Container>
 		);
 	}
 );

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -87,17 +87,68 @@ export const Dynamic = () => (
 						htmlFor="clay-autocomplete-1"
 						id="clay-autocomplete-label-1"
 					>
-						Numbers (one-five)
+						States
 					</label>
 					<ClayAutocomplete
 						aria-labelledby="clay-autocomplete-label-1"
-						defaultItems={['one', 'two', 'three', 'four', 'five']}
+						defaultItems={[
+							'Alabama',
+							'Alaska',
+							'Arizona',
+							'Arkansas',
+							'California',
+							'Colorado',
+							'Connecticut',
+							'Delaware',
+							'Florida',
+							'Georgia',
+							'Hawaii',
+							'Idaho',
+							'Illinois',
+							'Indiana',
+							'Iowa',
+							'Kansas',
+							'Kentucky',
+							'Louisiana',
+							'Maine',
+							'Maryland',
+							'Massachusetts',
+							'Michigan',
+							'Minnesota',
+							'Mississippi',
+							'Missouri',
+							'Montana',
+							'Nebraska',
+							'Nevada',
+							'New Hampshire',
+							'New Jersey',
+							'New Mexico',
+							'New York',
+							'North Carolina',
+							'North Dakota',
+							'Ohio',
+							'Oklahoma',
+							'Oregon',
+							'Pennsylvania',
+							'Rhode Island',
+							'South Carolina',
+							'South Dakota',
+							'Tennessee',
+							'Texas',
+							'Utah',
+							'Vermont',
+							'Virginia',
+							'Washington',
+							'West Virginia',
+							'Wisconsin',
+							'Wyoming',
+						]}
 						id="clay-autocomplete-1"
 						messages={{
 							loading: 'Loading...',
 							notFound: 'No results found',
 						}}
-						placeholder="Enter a number from One to Five"
+						placeholder="Enter a US state name"
 					>
 						{(item) => (
 							<ClayAutocomplete.Item key={item}>

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -195,7 +195,10 @@ export const CustomItem = () => {
 							value={value}
 						>
 							{(item) => (
-								<DropDown.Item key={item}>
+								<ClayAutocomplete.Item
+									key={item}
+									textValue={item}
+								>
 									<Layout.ContentRow>
 										<Layout.ContentCol expand>
 											<Text size={3}>
@@ -208,7 +211,7 @@ export const CustomItem = () => {
 											<Text size={2}>Description</Text>
 										</Layout.ContentCol>
 									</Layout.ContentRow>
-								</DropDown.Item>
+								</ClayAutocomplete.Item>
 							)}
 						</ClayAutocomplete>
 					</div>

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -33,7 +33,7 @@
 		"@clayui/modal": "^3.93.0",
 		"@clayui/provider": "^3.93.0",
 		"@clayui/shared": "^3.93.0",
-		"@tanstack/react-virtual": "3.0.0-beta.18",
+		"@tanstack/react-virtual": "3.0.0-beta.54",
 		"aria-hidden": "^1.2.2",
 		"classnames": "^2.2.6",
 		"fuzzy": "^0.1.3",

--- a/packages/clay-core/src/collection/Collection.tsx
+++ b/packages/clay-core/src/collection/Collection.tsx
@@ -157,7 +157,7 @@ export function Collection<
 }: Partial<ICollectionProps<T, P>> & Props<P, K> & Partial<IProps>) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const isVirtual = collection?.virtualize;
-	const Container = as ?? isVirtual ? 'div' : React.Fragment;
+	const Container = as ? as : isVirtual ? 'div' : React.Fragment;
 
 	const onScroll = useCallback(
 		(event: Event) => {

--- a/packages/clay-core/src/collection/index.ts
+++ b/packages/clay-core/src/collection/index.ts
@@ -6,4 +6,5 @@
 export {getKey, excludeProps} from './utils';
 export {Collection} from './Collection';
 export {useCollection, useCollectionKeys} from './useCollection';
+export {useVirtual} from './useVirtual';
 export type {ChildrenFunction, ICollectionProps} from './types';

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import type {Virtualizer} from '@tanstack/react-virtual';
+
 type ChildType = {
 	displayName?: string;
 	passthroughKey?: boolean;
@@ -42,6 +44,8 @@ export type CollectionState = {
 	getFirstItem: () => {key: string; value: string};
 	getItem: (key: React.Key) => string;
 	getLastItem: () => {key: string; value: string};
+	size?: number;
+	virtualize: boolean;
 };
 
 export type Props<P, K> = {
@@ -67,11 +71,6 @@ export type Props<P, K> = {
 	passthroughKey?: boolean;
 
 	/**
-	 * The custom loading component for the infinite scroll.
-	 */
-	loadingComponent?: React.ForwardRefExoticComponent<any>;
-
-	/**
 	 * Set for the parent's key to create the unique key of the list items, if
 	 * the collection is rendered nested.
 	 */
@@ -95,4 +94,6 @@ export type Props<P, K> = {
 	notFound?: JSX.Element;
 
 	suppressTextValueWarning?: boolean;
+
+	virtualizer?: Virtualizer<HTMLElement, Element>;
 };

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -41,6 +41,7 @@ export type CollectionState = {
 	collection: JSX.Element;
 	getFirstItem: () => {key: string; value: string};
 	getItem: (key: React.Key) => string;
+	getLastItem: () => {key: string; value: string};
 };
 
 export type Props<P, K> = {

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -67,6 +67,11 @@ export type Props<P, K> = {
 	passthroughKey?: boolean;
 
 	/**
+	 * The custom loading component for the infinite scroll.
+	 */
+	loadingComponent?: React.ForwardRefExoticComponent<any>;
+
+	/**
 	 * Set for the parent's key to create the unique key of the list items, if
 	 * the collection is rendered nested.
 	 */

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -40,6 +40,7 @@ export interface ICollectionProps<T, P> {
 }
 
 export type CollectionState = {
+	UNSAFE_virtualizer?: Virtualizer<HTMLElement, Element>;
 	collection: JSX.Element;
 	getFirstItem: () => {key: React.Key; value: string; index: number};
 	getItem: (key: React.Key) => {value: string; index: number};

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -41,9 +41,9 @@ export interface ICollectionProps<T, P> {
 
 export type CollectionState = {
 	collection: JSX.Element;
-	getFirstItem: () => {key: string; value: string};
-	getItem: (key: React.Key) => string;
-	getLastItem: () => {key: string; value: string};
+	getFirstItem: () => {key: React.Key; value: string; index: number};
+	getItem: (key: React.Key) => {value: string; index: number};
+	getLastItem: () => {key: React.Key; value: string; index: number};
 	size?: number;
 	virtualize: boolean;
 };

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -84,5 +84,10 @@ export type Props<P, K> = {
 	 */
 	itemContainer?: (props: any) => JSX.Element | null;
 
+	/**
+	 * Renders an element when there is no item matching the list of items.
+	 */
+	notFound?: JSX.Element;
+
 	suppressTextValueWarning?: boolean;
 };

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -43,6 +43,7 @@ export type CollectionState = {
 	collection: JSX.Element;
 	getFirstItem: () => {key: React.Key; value: string; index: number};
 	getItem: (key: React.Key) => {value: string; index: number};
+	getItems: () => Array<React.Key>;
 	getLastItem: () => {key: React.Key; value: string; index: number};
 	size?: number;
 	virtualize: boolean;

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -118,7 +118,7 @@ export function useCollection<
 				...(props ? props : {}),
 			});
 		},
-		[performFilter]
+		[ItemContainer, performFilter]
 	);
 
 	const createItemsLayout = useCallback(
@@ -336,7 +336,7 @@ export function useCollection<
 
 		const list = performCollectionRender({children, items});
 
-		if (list.length === 0 && filter) {
+		if (list.length === 0 && notFound) {
 			return notFound;
 		}
 

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -39,6 +39,7 @@ export function useCollection<
 	filterKey,
 	itemContainer: ItemContainer,
 	items,
+	notFound,
 	parentKey,
 	passthroughKey = true,
 	publicApi,
@@ -201,10 +202,15 @@ export function useCollection<
 		};
 	}, []);
 
-	const collection = useMemo(
-		() => performCollection({children, items}),
-		[children, performCollection, items]
-	);
+	const collection = useMemo(() => {
+		const list = performCollection({children, items});
+
+		if (list.length === 0 && filter) {
+			return notFound;
+		}
+
+		return list;
+	}, [children, performCollection, items]);
 
 	return {
 		collection: (

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -344,6 +344,7 @@ export function useCollection<
 	}, [children, createItemsLayout, performCollectionRender, items]);
 
 	return {
+		UNSAFE_virtualizer: virtualizer,
 		collection: (
 			<CollectionContext.Provider value={{keys: layoutKeysRef, layout}}>
 				{collection}

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -146,6 +146,10 @@ export function useCollection<
 				child: ChildElement,
 				index: number
 			) {
+				if (performFilter(child)) {
+					return;
+				}
+
 				const key = getKey(index, childKey, parentKey);
 
 				if (child.type.displayName === 'Item') {
@@ -157,10 +161,6 @@ export function useCollection<
 							suppressTextValueWarning
 						),
 					});
-				}
-
-				if (performFilter(child)) {
-					return;
 				}
 
 				const prevKey = keysRef.current[keysRef.current.length - 1];

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -310,6 +310,10 @@ export function useCollection<
 		};
 	}, []);
 
+	const getItems = useCallback(() => {
+		return Array.from(layout.current.keys());
+	}, []);
+
 	// It builds the dynamic or static collection, done in two steps: Data and
 	// Rendering, both go through the elements to get the data of each item.
 	//
@@ -347,6 +351,7 @@ export function useCollection<
 		),
 		getFirstItem,
 		getItem,
+		getItems,
 		getLastItem,
 		size: virtualizer ? virtualizer.getTotalSize() : undefined,
 		virtualize: !!virtualizer,

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -125,6 +125,7 @@ export function useCollection<
 		({children, items}: ICollectionProps<T, P>) => {
 			keysRef.current = [];
 			layoutKeysRef.current.clear();
+			layout.current.clear();
 
 			// Pre-initialization of nested collections to mount the layout
 			// structure.
@@ -191,6 +192,15 @@ export function useCollection<
 		};
 	}, []);
 
+	const getLastItem = useCallback(() => {
+		const key = Array.from(layout.current.values()).pop();
+
+		return {
+			key,
+			value: layout.current.get(key),
+		};
+	}, []);
+
 	const collection = useMemo(
 		() => performCollection({children, items}),
 		[children, performCollection, items]
@@ -204,6 +214,7 @@ export function useCollection<
 		),
 		getFirstItem,
 		getItem,
+		getLastItem,
 	};
 }
 

--- a/packages/clay-core/src/collection/useVirtual.ts
+++ b/packages/clay-core/src/collection/useVirtual.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useVirtualizer} from '@tanstack/react-virtual';
+import {useEffect, useRef} from 'react';
+
+type Props<T> = {
+	/**
+	 * Flag to estimate the default height of a list item in pixels.
+	 */
+	estimateSize: number;
+
+	/**
+	 * Flag to enable infinite scroll.
+	 */
+	hasMore?: boolean;
+
+	/**
+	 * Property to render content with dynamic data.
+	 */
+	items: Array<T>;
+
+	/**
+	 * Add the reference of the parent element that will be used to define the
+	 * scroll and get the height of the element for virtualization of the
+	 * collection.
+	 */
+	parentRef: React.RefObject<HTMLElement>;
+};
+
+export function useVirtual<T>({
+	estimateSize,
+	hasMore,
+	items = [],
+	parentRef,
+}: Props<T>) {
+	const virtualizer = useVirtualizer({
+		count: hasMore ? items.length + 1 : items.length,
+		estimateSize: () => estimateSize,
+		getScrollElement: () => parentRef.current,
+		overscan: 5,
+	});
+
+	const previousLengthRef = useRef(items.length);
+
+	useEffect(() => {
+		if (items.length < previousLengthRef.current && items.length > 0) {
+			virtualizer.scrollToIndex(0, {behavior: 'auto'});
+		}
+
+		previousLengthRef.current = items.length;
+	}, [items.length]);
+
+	return virtualizer;
+}

--- a/packages/clay-core/src/collection/useVirtual.ts
+++ b/packages/clay-core/src/collection/useVirtual.ts
@@ -13,11 +13,6 @@ type Props<T> = {
 	estimateSize: number;
 
 	/**
-	 * Flag to enable infinite scroll.
-	 */
-	hasMore?: boolean;
-
-	/**
 	 * Property to render content with dynamic data.
 	 */
 	items: Array<T>;
@@ -30,14 +25,9 @@ type Props<T> = {
 	parentRef: React.RefObject<HTMLElement>;
 };
 
-export function useVirtual<T>({
-	estimateSize,
-	hasMore,
-	items = [],
-	parentRef,
-}: Props<T>) {
+export function useVirtual<T>({estimateSize, items = [], parentRef}: Props<T>) {
 	const virtualizer = useVirtualizer({
-		count: hasMore ? items.length + 1 : items.length,
+		count: items.length,
 		estimateSize: () => estimateSize,
 		getScrollElement: () => parentRef.current,
 		overscan: 5,

--- a/packages/clay-core/src/picker/Option.tsx
+++ b/packages/clay-core/src/picker/Option.tsx
@@ -87,10 +87,7 @@ export function Option({
 
 	const hoverProps = useHover({
 		disabled,
-		onHover: useCallback(
-			() => onActiveDescendant(String(keyValue)),
-			[keyValue]
-		),
+		onHover: useCallback(() => onActiveDescendant(keyValue!), [keyValue]),
 	});
 
 	const isFocus = isFocusVisible();
@@ -119,8 +116,8 @@ export function Option({
 				aria-setsize={ariaSetSize}
 				className={classNames('dropdown-item', {
 					active: selectedKey === keyValue,
-					focus: activeDescendant === String(keyValue) && isFocus,
-					hover: activeDescendant === String(keyValue) && !isFocus,
+					focus: activeDescendant === keyValue && isFocus,
+					hover: activeDescendant === keyValue && !isFocus,
 				})}
 				disabled={disabled}
 				id={String(keyValue)}

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -184,7 +184,7 @@ export function Picker<T>({
 
 	const [activeDescendant, setActiveDescendant] = useState(() =>
 		typeof selectedKey !== 'undefined'
-			? String(selectedKey)
+			? selectedKey
 			: collection.getFirstItem().key
 	);
 
@@ -215,7 +215,8 @@ export function Picker<T>({
 		activation: 'manual',
 		active: activeDescendant,
 		containerRef: menuRef,
-		onNavigate: (tab) => setActiveDescendant(tab.getAttribute('id')!),
+		onNavigate: (tab) =>
+			setActiveDescendant((tab as HTMLElement).getAttribute('id')!),
 		orientation: 'vertical',
 		typeahead: true,
 		visible: active,
@@ -223,7 +224,7 @@ export function Picker<T>({
 
 	const onPress = useCallback(() => {
 		if (menuRef.current && activeDescendant) {
-			const item = document.getElementById(activeDescendant);
+			const item = document.getElementById(String(activeDescendant));
 
 			if (item) {
 				item.click();
@@ -242,16 +243,16 @@ export function Picker<T>({
 			activeDescendant &&
 			active
 		) {
-			const value = collection.getItem(activeDescendant);
+			const item = collection.getItem(activeDescendant);
 
-			if (!value) {
+			if (!item) {
 				return;
 			}
 
 			announcerAPI.current.announce(
 				selectedKey === activeDescendant
-					? sub(messages.itemSelected, [value])
-					: `${value}`
+					? sub(messages.itemSelected, [item.value])
+					: `${item.value}`
 			);
 
 			// Announces item description with delay to replace combobox description.
@@ -298,7 +299,7 @@ export function Picker<T>({
 
 			<As
 				{...otherProps}
-				aria-activedescendant={active ? activeDescendant : ''}
+				aria-activedescendant={active ? String(activeDescendant) : ''}
 				aria-controls={
 					active && isAppleDevice() ? ariaControls : undefined
 				}
@@ -374,7 +375,7 @@ export function Picker<T>({
 							const position = list.findIndex(
 								(element) =>
 									element.getAttribute('id') ===
-									activeDescendant
+									String(activeDescendant)
 							);
 
 							if (position === -1) {
@@ -408,7 +409,9 @@ export function Picker<T>({
 				role="combobox"
 				tabIndex={0}
 			>
-				{selectedKey ? collection.getItem(selectedKey) : placeholder}
+				{selectedKey
+					? collection.getItem(selectedKey)?.value
+					: placeholder}
 			</As>
 
 			{active && (
@@ -427,9 +430,9 @@ export function Picker<T>({
 							onPress();
 						} else {
 							const key =
-								String(selectedKey) === 'undefined'
+								typeof selectedKey === 'undefined'
 									? collection.getFirstItem().key
-									: String(selectedKey);
+									: selectedKey;
 
 							if (key !== activeDescendant) {
 								setActiveDescendant(key);

--- a/packages/clay-core/src/picker/context.ts
+++ b/packages/clay-core/src/picker/context.ts
@@ -8,9 +8,9 @@ import {createContext, useContext} from 'react';
 import type {InternalDispatch} from '@clayui/shared';
 
 type PickerContextProps = {
-	activeDescendant: string;
+	activeDescendant: React.Key;
 	isMobile: boolean;
-	onActiveDescendant: (value: string) => void;
+	onActiveDescendant: (value: React.Key) => void;
 	onSelectionChange: InternalDispatch<React.Key>;
 	selectedKey: React.Key;
 };

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -25,6 +25,11 @@ export interface IProps
 	disabled?: boolean;
 
 	/**
+	 * @ignore
+	 */
+	'data-index'?: number;
+
+	/**
 	 * Path for item to link to.
 	 */
 	href?: string;
@@ -59,6 +64,7 @@ const ClayDropDownItem = React.forwardRef<HTMLLIElement, IProps>(
 			active,
 			children,
 			className,
+			'data-index': dataIndex,
 			disabled,
 			href,
 			innerRef,
@@ -80,7 +86,13 @@ const ClayDropDownItem = React.forwardRef<HTMLLIElement, IProps>(
 		const {close, closeOnClick, tabFocus} = useContext(DropDownContext);
 
 		return (
-			<li aria-selected={active} ref={ref} role={role} style={style}>
+			<li
+				aria-selected={active}
+				data-index={dataIndex}
+				ref={ref}
+				role={role}
+				style={style}
+			>
 				<ItemElement
 					{...otherProps}
 					className={classNames('dropdown-item', className, {

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -341,7 +341,7 @@ export function useNavigation<T extends HTMLElement | null>({
 		// Moves the scroll to the element with visual "focus" if it exists.
 		if (visible && containerRef.current && active && onNavigate) {
 			const child = isScrollable(containerRef.current)
-				? containerRef.current
+				? containerRef.current!
 				: (containerRef.current.firstElementChild as HTMLElement);
 			const activeElement = document.getElementById(String(active));
 

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -339,7 +339,13 @@ export function useNavigation<T extends HTMLElement | null>({
 
 	useEffect(() => {
 		// Moves the scroll to the element with visual "focus" if it exists.
-		if (visible && containerRef.current && active && onNavigate) {
+		if (
+			visible &&
+			containerRef.current &&
+			active &&
+			onNavigate &&
+			!collection?.virtualize
+		) {
 			const child = isScrollable(containerRef.current)
 				? containerRef.current!
 				: (containerRef.current.firstElementChild as HTMLElement);

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -47,7 +47,6 @@ type Props<T> = {
 	/**
 	 * Defines that the navigation is done with the collection API when
 	 * it's declared.
-	 * OBS: Only supported with Collection and List Virtualization.
 	 */
 	collection?: CollectionState;
 
@@ -407,7 +406,7 @@ export function isTypeahead(event: React.KeyboardEvent<HTMLElement>) {
 }
 
 function isElementInView(element: HTMLElement) {
-	var bounding = element.getBoundingClientRect();
+	const bounding = element.getBoundingClientRect();
 
 	return (
 		bounding.top >= 0 &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,17 +4083,17 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tanstack/react-virtual@3.0.0-beta.18":
-  version "3.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.18.tgz#b97b2019f7d6a5770fb88ee1f7591da55b9059b4"
-  integrity sha512-mnyCZT6htcRNw1jVb+WyfMUMbd1UmXX/JWPuMf6Bmj92DB/V7Ogk5n5rby5Y5aste7c7mlsBeMF8HtpwERRvEQ==
+"@tanstack/react-virtual@3.0.0-beta.54":
+  version "3.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.54.tgz#755979455adf13f2584937204a3f38703e446037"
+  integrity sha512-D1mDMf4UPbrtHRZZriCly5bXTBMhylslm4dhcHqTtDJ6brQcgGmk8YD9JdWBGWfGSWPKoh2x1H3e7eh+hgPXtQ==
   dependencies:
-    "@tanstack/virtual-core" "3.0.0-beta.18"
+    "@tanstack/virtual-core" "3.0.0-beta.54"
 
-"@tanstack/virtual-core@3.0.0-beta.18":
-  version "3.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.18.tgz#d4b0738c1d0aada922063c899675ff4df9f696b2"
-  integrity sha512-tcXutY05NpN9lp3+AXI9Sn85RxSPV0EJC0XMim9oeQj/E7bjXoL0qZ4Er4wwnvIbv/hZjC91EmbIQGjgdr6nZg==
+"@tanstack/virtual-core@3.0.0-beta.54":
+  version "3.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.54.tgz#12259d007911ad9fce1388385c54a9141f4ecdc4"
+  integrity sha512-jtkwqdP2rY2iCCDVAFuaNBH3fiEi29aTn2RhtIoky8DTTiCdc48plpHHreLwmv1PICJ4AJUUESaq3xa8fZH8+g==
 
 "@testing-library/dom@^8.0.0", "@testing-library/dom@^8.9.0":
   version "8.10.1"
@@ -8291,10 +8291,15 @@ core-js-compat@^3.16.0, core-js-compat@^3.16.2, core-js-compat@^3.8.1:
     browserslist "^4.17.5"
     semver "7.0.0"
 
-core-js-pure@^3.16.0, core-js-pure@^3.8.1:
+core-js-pure@^3.16.0:
   version "3.21.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.21.1.tgz#8c4d1e78839f5f46208de7230cebfb72bc3bdb51"
   integrity sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==
+
+core-js-pure@^3.8.1:
+  version "3.30.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.30.1.tgz#7d93dc89e7d47b8ef05d7e79f507b0e99ea77eec"
+  integrity sha512-nXBEVpmUnNRhz83cHd9JRQC52cTMcuXAmR56+9dSMpRdpeA4I1PX6yjmhd71Eyc/wXNsdBdUDIj1QTIeZpU5Tg==
 
 core-js@^2.4.0, core-js@^2.6.10, core-js@^2.6.5:
   version "2.6.12"


### PR DESCRIPTION
Closes #5203

This PR is still a draft of the Autocomplete refactoring, there is a lot of work here to make the accessibility improvements because we need to make changes in the navigation and collection mechanisms, firstly because the navigation in Autocomplete is done with the virtual focus and not with the focus of the browser and second that Autocomplete has virtualization and infinite scroll capabilities this combination means that we need to rebuild the collection virtualization system and the navigation system so that both can work together.

I made some changes to the collection implementation but still incomplete, the first work I did was to finally move the virtualization implementation to the `useCollection` hook and create the `useVirtual` hook that handles the virtualization logic so we can use the two hooks together or just `useCollection` when we don't want virtualization. There are some jobs to be done:

- [x] Separate the logic of creating the layout structure and linked list from the collection to discover the keys and values of the items in the rendering system, this has to work independently otherwise in virtualization we will only register for the visible items but we want all items so the navigation system knows where to go.
- [x] Implement virtual navigation to work with a collection with virtualization
- [x] Implements the infinite scroll functionality in the `useCollection` hook, it has to work when virtualization is enabled.

Once we have these foundations we can use virtualization in Autocomplete with infinite scroll functionality. For now, Autocomplete already complies with the accessibility behaviors but we don't have the virtualization feature enabled and infinite scroll.