### PR TITLE
fix(@clayui/focus-trap): Add display contents to ignore the element itself

### DIFF
--- a/packages/clay-core/docs/focus-trap.mdx
+++ b/packages/clay-core/docs/focus-trap.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Focus Trap'
-description: "Focus Trap holds the user's focus inside its children components."
+description: 'Focus Trap keeps the focus within its focusable children elements.'
 packageNpm: '@clayui/core'
 packageStatus: 'Beta'
 storybookPath: 'design-system-components-focus-trap'

--- a/packages/clay-core/src/focus-trap/FocusTrap.tsx
+++ b/packages/clay-core/src/focus-trap/FocusTrap.tsx
@@ -68,7 +68,7 @@ export function FocusTrap({active = false, children, focusElementRef}: Props) {
 
 	return (
 		<FocusScope>
-			<div ref={childrenRef}>
+			<div ref={childrenRef} style={{display: 'contents'}}>
 				{active ? (
 					<span
 						aria-hidden="true"

--- a/packages/clay-core/src/focus-trap/FocusTrap.tsx
+++ b/packages/clay-core/src/focus-trap/FocusTrap.tsx
@@ -47,7 +47,7 @@ export function FocusTrap({active = false, children, focusElementRef}: Props) {
 
 			const focusableElements = getFocusableElements(childrenRef);
 
-			if (focusableElements) {
+			if (focusableElements?.length) {
 				(focusableElements[0] as HTMLDivElement).focus();
 			}
 		}

--- a/packages/clay-core/src/focus-trap/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/focus-trap/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -3,7 +3,9 @@
 exports[`FocusTrap basic rendering render static content when focus trap is actived 1`] = `
 <body>
   <div>
-    <div>
+    <div
+      style="display: contents;"
+    >
       <span
         aria-hidden="true"
         data-focus-scope-start="true"
@@ -28,7 +30,9 @@ exports[`FocusTrap basic rendering render static content when focus trap is acti
 exports[`FocusTrap basic rendering render static content when focus trap is not actived 1`] = `
 <body>
   <div>
-    <div>
+    <div
+      style="display: contents;"
+    >
       <button
         class="btn btn-primary"
         type="button"


### PR DESCRIPTION
Fixes https://github.com/liferay/clay/issues/5480

Hi @matuzalemsteles, as we discussed yesterday, I added the `display: contents` style to the `div`, this makes the children of this element appear as if they were direct children of the element's parent, ignoring the element itself.

I have also added several changes:
- Take into account when the `focusableElements` array is empty
- A more understandable description of the component