### PR TITLE
feat(clay-card): Added card-title aria-label and sticker titles

### DIFF
--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -87,13 +87,14 @@ export const ClayCardWithHorizontal = ({
 		<ClayCard.Body>
 			<ClayCard.Row>
 				<ClayLayout.ContentCol>
-					<ClaySticker inline>
+					<ClaySticker inline title={symbol}>
 						<ClayIcon spritemap={spritemap} symbol={symbol} />
 					</ClaySticker>
 				</ClayLayout.ContentCol>
 
 				<ClayLayout.ContentCol expand gutters>
 					<ClayCard.Description
+						aria-label={title}
 						disabled={disabled}
 						displayType="title"
 						href={href}

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -186,6 +186,11 @@ export const ClayCardWithInfo = ({
 							: 'primary'
 					}
 					position="bottom-left"
+					title={
+						stickerProps.content
+							? stickerProps.content
+							: stickerSymbol
+					}
 					{...stickerProps}
 				>
 					{stickerProps.children ? (
@@ -227,6 +232,7 @@ export const ClayCardWithInfo = ({
 				<ClayCard.Row>
 					<ClayLayout.ContentCol expand>
 						<ClayCard.Description
+							aria-label={title}
 							disabled={disabled}
 							displayType="title"
 							href={href}

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -107,6 +107,7 @@ export const ClayCardWithNavigation = ({
 						<>
 							{title && (
 								<ClayCard.Description
+									aria-label={title}
 									displayType="title"
 									truncate
 								>
@@ -128,7 +129,7 @@ export const ClayCardWithNavigation = ({
 					{horizontal && (
 						<ClayCard.Row>
 							<ClayLayout.ContentCol>
-								<ClaySticker inline>
+								<ClaySticker inline title={horizontalSymbol}>
 									<ClayIcon
 										spritemap={spritemap}
 										symbol={horizontalSymbol}
@@ -139,6 +140,7 @@ export const ClayCardWithNavigation = ({
 								<ClayLayout.ContentCol expand>
 									<ClayLayout.ContentSection>
 										<ClayCard.Description
+											aria-label={title}
 											displayType="title"
 											truncate
 										>

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -115,6 +115,7 @@ export const ClayCardWithUser = ({
 				className="sticker-user-icon"
 				displayType={userDisplayType}
 				shape="circle"
+				title={userSymbol}
 			>
 				{userImageSrc && (
 					<ClaySticker.Image alt={userImageAlt} src={userImageSrc} />
@@ -152,6 +153,7 @@ export const ClayCardWithUser = ({
 				<ClayCard.Row>
 					<ClayLayout.ContentCol expand>
 						<ClayCard.Description
+							aria-label={title}
 							disabled={disabled}
 							displayType="title"
 							href={href}

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.89.0
+ * Clay 3.92.0
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>


### PR DESCRIPTION
Hello! This is my first time contributing to the Clay repository.
I am attempting to add the changes for the proposal "[Accessibility improvements for Card components](https://github.com/liferay/clay/issues/5425)" and am unsure of how to go about adding the titles to the clay stickers. 

I believe I added the aria-labels to the card-titles properly, but I tried using the symbol names to add titles to stickers and I do not think this is the best way to do this. Are there any suggestions for how to do this better, and is there anything I missed in making the commit/pull request? 

Thank you so much!