### PR TITLE
fix(@clayui/modal): fix focus visual error in Modal

### DIFF
--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -154,18 +154,20 @@ const ClayModal = ({
 				style={{zIndex: zIndex && zIndex + 10}}
 			>
 				<div
-					aria-labelledby={ariaLabelledby}
-					aria-modal="true"
 					className={classNames('modal-dialog', {
 						[`modal-${size}`]: size,
 						[`modal-${status}`]: status,
 						'modal-dialog-centered': center,
 					})}
-					ref={modalBodyElementRef}
-					role={role}
-					tabIndex={-1}
 				>
-					<div className="modal-content">
+					<div
+						aria-labelledby={ariaLabelledby}
+						aria-modal="true"
+						className="modal-content"
+						ref={modalBodyElementRef}
+						role={role}
+						tabIndex={-1}
+					>
 						<Context.Provider
 							value={{
 								ariaLabelledby,

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -30,14 +30,14 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-9"
-        aria-modal="true"
         class="modal-dialog modal-lg"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-9"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         >
           <div
             class="modal-header"

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -14,14 +14,14 @@ exports[`ClayModal renders 1`] = `
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-1"
-        aria-modal="true"
         class="modal-dialog"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-1"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         >
           <div
             class="modal-header"
@@ -99,14 +99,14 @@ exports[`ClayModal renders Header w/ low-level API 1`] = `
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-3"
-        aria-modal="true"
         class="modal-dialog"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-3"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         >
           <div
             class="modal-header"
@@ -168,14 +168,14 @@ exports[`ClayModal renders a body component with url 1`] = `
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-7"
-        aria-modal="true"
         class="modal-dialog"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-7"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         >
           <div
             class="modal-body modal-body-iframe"
@@ -210,14 +210,14 @@ exports[`ClayModal renders a footer component with buttons 1`] = `
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-8"
-        aria-modal="true"
         class="modal-dialog"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-8"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         >
           <div
             class="modal-footer"
@@ -278,14 +278,14 @@ exports[`ClayModal renders with Header 1`] = `
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-2"
-        aria-modal="true"
         class="modal-dialog"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-2"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         >
           <div
             class="modal-header"
@@ -336,14 +336,14 @@ exports[`ClayModal renders with center 1`] = `
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-6"
-        aria-modal="true"
         class="modal-dialog modal-dialog-centered"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-6"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         />
       </div>
     </div>
@@ -369,14 +369,14 @@ exports[`ClayModal renders with size 1`] = `
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-4"
-        aria-modal="true"
         class="modal-dialog modal-lg"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-4"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         />
       </div>
     </div>
@@ -402,14 +402,14 @@ exports[`ClayModal renders with status 1`] = `
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-5"
-        aria-modal="true"
         class="modal-dialog modal-success"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-5"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         />
       </div>
     </div>

--- a/packages/clay-modal/src/__tests__/__snapshots__/modal.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/modal.tsx.snap
@@ -14,14 +14,14 @@ exports[`ClayModal custom opener does not close automatically with disableAutoCl
       class="fade modal d-block"
     >
       <div
-        aria-labelledby="clay-modal-label-2"
-        aria-modal="true"
         class="modal-dialog"
-        role="dialog"
-        tabindex="-1"
       >
         <div
+          aria-labelledby="clay-modal-label-2"
+          aria-modal="true"
           class="modal-content"
+          role="dialog"
+          tabindex="-1"
         />
       </div>
     </div>
@@ -47,14 +47,14 @@ exports[`ClayModal custom opener renders inside a container element 1`] = `
           class="fade modal d-block"
         >
           <div
-            aria-labelledby="clay-modal-label-1"
-            aria-modal="true"
             class="modal-dialog"
-            role="dialog"
-            tabindex="-1"
           >
             <div
+              aria-labelledby="clay-modal-label-1"
+              aria-modal="true"
               class="modal-content"
+              role="dialog"
+              tabindex="-1"
             />
           </div>
         </div>


### PR DESCRIPTION
Fixes #5493

We are moving ARIA attributes to `modal-content` to avoid Modal visual focus error.