### PR TITLE
fix(@clayui/css): Modals converts some components to clay Sass map pattern

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_modals.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_modals.scss
@@ -10,15 +10,7 @@
 
 .modal,
 &.modal {
-	display: none;
-	height: 100%;
-	left: 0;
-	outline: 0;
-	overflow: hidden;
-	position: fixed;
-	top: 0;
-	width: 100%;
-	z-index: $cadmin-zindex-modal;
+	@include clay-css($cadmin-modal);
 }
 
 .modal-dialog {
@@ -122,67 +114,44 @@
 
 .modal-backdrop,
 &.modal-backdrop {
-	background-color: $cadmin-modal-backdrop-bg;
-	height: 100vh;
-	left: 0;
-	position: fixed;
-	top: 0;
-	width: 100vw;
-	z-index: $cadmin-zindex-modal-backdrop;
-
-	&.fade {
-		opacity: 0;
-	}
-
-	&.show {
-		opacity: $cadmin-modal-backdrop-opacity;
-	}
+	@include clay-map-to-css($cadmin-modal-backdrop);
 }
 
 .modal-content {
-	background-clip: padding-box;
-	background-color: $cadmin-modal-content-bg;
-	border: $cadmin-modal-content-border-width solid
-		$cadmin-modal-content-border-color;
-
-	@include border-radius($cadmin-modal-content-border-radius);
-	@include box-shadow($cadmin-modal-content-box-shadow-xs);
-
-	color: $cadmin-modal-content-color;
-	display: flex;
-	flex-direction: column;
-	outline: 0;
-	overflow: hidden;
-	pointer-events: auto;
-	position: relative;
-	width: 100%;
+	@include clay-map-to-css($cadmin-modal-content);
 }
 
 .modal-header,
 &.modal-header {
-	$breakpoint-down: map-get($cadmin-modal-header, breakpoint-down);
+	$_modal-header: setter(map-get($cadmin-modal, modal-header), ());
 
-	@include clay-css($cadmin-modal-header);
+	$_breakpoint-down: map-get($_modal-header, breakpoint-down);
+	$_mobile: map-get($_modal-header, mobile);
 
-	@include clay-scale-component(null, $breakpoint-down) {
-		$mobile: setter(map-get($cadmin-modal-header, mobile), ());
+	$_modal-header: map-remove($_modal-header, breakpoint-down, mobile);
 
-		@include clay-css($mobile);
+	@include clay-map-to-css($_modal-header);
+
+	@include clay-scale-component(null, $_breakpoint-down) {
+		@include clay-css(map-get($_modal-header, mobile));
 	}
 }
 
 .modal-body,
 &.modal-body {
-	@include clay-css($cadmin-modal-body);
+	$_modal-body: setter(map-get($cadmin-modal, modal-body), ());
+	$_modal-body: map-deep-merge(
+		$_modal-body,
+		(
+			'&.inline-scroller':
+				map-merge(
+					setter(map-get($_modal-body, '&.inline-scroller'), ()),
+					setter(map-get($_modal-body, inline-scroller), ())
+				),
+		)
+	);
 
-	&.inline-scroller {
-		$inline-scroller: setter(
-			map-get($cadmin-modal-body, inline-scroller),
-			()
-		);
-
-		@include clay-css($inline-scroller);
-	}
+	@include clay-map-to-css($_modal-body);
 }
 
 .modal-body-flush,
@@ -192,31 +161,10 @@
 
 .modal-footer,
 &.modal-footer {
-	align-items: center;
-	background-color: $cadmin-modal-footer-bg;
-	border-top: $cadmin-modal-footer-border-width solid
-		$cadmin-modal-footer-border-color;
-
-	@include border-bottom-radius($cadmin-modal-content-inner-border-radius);
-	@include box-shadow($cadmin-modal-footer-box-shadow);
-
-	color: $cadmin-modal-footer-color;
-	display: flex;
-	flex-shrink: 0;
-	flex-wrap: wrap;
-	height: $cadmin-modal-footer-height;
-	justify-content: flex-start;
-	padding-bottom: $cadmin-modal-footer-padding-y;
-	padding-left: $cadmin-modal-footer-padding-x;
-	padding-right: $cadmin-modal-footer-padding-x;
-	padding-top: $cadmin-modal-footer-padding-y;
+	@include clay-map-to-css(map-get($cadmin-modal, modal-footer));
 
 	@include clay-scale-component {
 		height: $cadmin-modal-footer-height-mobile;
-	}
-
-	> * {
-		margin: $cadmin-modal-footer-margin-between * 0.5;
 	}
 }
 
@@ -272,15 +220,7 @@
 // Modal Title
 
 .modal-title {
-	flex-grow: 1;
-	font-size: $cadmin-modal-title-font-size;
-	font-weight: $cadmin-modal-title-font-weight;
-	line-height: $cadmin-modal-title-line-height;
-	margin-bottom: 0;
-	overflow: hidden;
-	text-align: $cadmin-modal-title-text-align;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	@include clay-map-to-css(map-get($cadmin-modal, modal-title));
 
 	@include clay-scale-component {
 		font-size: $cadmin-modal-title-font-size-mobile;
@@ -288,11 +228,7 @@
 }
 
 .modal-title-indicator {
-	display: inline-block;
-	font-size: $cadmin-modal-title-indicator-font-size;
-	margin-right: $cadmin-modal-title-indicator-spacer-x;
-	margin-top: -0.2em;
-	vertical-align: middle;
+	@include clay-map-to-css(map-get($cadmin-modal, modal-title-indicator));
 }
 
 // Modal Subtitle
@@ -314,13 +250,7 @@
 &.modal,
 .modal {
 	.close {
-		&:first-child {
-			margin-left: math-sign($cadmin-modal-close-spacer-x);
-		}
-
-		&:last-child {
-			margin-right: math-sign($cadmin-modal-close-spacer-x);
-		}
+		@include clay-close(map-get($cadmin-modal, close));
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/variables/_modals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_modals.scss
@@ -1,6 +1,26 @@
 $cadmin-modal-backdrop-bg: $cadmin-gray-800 !default;
 $cadmin-modal-backdrop-opacity: 0.8 !default;
 
+$cadmin-modal-backdrop: () !default;
+$cadmin-modal-backdrop: map-deep-merge(
+	(
+		background-color: $cadmin-modal-backdrop-bg,
+		height: 100vh,
+		left: 0,
+		position: fixed,
+		top: 0,
+		width: 100vw,
+		z-index: $cadmin-zindex-modal-backdrop,
+		'&.fade': (
+			opacity: 0,
+		),
+		'&.show': (
+			opacity: $cadmin-modal-backdrop-opacity,
+		),
+	),
+	$cadmin-modal-backdrop
+);
+
 // Modal Dialog
 
 $cadmin-modal-dialog-margin: 8px !default;
@@ -25,6 +45,27 @@ $cadmin-modal-content-inner-border-radius: calc(
 
 $cadmin-modal-content-box-shadow-xs: 0 0 3px 1px rgba(0, 0, 0, 0.2) !default;
 $cadmin-modal-content-box-shadow-sm-up: 0 8px 16px rgba($cadmin-black, 0.5) !default;
+
+$cadmin-modal-content: () !default;
+$cadmin-modal-content: map-deep-merge(
+	(
+		background-clip: padding-box,
+		background-color: $cadmin-modal-content-bg,
+		border-radius: clay-enable-rounded($cadmin-modal-content-border-radius),
+		border: $cadmin-modal-content-border-width solid
+			$cadmin-modal-content-border-color,
+		box-shadow: clay-enable-shadows($cadmin-modal-content-box-shadow-xs),
+		color: $cadmin-modal-content-color,
+		display: flex,
+		flex-direction: column,
+		outline: 0,
+		overflow: hidden,
+		pointer-events: auto,
+		position: relative,
+		width: 100%,
+	),
+	$cadmin-modal-content
+);
 
 // .modal-header
 
@@ -85,7 +126,7 @@ $cadmin-modal-body: map-deep-merge(
 		margin-top: math-sign($cadmin-modal-content-border-width),
 		padding: $cadmin-modal-inner-padding,
 		position: relative,
-		inline-scroller: (
+		'&.inline-scroller': (
 			max-height: 320px,
 			-webkit-overflow-scrolling: touch,
 			overflow: auto,
@@ -255,6 +296,76 @@ $cadmin-modal-height-full-modal-content-sm-up: map-merge(
 		top: $cadmin-modal-dialog-margin-y-sm-up,
 	),
 	$cadmin-modal-height-full-modal-content-sm-up
+);
+
+// Modal
+
+$cadmin-modal: () !default;
+$cadmin-modal: map-deep-merge(
+	(
+		display: none,
+		height: 100%,
+		left: 0,
+		outline: 0,
+		overflow: hidden,
+		position: fixed,
+		top: 0,
+		width: 100%,
+		z-index: $cadmin-zindex-modal,
+		close: (
+			'&:first-child': (
+				margin-left: math-sign($cadmin-modal-close-spacer-x),
+			),
+			'&:last-child': (
+				margin-right: math-sign($cadmin-modal-close-spacer-x),
+			),
+		),
+		modal-header: $cadmin-modal-header,
+		modal-body: $cadmin-modal-body,
+		modal-footer: (
+			align-items: center,
+			background-color: $cadmin-modal-footer-bg,
+			border-bottom-left-radius:
+				clay-enable-rounded($cadmin-modal-content-inner-border-radius),
+			border-bottom-right-radius:
+				clay-enable-rounded($cadmin-modal-content-inner-border-radius),
+			border-top: $cadmin-modal-footer-border-width solid
+				$cadmin-modal-footer-border-color,
+			box-shadow: clay-enable-shadows($cadmin-modal-footer-box-shadow),
+			color: $cadmin-modal-footer-color,
+			display: flex,
+			flex-shrink: 0,
+			flex-wrap: wrap,
+			height: $cadmin-modal-footer-height,
+			justify-content: flex-start,
+			padding-bottom: $cadmin-modal-footer-padding-y,
+			padding-left: $cadmin-modal-footer-padding-x,
+			padding-right: $cadmin-modal-footer-padding-x,
+			padding-top: $cadmin-modal-footer-padding-y,
+			'> *': (
+				margin: calc(#{$cadmin-modal-footer-margin-between} * 0.5),
+			),
+		),
+		modal-title: (
+			flex-grow: 1,
+			font-size: $cadmin-modal-title-font-size,
+			font-weight: $cadmin-modal-title-font-weight,
+			line-height: $cadmin-modal-title-line-height,
+			margin-bottom: 0,
+			overflow: hidden,
+			text-align: $cadmin-modal-title-text-align,
+			text-overflow: ellipsis,
+			white-space: nowrap,
+		),
+		modal-title-indicator: (
+			display: inline-block,
+			font-size: $cadmin-modal-title-indicator-font-size,
+			margin-right: $cadmin-modal-title-indicator-spacer-x,
+			margin-top: -0.2em,
+			vertical-align: middle,
+		),
+	),
+	$cadmin-modal
 );
 
 // Modal Success

--- a/packages/clay-css/src/scss/components/_modals.scss
+++ b/packages/clay-css/src/scss/components/_modals.scss
@@ -8,15 +8,7 @@
 }
 
 .modal {
-	display: none;
-	height: 100%;
-	left: 0;
-	outline: 0;
-	overflow: hidden;
-	position: fixed;
-	top: 0;
-	width: 100%;
-	z-index: $zindex-modal;
+	@include clay-css($modal);
 }
 
 .modal-dialog {
@@ -143,57 +135,42 @@
 }
 
 .modal-backdrop {
-	background-color: $modal-backdrop-bg;
-	height: 100vh;
-	left: 0;
-	position: fixed;
-	top: 0;
-	width: 100vw;
-	z-index: $zindex-modal-backdrop;
-
-	&.fade {
-		opacity: 0;
-	}
-
-	&.show {
-		opacity: $modal-backdrop-opacity;
-	}
+	@include clay-map-to-css($modal-backdrop);
 }
 
 .modal-content {
-	background-clip: padding-box;
-	background-color: $modal-content-bg;
-	border: $modal-content-border-width solid $modal-content-border-color;
-
-	@include border-radius($modal-content-border-radius);
-	@include box-shadow($modal-content-box-shadow-xs);
-
-	color: $modal-content-color;
-	display: flex;
-	flex-direction: column;
-	outline: 0;
-	overflow: hidden;
-	pointer-events: auto;
-	position: relative;
-	width: 100%;
+	@include clay-map-to-css($modal-content);
 }
 
 .modal-header {
-	$breakpoint-down: map-get($modal-header, breakpoint-down);
+	$_modal-header: setter(map-get($modal, modal-header), ());
 
-	@include clay-css($modal-header);
+	$_breakpoint-down: map-get($_modal-header, breakpoint-down);
+	$_mobile: map-get($_modal-header, mobile);
 
-	@include clay-scale-component(null, $breakpoint-down) {
-		@include clay-css(map-get($modal-header, mobile));
+	$_modal-header: map-remove($_modal-header, breakpoint-down, mobile);
+
+	@include clay-map-to-css($_modal-header);
+
+	@include clay-scale-component(null, $_breakpoint-down) {
+		@include clay-css(map-get($_modal-header, mobile));
 	}
 }
 
 .modal-body {
-	@include clay-css($modal-body);
+	$_modal-body: setter(map-get($modal, modal-body), ());
+	$_modal-body: map-deep-merge(
+		$_modal-body,
+		(
+			'&.inline-scroller':
+				map-merge(
+					setter(map-get($_modal-body, '&.inline-scroller'), ()),
+					setter(map-get($_modal-body, inline-scroller), ())
+				),
+		)
+	);
 
-	&.inline-scroller {
-		@include clay-css(map-get($modal-body, inline-scroller));
-	}
+	@include clay-map-to-css($modal-body);
 }
 
 .modal-body-flush {
@@ -201,23 +178,7 @@
 }
 
 .modal-footer {
-	align-items: center;
-	background-color: $modal-footer-bg;
-	border-top: $modal-footer-border-width solid $modal-footer-border-color;
-
-	@include border-bottom-radius($modal-content-inner-border-radius);
-	@include box-shadow($modal-footer-box-shadow);
-
-	color: $modal-footer-color;
-	display: flex;
-	flex-shrink: 0;
-	flex-wrap: wrap;
-	height: $modal-footer-height;
-	justify-content: flex-start;
-	padding-bottom: $modal-footer-padding-y;
-	padding-left: $modal-footer-padding-x;
-	padding-right: $modal-footer-padding-x;
-	padding-top: $modal-footer-padding-y;
+	@include clay-map-to-css(map-get($modal, modal-footer));
 
 	@include clay-scale-component {
 		height: $modal-footer-height-mobile;
@@ -279,15 +240,7 @@
 // Modal Title
 
 .modal-title {
-	flex-grow: 1;
-	font-size: $modal-title-font-size;
-	font-weight: $modal-title-font-weight;
-	line-height: $modal-title-line-height;
-	margin-bottom: 0;
-	overflow: hidden;
-	text-align: $modal-title-text-align;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	@include clay-css(map-get($modal, modal-title));
 
 	@include clay-scale-component {
 		font-size: $modal-title-font-size-mobile;
@@ -295,11 +248,7 @@
 }
 
 .modal-title-indicator {
-	display: inline-block;
-	font-size: $modal-title-indicator-font-size;
-	margin-right: $modal-title-indicator-spacer-x;
-	margin-top: -0.2em;
-	vertical-align: middle;
+	@include clay-css(map-get($modal, modal-title-indicator));
 }
 
 // Modal Subtitle
@@ -319,13 +268,7 @@
 // Modal Close
 
 .modal .close {
-	&:first-child {
-		margin-left: math-sign($modal-close-spacer-x);
-	}
-
-	&:last-child {
-		margin-right: math-sign($modal-close-spacer-x);
-	}
+	@include clay-close(map-get($modal, close));
 }
 
 .close + .modal-title {

--- a/packages/clay-css/src/scss/components/_modals.scss
+++ b/packages/clay-css/src/scss/components/_modals.scss
@@ -170,7 +170,7 @@
 		)
 	);
 
-	@include clay-map-to-css($modal-body);
+	@include clay-map-to-css($_modal-body);
 }
 
 .modal-body-flush {
@@ -182,10 +182,6 @@
 
 	@include clay-scale-component {
 		height: $modal-footer-height-mobile;
-	}
-
-	> * {
-		margin: $modal-footer-margin-between * 0.5;
 	}
 }
 

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -336,42 +336,30 @@
 }
 
 /// A mixin that outputs CSS based on the structure of a Sass map.
+/// @param {Map} $map - A map of `key: value` pairs.
 
 @mixin clay-map-to-css($map) {
+	@include clay-css($map);
+
 	@each $key, $value in $map {
 		@if not clay-is-map-unset($value) {
-			@each $nestedKey, $nestedValue in $value {
-				@if (type-of($nestedValue) == 'map') {
-					$parentSelector: if(
-						starts-with($key, '.') or
-							starts-with($key, '#') or
-							starts-with($key, '@'),
-						$key,
-						str-insert($key, '.', 1)
-					);
+			@if (type-of($value) == 'map') {
+				$selector: if(
+					starts-with($key, '.') or
+						starts-with($key, '#') or
+						starts-with($key, '&') or
+						starts-with($key, '@'),
+					$key,
+					str-insert($key, '.', 1)
+				);
 
-					$nestedMap: (#{$nestedKey}: $nestedValue);
-
-					@if (starts-with($parentSelector, '@media ')) {
-						@media #{clay-str-replace('#{$parentSelector}', '@media ', '')} {
-							@include clay-map-to-css($nestedMap);
-						}
-					} @else {
-						#{$parentSelector} {
-							@include clay-map-to-css($nestedMap);
-						}
+				@if (starts-with($selector, '@media ')) {
+					@media #{clay-str-replace('#{$selector}', '@media ', '')} {
+						@include clay-map-to-css($value);
 					}
 				} @else {
-					$selector: if(
-						starts-with($key, '.') or
-							starts-with($key, '#') or
-							starts-with($key, '@'),
-						$key,
-						str-insert($key, '.', 1)
-					);
-
 					#{$selector} {
-						@include clay-css($value);
+						@include clay-map-to-css($value);
 					}
 				}
 			}

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -344,11 +344,10 @@
 	@each $key, $value in $map {
 		@if not clay-is-map-unset($value) {
 			@if (type-of($value) == 'map') {
+				$valid-prefixes: '#', '&', '.', '>', '@';
+
 				$selector: if(
-					starts-with($key, '.') or
-						starts-with($key, '#') or
-						starts-with($key, '&') or
-						starts-with($key, '@'),
+					index($valid-prefixes, str-slice($key, 1, 1)),
 					$key,
 					str-insert($key, '.', 1)
 				);

--- a/packages/clay-css/src/scss/mixins/_modals.scss
+++ b/packages/clay-css/src/scss/mixins/_modals.scss
@@ -109,8 +109,30 @@
 			)
 		);
 
+		$map: map-remove(
+			$map,
+			enabled,
+			modal-header,
+			header,
+			header-bg,
+			header-border-color,
+			header-color,
+			header-close,
+			header-close-color,
+			btn-focus-box-shadow,
+			btn-focus-outline,
+			modal-body,
+			body,
+			body-bg,
+			body-color,
+			modal-footer,
+			footer,
+			footer-bg,
+			footer-border-color
+		);
+
 		@if ($enabled) {
-			@include clay-css($map);
+			@include clay-map-to-css($map);
 
 			// Modal specific btn-monospaced is deprecated in v2.0.0-rc.12
 
@@ -130,15 +152,15 @@
 			}
 
 			.modal-header {
-				@include clay-css($header);
+				@include clay-map-to-css($header);
 			}
 
 			.modal-body {
-				@include clay-css($body);
+				@include clay-map-to-css($body);
 			}
 
 			.modal-footer {
-				@include clay-css($footer);
+				@include clay-map-to-css($footer);
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/variables/_modals.scss
+++ b/packages/clay-css/src/scss/variables/_modals.scss
@@ -341,6 +341,9 @@ $modal: map-deep-merge(
 			padding-left: $modal-footer-padding-x,
 			padding-right: $modal-footer-padding-x,
 			padding-top: $modal-footer-padding-y,
+			'> *': (
+				margin: calc(#{$modal-footer-margin-between} * 0.5),
+			),
 		),
 		modal-title: (
 			flex-grow: 1,

--- a/packages/clay-css/src/scss/variables/_modals.scss
+++ b/packages/clay-css/src/scss/variables/_modals.scss
@@ -1,6 +1,26 @@
 $modal-backdrop-bg: $black !default;
 $modal-backdrop-opacity: 0.5 !default;
 
+$modal-backdrop: () !default;
+$modal-backdrop: map-deep-merge(
+	(
+		background-color: $modal-backdrop-bg,
+		height: 100vh,
+		left: 0,
+		position: fixed,
+		top: 0,
+		width: 100vw,
+		z-index: $zindex-modal-backdrop,
+		'&.fade': (
+			opacity: 0,
+		),
+		'&.show': (
+			opacity: $modal-backdrop-opacity,
+		),
+	),
+	$modal-backdrop
+);
+
 // Modal Dialog
 
 $modal-dialog-margin: 0.5rem !default;
@@ -25,6 +45,26 @@ $modal-content-inner-border-radius: calc(
 
 $modal-content-box-shadow-xs: 0 0.25rem 0.5rem rgba($black, 0.5) !default;
 $modal-content-box-shadow-sm-up: 0 0.5rem 1rem rgba($black, 0.5) !default;
+
+$modal-content: () !default;
+$modal-content: map-deep-merge(
+	(
+		background-clip: padding-box,
+		background-color: $modal-content-bg,
+		border-radius: clay-enable-rounded($modal-content-border-radius),
+		border: $modal-content-border-width solid $modal-content-border-color,
+		box-shadow: clay-enable-shadows($modal-content-box-shadow-xs),
+		color: $modal-content-color,
+		display: flex,
+		flex-direction: column,
+		outline: 0,
+		overflow: hidden,
+		pointer-events: auto,
+		position: relative,
+		width: 100%,
+	),
+	$modal-content
+);
 
 // Modal Header
 
@@ -85,7 +125,7 @@ $modal-body: map-deep-merge(
 		margin-top: math-sign($modal-content-border-width),
 		padding: $modal-inner-padding,
 		position: relative,
-		inline-scroller: (
+		'&.inline-scroller': (
 			max-height: 320px,
 			-webkit-overflow-scrolling: touch,
 			overflow: auto,
@@ -255,6 +295,73 @@ $modal-height-full-modal-content-sm-up: map-merge(
 		top: $modal-dialog-margin-y-sm-up,
 	),
 	$modal-height-full-modal-content-sm-up
+);
+
+// Modal
+
+$modal: () !default;
+$modal: map-deep-merge(
+	(
+		display: none,
+		height: 100%,
+		left: 0,
+		outline: 0,
+		overflow: hidden,
+		position: fixed,
+		top: 0,
+		width: 100%,
+		z-index: $zindex-modal,
+		close: (
+			'&:first-child': (
+				margin-left: math-sign($modal-close-spacer-x),
+			),
+			'&:last-child': (
+				margin-right: math-sign($modal-close-spacer-x),
+			),
+		),
+		modal-header: $modal-header,
+		modal-body: $modal-body,
+		modal-footer: (
+			align-items: center,
+			background-color: $modal-footer-bg,
+			border-bottom-left-radius:
+				clay-enable-rounded($modal-content-inner-border-radius),
+			border-bottom-right-radius:
+				clay-enable-rounded($modal-content-inner-border-radius),
+			border-top: $modal-footer-border-width solid
+				$modal-footer-border-color,
+			box-shadow: clay-enable-shadows($modal-footer-box-shadow),
+			color: $modal-footer-color,
+			display: flex,
+			flex-shrink: 0,
+			flex-wrap: wrap,
+			height: $modal-footer-height,
+			justify-content: flex-start,
+			padding-bottom: $modal-footer-padding-y,
+			padding-left: $modal-footer-padding-x,
+			padding-right: $modal-footer-padding-x,
+			padding-top: $modal-footer-padding-y,
+		),
+		modal-title: (
+			flex-grow: 1,
+			font-size: $modal-title-font-size,
+			font-weight: $modal-title-font-weight,
+			line-height: $modal-title-line-height,
+			margin-bottom: 0,
+			overflow: hidden,
+			text-align: $modal-title-text-align,
+			text-overflow: ellipsis,
+			white-space: nowrap,
+		),
+		modal-title-indicator: (
+			display: inline-block,
+			font-size: $modal-title-indicator-font-size,
+			margin-right: $modal-title-indicator-spacer-x,
+			margin-top: -0.2em,
+			vertical-align: middle,
+		),
+	),
+	$modal
 );
 
 // Modal Success


### PR DESCRIPTION
fixes #5488

fix(@clayui/css): Mixins clay-modal-variant should use clay-map-to-css where applicable
fix(@clayui/css): Mixins clay-map-to-css should accept parent selector &

This is the first mixin to use `clay-map-to-css`. It gives us more flexibility when customizing variants. We no longer need to declare all the subcomponents in the mixin. It will output classes based on the Sass map.

```scss
$modal-info: (
	modal-footer: (
		modal-item-last: (
			margin: 0,
		),
	),
);
```

will output:

```css
.modal-info .modal-footer .modal-item-last {
    margin: 0;
}
```