### PR TITLE
fix(@clayui/shared): fix error when not recalculating positioning for elements with parent with scroll

### DIFF
--- a/packages/clay-shared/src/useOverlayPositon.ts
+++ b/packages/clay-shared/src/useOverlayPositon.ts
@@ -122,10 +122,10 @@ export function useOverlayPosition(
 			}
 		}
 
-		if (isOpen && ref.current) {
+		if (isOpen && triggerRef.current) {
 			alignElement();
 
-			return observeRect(ref.current, alignElement);
+			return observeRect(triggerRef.current, alignElement);
 		}
 	}, deps);
 }


### PR DESCRIPTION
Fixes #5475

The implementation of the `useOverlayPosition` hook was checking the menu instead of the target to see if it changed its positioning, this only worked when the scroll was with the viewport instead of the parent element that has a scroll the right thing is to check the target that is in relation to the scroll of the parent element.