### PR TITLE
@clayui/css: More complex input-groups should accommodate inset focus styles

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -1,5 +1,6 @@
 $input-bg: $gray-200 !default;
 $input-border-color: $gray-300 !default;
+$input-border-radius: $border-radius !default;
 $input-border-width: 0.0625rem !default; // 1px
 
 $input-border-bottom-width: $input-border-width !default; // 1px
@@ -520,6 +521,63 @@ $input-group-addon-color: $gray-600 !default;
 $input-group-addon-font-weight: $font-weight-semi-bold !default;
 $input-group-addon-min-width: 2.5rem !default; // 40px
 $input-group-addon-padding-x: 0.75rem !default; // 12px
+$input-group-item-margin-left: 0.5rem !default;
+$input-group-item: () !default;
+$input-group-item: map-deep-merge(
+	(
+		display: flex,
+		flex-grow: 1,
+		flex-wrap: wrap,
+		margin-left: $input-group-item-margin-left,
+		width: 1%,
+		word-wrap: break-word,
+		focus: (
+			border-radius: clay-enable-rounded($input-border-radius),
+			after: (
+				border-radius: inherit,
+				bottom: 0,
+				box-shadow: $input-focus-box-shadow,
+				content: '',
+				display: block,
+				left: 0,
+				pointer-events: none,
+				position: absolute,
+				right: 0,
+				top: 0,
+			),
+			input-group-prepend: (
+				border-bottom-right-radius: clay-enable-rounded(0),
+				border-top-right-radius: clay-enable-rounded(0),
+				z-index: 1,
+			),
+			input-group-append: (
+				border-bottom-left-radius: clay-enable-rounded(0),
+				border-top-left-radius: clay-enable-rounded(0),
+			),
+			form-control: (
+				background-color: $input-focus-bg,
+				border-color: $input-focus-border-color,
+			),
+			input-group-inset-item: (
+				background-color: $input-focus-bg,
+				border-color: $input-focus-border-color,
+			),
+		),
+		first-child: (
+			margin-left: 0,
+		),
+		btn: (
+			align-self: flex-start,
+		),
+		dropdown: (
+			display: flex,
+			flex-wrap: wrap,
+			word-wrap: break-word,
+			width: 100%,
+		),
+	),
+	$input-group-item
+);
 
 // Input Group Sizes
 

--- a/packages/clay-css/src/scss/mixins/_input-groups.scss
+++ b/packages/clay-css/src/scss/mixins/_input-groups.scss
@@ -300,6 +300,14 @@
 		@if ($enabled) {
 			@include clay-css($map);
 
+			&::before {
+				@include clay-css(map-get($map, before));
+			}
+
+			&::after {
+				@include clay-css(map-get($map, after));
+			}
+
 			&.focus {
 				@include clay-input-group-item-variant(
 					map-deep-get($map, focus)

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -1435,7 +1435,18 @@ $input-group-item: map-deep-merge(
 		word-wrap: break-word,
 		focus: (
 			border-radius: clay-enable-rounded($input-border-radius),
-			box-shadow: $input-focus-box-shadow,
+			after: (
+				border-radius: inherit,
+				bottom: 0,
+				box-shadow: $input-focus-box-shadow,
+				content: '',
+				display: block,
+				left: 0,
+				pointer-events: none,
+				position: absolute,
+				right: 0,
+				top: 0,
+			),
 			input-group-prepend: (
 				border-bottom-right-radius: clay-enable-rounded(0),
 				border-top-right-radius: clay-enable-rounded(0),


### PR DESCRIPTION
Solution for https://github.com/liferay/clay/issues/5487