### PR TITLE
chore(@clayui/core): restores focus to the FocusTrap example trigger

### DIFF
--- a/packages/clay-core/docs/focus-trap.js
+++ b/packages/clay-core/docs/focus-trap.js
@@ -5,7 +5,7 @@
 
 import Editor from '$clayui.com/src/components/Editor';
 import {Button, FocusTrap} from '@clayui/core';
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 const exampleImports = `import {Button, FocusTrap} from '@clayui/core';
 import React, {useState, useRef} from 'react';`;
@@ -14,13 +14,11 @@ const exampleCode = `const FocusTrapTrigger = () => {
     const [active, setActive] = useState(false);
 	const activateButtonRef = useRef(null);
 
-	const onDeactivateFocusTrap = () => {
-		setActive(false);
-
-		if (activateButtonRef.current) {
-			activateButtonRef.current.focus();
+	useEffect(() => {
+		if (active) {
+			return () => activateButtonRef.current?.focus();
 		}
-	};
+	}, [active]);
 
 	return (
 		<>
@@ -33,7 +31,7 @@ const exampleCode = `const FocusTrapTrigger = () => {
                     <Button displayType="link">Button 1</Button>
                     <Button displayType="link">Button 2</Button>
                     <div className="c-mt-4">
-                        <Button onClick={onDeactivateFocusTrap}>
+                        <Button onClick={() => setActive(false)}>
                             Leave trap
                         </Button>
                     </div>
@@ -47,7 +45,7 @@ const exampleCode = `const FocusTrapTrigger = () => {
 render(<FocusTrapTrigger/>)`;
 
 const FocusTrapExample = () => {
-	const scope = {Button, FocusTrap, useRef, useState};
+	const scope = {Button, FocusTrap, useEffect, useRef, useState};
 
 	return <Editor code={exampleCode} imports={exampleImports} scope={scope} />;
 };

--- a/packages/clay-core/stories/FocusTrap.stories.tsx
+++ b/packages/clay-core/stories/FocusTrap.stories.tsx
@@ -5,7 +5,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayCard from '@clayui/card';
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import {FocusTrap} from '../src/focus-trap';
 
@@ -18,13 +18,11 @@ export const Default = () => {
 	const [active, setActive] = useState(false);
 	const activateButtonRef = useRef<HTMLButtonElement>(null);
 
-	const onDeactivateFocusTrap = () => {
-		setActive(false);
-
-		if (activateButtonRef.current) {
-			activateButtonRef.current.focus();
+	useEffect(() => {
+		if (active) {
+			return () => activateButtonRef.current?.focus();
 		}
-	};
+	}, [active]);
 
 	return (
 		<>
@@ -37,7 +35,7 @@ export const Default = () => {
 						<ClayButton displayType="link">Button 1</ClayButton>
 						<ClayButton displayType="link">Button 2</ClayButton>
 						<div className="mt-4">
-							<ClayButton onClick={onDeactivateFocusTrap}>
+							<ClayButton onClick={() => setActive(false)}>
 								Leave trap
 							</ClayButton>
 						</div>
@@ -53,13 +51,11 @@ export const FocusOnSpecificElement = () => {
 	const activateButtonRef = useRef<HTMLButtonElement>(null);
 	const thirdButtonRef = useRef<HTMLButtonElement>(null);
 
-	const onDeactivateFocusTrap = () => {
-		setActive(false);
-
-		if (activateButtonRef.current) {
-			activateButtonRef.current.focus();
+	useEffect(() => {
+		if (active) {
+			return () => activateButtonRef.current?.focus();
 		}
-	};
+	}, [active]);
 
 	return (
 		<>
@@ -75,7 +71,7 @@ export const FocusOnSpecificElement = () => {
 							Button 3
 						</ClayButton>
 						<div className="mt-4">
-							<ClayButton onClick={onDeactivateFocusTrap}>
+							<ClayButton onClick={() => setActive(false)}>
 								Leave trap
 							</ClayButton>
 						</div>


### PR DESCRIPTION
Closes #5518

I improved the FocusTrap examples to retrieve the focus for the trigger after the user exits the FocusTrap, the implementation moves the focus only after the component is unmounted to ensure that suppressed elements are removed before we move the focus, this is due to the [inert](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert) functionality that removes any user interaction on the elements.

I also send a PR to DXP to fix the specific use case https://github.com/liferay-peds/liferay-portal/pull/41.