### PR TITLE
fix(@clayui/css): Cadmin only generate Sass placeholders for specific key names

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_alerts.scss
@@ -434,31 +434,33 @@
 // Alert Variants
 
 @each $color, $value in $cadmin-alert-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.alert-', 1)
-	);
-
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-alert-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%alert-#{$color}'
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.alert-', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-alert-variant($value);
-		}
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-alert-variant($value);
+			}
+		} @else if (starts-with($color, 'alert-')) {
+			$placeholder: '%alert-#{$color}';
 
-		#{$selector} {
-			@extend %alert-#{$color} !optional;
+			#{$placeholder} {
+				@include clay-alert-variant($value);
+			}
+
+			#{$selector} {
+				@extend %alert-#{$color} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-alert-variant($value);
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_aspect-ratio.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_aspect-ratio.scss
@@ -160,42 +160,47 @@
 
 // aspect-ratio-#-to-#
 
-@each $selector, $value in $cadmin-aspect-ratio-sizes {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
-
-	@if (starts-with($selector, '%')) {
-		#{$selector} {
-			@include clay-aspect-ratio(
-				map-get($value, width),
-				map-get($value, height)
-			);
-		}
-	} @else if (map-get($value, extend)) {
-		#{$selector} {
-			@include clay-css($value);
-		}
-	} @else {
-		$placeholder: str-insert(
-			str-slice($selector, 2, str-length($selector)),
-			'%',
-			1
+@each $size, $value in $cadmin-aspect-ratio-sizes {
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($size, '.') or
+				starts-with($size, '#') or
+				starts-with($size, '%'),
+			$size,
+			str-insert($size, '.', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-aspect-ratio(
-				map-get($value, width),
-				map-get($value, height)
-			);
-		}
+		@if (starts-with($selector, '%')) {
+			#{$selector} {
+				@include clay-aspect-ratio(
+					map-get($value, width),
+					map-get($value, height)
+				);
+			}
+		} @else if (map-get($value, extend)) {
+			#{$selector} {
+				@include clay-css($value);
+			}
+		} @else if (starts-with($size, 'aspect-ratio-')) {
+			$placeholder: '%#{$size}';
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-aspect-ratio(
+					map-get($value, width),
+					map-get($value, height)
+				);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-aspect-ratio(
+					map-get($value, width),
+					map-get($value, height)
+				);
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_badges.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_badges.scss
@@ -61,35 +61,49 @@
 // Badge Variants
 
 @each $color, $value in $cadmin-badge-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		if(
-			starts-with($color, 'badge'),
-			str-insert($color, '.', 1),
-			str-insert($color, '.badge-', 1)
-		)
-	);
+	@if not clay-is-map-unset($value) {
+		$deprecated-keys: 'primary', 'secondary', 'success', 'info', 'warning',
+			'danger', 'dark', 'light';
 
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-badge-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%badge-#{$color}'
+		$selector: if(
+			index($deprecated-keys, '#{$color}') != null,
+			str-insert($color, '.badge-', 1),
+			if
+				(
+					starts-with($color, 'badge'),
+					str-insert($color, '.', 1),
+					$color
+				)
 		);
 
-		#{$placeholder} {
-			@include clay-badge-variant($value);
-		}
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-badge-variant($value);
+			}
+		} @else if
+			(
+				starts-with($color, 'badge') or
+					index($deprecated-keys, '#{$color}') !=
+					null
+			)
+		{
+			$placeholder: if(
+				starts-with($color, '.') or starts-with($color, '#'),
+				'%#{str-slice($color, 2)}',
+				'%badge-#{$color}'
+			);
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-badge-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-badge-variant($value);
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_buttons.scss
@@ -19,29 +19,31 @@ fieldset:disabled a.btn {
 // Button Sizes
 
 @each $size, $value in $cadmin-btn-sizes {
-	$selector: if(
-		starts-with($size, 'btn-'),
-		clay-str-replace($size, 'btn-', '.btn-'),
-		$size
-	);
-
-	@if (starts-with($size, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-button-variant($value);
-		}
-	} @else {
-		$placeholder: if(
+	@if not clay-is-map-unset($value) {
+		$selector: if(
 			starts-with($size, 'btn-'),
-			'%clay-#{$size}',
-			'%#{str-slice($size, 2)}'
+			clay-str-replace($size, 'btn-', '.btn-'),
+			$size
 		);
 
-		#{$placeholder} {
-			@include clay-button-variant($value);
-		}
+		@if (starts-with($size, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
+		} @else if (starts-with($size, 'btn-')) {
+			$placeholder: '%clay-#{$size}';
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-button-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
 		}
 	}
 }
@@ -80,33 +82,35 @@ input[type='button'] {
 // Button Monospaced
 
 @each $size, $value in $cadmin-btn-monospaced-sizes {
-	$selector: if(
-		starts-with($size, 'btn-monospaced-'),
-		clay-str-replace($size, 'btn-monospaced', '.btn-monospaced.btn'),
-		if(
-			$size == 'btn-monospaced',
-			clay-str-replace($size, 'btn-monospaced', '.btn-monospaced'),
-			$size
-		)
-	);
-
-	@if (starts-with($size, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-button-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($size, 'btn-monospaced'),
-			'%clay-#{$size}',
-			'%#{str-slice($size, 2)}'
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($size, 'btn-monospaced-'),
+			clay-str-replace($size, 'btn-monospaced', '.btn-monospaced.btn'),
+			if(
+				$size == 'btn-monospaced',
+				clay-str-replace($size, 'btn-monospaced', '.btn-monospaced'),
+				$size
+			)
 		);
 
-		#{$placeholder} {
-			@include clay-button-variant($value);
-		}
+		@if (starts-with($size, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
+		} @else if (starts-with($size, 'btn-monospaced')) {
+			$placeholder: '%clay-#{$size}';
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-button-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
 		}
 	}
 }
@@ -114,37 +118,43 @@ input[type='button'] {
 // Button Variants
 
 @each $color, $value in $cadmin-btn-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		if(
-			starts-with($color, 'btn-'),
-			str-insert($color, '.', 1),
-			str-insert($color, '.btn-', 1)
-		)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			if(
+				starts-with($color, 'btn'),
+				str-insert($color, '.', 1),
+				str-insert($color, '.btn-', 1)
+			)
+		);
 
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-button-variant($value);
-		}
-	} @else {
-		$placeholder: '%#{str-slice($selector, 2)}';
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
+		} @else if (starts-with($color, 'btn-')) {
+			$placeholder: '%#{str-slice($selector, 2)}';
 
-		$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
+			$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
 
-		#{$placeholder} {
-			@include clay-button-variant($value);
-		}
+			#{$placeholder} {
+				@include clay-button-variant($value);
+			}
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
-		}
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 
-		#{$placeholder-focus} {
-			@include clay-button-variant(map-get($value, focus));
+			#{$placeholder-focus} {
+				@include clay-button-variant(map-get($value, focus));
+			}
+		} @else {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
 		}
 	}
 }
@@ -152,37 +162,43 @@ input[type='button'] {
 // Button Outline Variants
 
 @each $color, $value in $cadmin-btn-outline-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		if(
-			starts-with($color, 'btn-'),
-			str-insert($color, '.', 1),
-			str-insert($color, '.btn-outline-', 1)
-		)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			if(
+				starts-with($color, 'btn'),
+				str-insert($color, '.', 1),
+				str-insert($color, '.btn-outline-', 1)
+			)
+		);
 
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-button-variant($value);
-		}
-	} @else {
-		$placeholder: '%#{str-slice($selector, 2)}';
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
+		} @else if (starts-with($color, 'btn-outline')) {
+			$placeholder: '%#{str-slice($selector, 2)}';
 
-		$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
+			$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
 
-		#{$placeholder} {
-			@include clay-button-variant($value);
-		}
+			#{$placeholder} {
+				@include clay-button-variant($value);
+			}
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
-		}
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
 
-		#{$placeholder-focus} {
-			@include clay-button-variant(map-get($value, focus));
+			#{$placeholder-focus} {
+				@include clay-button-variant(map-get($value, focus));
+			}
+		} @else {
+			#{$selector} {
+				@include clay-button-variant($value);
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -181,14 +181,16 @@ fieldset[disabled] .form-control {
 }
 
 @each $key, $value in $cadmin-input-palette {
-	$selector: if(
-		starts-with($key, '.') or starts-with($key, '#'),
-		$key,
-		str-insert($key, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($key, '.') or starts-with($key, '#'),
+			$key,
+			str-insert($key, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-form-control-variant($value);
+		#{$selector} {
+			@include clay-form-control-variant($value);
+		}
 	}
 }
 
@@ -324,14 +326,16 @@ select.form-control[multiple] {
 // Form Control Select Variants
 
 @each $key, $value in $cadmin-form-control-select-palette {
-	$selector: if(
-		starts-with($key, '.') or starts-with($key, '#'),
-		$key,
-		str-insert($key, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($key, '.') or starts-with($key, '#'),
+			$key,
+			str-insert($key, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-select-variant($value);
+		#{$selector} {
+			@include clay-select-variant($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_labels.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_labels.scss
@@ -56,32 +56,34 @@
 
 // Label Sizes
 
-@each $selector, $value in $cadmin-label-sizes {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
-
-	@if (starts-with($selector, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-label-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($selector, '.') or starts-with($selector, '#'),
-			'%#{str-slice($selector, 2)}',
-			'%#{$selector}'
+@each $size, $value in $cadmin-label-sizes {
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($size, '.') or
+				starts-with($size, '#') or
+				starts-with($size, '%'),
+			$size,
+			str-insert($size, '.', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-label-variant($value);
-		}
+		@if (starts-with($size, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-label-variant($value);
+			}
+		} @else if (starts-with($size, 'label-')) {
+			$placeholder: '%#{size}';
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-label-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-label-variant($value);
+			}
 		}
 	}
 }
@@ -89,31 +91,42 @@
 // Label Variants
 
 @each $color, $value in $cadmin-label-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.label-', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$deprecated-keys: 'primary', 'secondary', 'success', 'info', 'warning',
+			'danger', 'dark', 'light';
 
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-label-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%label-#{$color}'
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.label-', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-label-variant($value);
-		}
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-label-variant($value);
+			}
+		} @else if
+			(
+				starts-with($color, 'inverse-') or
+					index($deprecated-keys, '#{$color}') !=
+					null
+			)
+		{
+			$placeholder: '%label-#{$color}';
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-label-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-label-variant($value);
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_list-group.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_list-group.scss
@@ -376,23 +376,25 @@
 // List Group Item Variants
 
 @each $cadmin-color, $cadmin-value in $cadmin-theme-colors {
-	.list-group-item-#{$cadmin-color} {
-		background-color: theme-color-level($cadmin-color, -9);
-		color: theme-color-level($cadmin-color, 6);
+	@if not clay-is-map-unset($cadmin-value) {
+		.list-group-item-#{$cadmin-color} {
+			background-color: theme-color-level($cadmin-color, -9);
+			color: theme-color-level($cadmin-color, 6);
 
-		&.list-group-item-action {
-			@include hover-focus() {
-				background-color: clay-darken(
-					theme-color-level($cadmin-color, -9),
-					5%
-				);
-				color: theme-color-level($cadmin-color, 6);
-			}
+			&.list-group-item-action {
+				@include hover-focus() {
+					background-color: clay-darken(
+						theme-color-level($cadmin-color, -9),
+						5%
+					);
+					color: theme-color-level($cadmin-color, 6);
+				}
 
-			&.active {
-				background-color: theme-color-level($cadmin-color, 6);
-				border-color: theme-color-level($cadmin-color, 6);
-				color: $cadmin-white;
+				&.active {
+					background-color: theme-color-level($cadmin-color, 6);
+					border-color: theme-color-level($cadmin-color, 6);
+					color: $cadmin-white;
+				}
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/cadmin/components/_loaders.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_loaders.scss
@@ -79,31 +79,35 @@
 // Loading Animation Sizes
 
 @each $selector, $value in $cadmin-loading-animation-sizes {
-	$_selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$_selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$_selector} {
-		@include clay-spinner-variant($value);
+		#{$_selector} {
+			@include clay-spinner-variant($value);
+		}
 	}
 }
 
 // Loading Animation Variants
 
 @each $selector, $value in $cadmin-loading-animation-palette {
-	$_selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$_selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$_selector} {
-		@include clay-spinner-variant($value);
+		#{$_selector} {
+			@include clay-spinner-variant($value);
+		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_modals.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_modals.scss
@@ -492,10 +492,21 @@
 
 // Modal Variants
 
-@each $cadmin-color, $cadmin-value in $cadmin-modal-palette {
-	&.modal-#{$cadmin-color},
-	.modal-#{$cadmin-color} {
-		@include clay-modal-variant($cadmin-value);
+@each $color, $value in $cadmin-modal-palette {
+	@if not clay-is-map-unset($value) {
+		$deprecated-keys: 'primary', 'secondary', 'success', 'info', 'warning',
+			'danger', 'dark', 'light';
+
+		$selector: if(
+			index($deprecated-keys, '#{$color}') != null,
+			str-insert($color, '.modal-', 1),
+			$color
+		);
+
+		&#{$selector},
+		#{$selector} {
+			@include clay-modal-variant($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_navs.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_navs.scss
@@ -199,13 +199,15 @@
 // Nav Variants
 
 @each $key, $value in $cadmin-nav-palette {
-	$selector: if(
-		starts-with($key, '.') or starts-with($key, '#'),
-		$key,
-		str-insert($key, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($key, '.') or starts-with($key, '#'),
+			$key,
+			str-insert($key, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-nav-variant($value);
+		#{$selector} {
+			@include clay-nav-variant($value);
+		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_popovers.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_popovers.scss
@@ -1,16 +1,18 @@
 // Popovers
 
 @each $selector, $value in $cadmin-popovers {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-popover-variant($value);
+		#{$selector} {
+			@include clay-popover-variant($value);
+		}
 	}
 }
 
@@ -155,48 +157,54 @@
 // Popover Headers
 
 @each $selector, $value in $cadmin-popover-headers {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-popover-header-variant($value);
+		#{$selector} {
+			@include clay-popover-header-variant($value);
+		}
 	}
 }
 
 // Popover Bodies
 
 @each $selector, $value in $cadmin-popover-bodies {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-popover-header-variant($value);
+		#{$selector} {
+			@include clay-popover-header-variant($value);
+		}
 	}
 }
 
 // Popover Widths
 
 @each $selector, $value in $cadmin-popover-widths {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-popover-variant($value);
+		#{$selector} {
+			@include clay-popover-variant($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_progress-bars.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_progress-bars.scss
@@ -132,13 +132,15 @@
 // Progress Variants
 
 @each $cadmin-color, $cadmin-value in $cadmin-progress-palette {
-	.progress-#{$cadmin-color} {
-		.progress-bar {
-			background-color: map-get($cadmin-value, bar-bg);
-		}
+	@if not clay-is-map-unset($cadmin-value) {
+		.progress-#{$cadmin-color} {
+			.progress-bar {
+				background-color: map-get($cadmin-value, bar-bg);
+			}
 
-		.progress-group-feedback {
-			color: map-get($cadmin-value, group-feedback-color);
+			.progress-group-feedback {
+				color: map-get($cadmin-value, group-feedback-color);
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_sidebar.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_sidebar.scss
@@ -109,13 +109,15 @@
 // Sidebar Variants
 
 @each $color, $value in $cadmin-sidebar-palette {
-	$selector: if(
-		starts-with($color, '.') or starts-with($color, '#'),
-		$color,
-		str-insert($color, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			$color,
+			str-insert($color, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-sidebar-variant($value);
+		#{$selector} {
+			@include clay-sidebar-variant($value);
+		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_stickers.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_stickers.scss
@@ -68,32 +68,34 @@
 
 // Sticker Sizes
 
-@each $selector, $value in $cadmin-sticker-sizes {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
-
-	@if (starts-with($selector, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-sticker-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($selector, '.') or starts-with($selector, '#'),
-			'%#{str-slice($selector, 2)}',
-			'%#{$selector}'
+@each $size, $value in $cadmin-sticker-sizes {
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($size, '.') or
+				starts-with($size, '#') or
+				starts-with($size, '%'),
+			$size,
+			str-insert($size, '.', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-sticker-variant($value);
-		}
+		@if (starts-with($size, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-sticker-variant($value);
+			}
+		} @else if(starts-with($size, 'sticker-')) {
+			$placeholder: '%#{$size}';
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-sticker-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-sticker-variant($value);
+			}
 		}
 	}
 }
@@ -101,31 +103,36 @@
 // Sticker Variants
 
 @each $color, $value in $cadmin-sticker-palette {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.sticker-', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$deprecated-keys: 'primary', 'secondary', 'success', 'info', 'warning',
+			'danger', 'dark', 'light';
 
-	@if (starts-with($color, '%') or map-get($value, extend)) {
-		#{$selector} {
-			@include clay-sticker-variant($value);
-		}
-	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%sticker-#{$color}'
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.sticker-', 1)
 		);
 
-		#{$placeholder} {
-			@include clay-sticker-variant($value);
-		}
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-sticker-variant($value);
+			}
+		} @else if (index($deprecated-keys, '#{$color}') != null) {
+			$placeholder: '%sticker-#{$color}';
 
-		#{$selector} {
-			@extend #{$placeholder} !optional;
+			#{$placeholder} {
+				@include clay-sticker-variant($value);
+			}
+
+			#{$selector} {
+				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-sticker-variant($value);
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
@@ -25,31 +25,35 @@
 // Background
 
 @each $color, $value in $cadmin-bg-theme-colors {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.bg-', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.bg-', 1)
+		);
 
-	#{$selector} {
-		@include clay-css($value);
-	}
+		#{$selector} {
+			@include clay-css($value);
+		}
 
-	a#{$selector},
-	button#{$selector} {
-		&:hover,
-		&:focus {
-			@include clay-css(map-get($value, hover));
+		a#{$selector},
+		button#{$selector} {
+			&:hover,
+			&:focus {
+				@include clay-css(map-get($value, hover));
+			}
 		}
 	}
 }
 
 @if $cadmin-enable-gradients {
 	@each $color, $value in $cadmin-bg-gradient-theme-colors {
-		.bg-gradient-#{$color} {
-			@include clay-css($value);
+		@if not clay-is-map-unset($value) {
+			.bg-gradient-#{$color} {
+				@include clay-css($value);
+			}
 		}
 	}
 }
@@ -97,16 +101,18 @@
 }
 
 @each $color, $value in $cadmin-border-theme-colors {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.border-', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.border-', 1)
+		);
 
-	#{$selector} {
-		@include clay-css($value);
+		#{$selector} {
+			@include clay-css($value);
+		}
 	}
 }
 
@@ -760,16 +766,18 @@
 // Font Sizes
 
 @each $selector, $value in $cadmin-font-sizes {
-	$selector: if(
-		starts-with($selector, '.') or
-			starts-with($selector, '#') or
-			starts-with($selector, '%'),
-		$selector,
-		str-insert($selector, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($selector, '.') or
+				starts-with($selector, '#') or
+				starts-with($selector, '%'),
+			$selector,
+			str-insert($selector, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-css($value);
+		#{$selector} {
+			@include clay-css($value);
+		}
 	}
 }
 
@@ -780,22 +788,24 @@
 }
 
 @each $color, $value in $cadmin-text-theme-colors {
-	$selector: if(
-		starts-with($color, '.') or
-			starts-with($color, '#') or
-			starts-with($color, '%'),
-		$color,
-		str-insert($color, '.text-', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			str-insert($color, '.text-', 1)
+		);
 
-	#{$selector} {
-		@include clay-css($value);
-	}
+		#{$selector} {
+			@include clay-css($value);
+		}
 
-	a#{$selector} {
-		&:hover,
-		&:focus {
-			@include clay-css(map-get($value, hover));
+		a#{$selector} {
+			&:hover,
+			&:focus {
+				@include clay-css(map-get($value, hover));
+			}
 		}
 	}
 }
@@ -811,16 +821,18 @@
 }
 
 @each $key, $value in $cadmin-text-decorations {
-	$selector: if(
-		starts-with($key, '.') or
-			starts-with($key, '#') or
-			starts-with($key, '%'),
-		$key,
-		str-insert($key, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($key, '.') or
+				starts-with($key, '#') or
+				starts-with($key, '%'),
+			$key,
+			str-insert($key, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-link($value);
+		#{$selector} {
+			@include clay-link($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_alerts.scss
+++ b/packages/clay-css/src/scss/components/_alerts.scss
@@ -385,12 +385,8 @@
 			#{$selector} {
 				@include clay-alert-variant($value);
 			}
-		} @else {
-			$placeholder: if(
-				starts-with($color, '.') or starts-with($color, '#'),
-				'%#{str-slice($color, 2)}',
-				'%alert-#{$color}'
-			);
+		} @else if (starts-with($color, 'alert-')) {
+			$placeholder: '%alert-#{$color}';
 
 			#{$placeholder} {
 				@include clay-alert-variant($value);
@@ -398,6 +394,10 @@
 
 			#{$selector} {
 				@extend %alert-#{$color} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-alert-variant($value);
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/components/_aspect-ratio.scss
+++ b/packages/clay-css/src/scss/components/_aspect-ratio.scss
@@ -160,14 +160,14 @@
 
 // aspect-ratio-#-to-#
 
-@each $selector, $value in $aspect-ratio-sizes {
+@each $size, $value in $aspect-ratio-sizes {
 	@if not clay-is-map-unset($value) {
 		$selector: if(
-			starts-with($selector, '.') or
-				starts-with($selector, '#') or
-				starts-with($selector, '%'),
-			$selector,
-			str-insert($selector, '.', 1)
+			starts-with($size, '.') or
+				starts-with($size, '#') or
+				starts-with($size, '%'),
+			$size,
+			str-insert($size, '.', 1)
 		);
 
 		@if (starts-with($selector, '%')) {
@@ -181,12 +181,8 @@
 			#{$selector} {
 				@include clay-css($value);
 			}
-		} @else {
-			$placeholder: str-insert(
-				str-slice($selector, 2, str-length($selector)),
-				'%',
-				1
-			);
+		} @else if (starts-with($size, 'aspect-ratio-')) {
+			$placeholder: '%#{$size}';
 
 			#{$placeholder} {
 				@include clay-aspect-ratio(
@@ -197,6 +193,13 @@
 
 			#{$selector} {
 				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-aspect-ratio(
+					map-get($value, width),
+					map-get($value, height)
+				);
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/components/_badges.scss
+++ b/packages/clay-css/src/scss/components/_badges.scss
@@ -109,23 +109,31 @@
 
 @each $color, $value in $badge-palette {
 	@if not clay-is-map-unset($value) {
+		$deprecated-keys: 'primary', 'secondary', 'success', 'info', 'warning',
+			'danger', 'dark', 'light';
+
 		$selector: if(
-			starts-with($color, '.') or
-				starts-with($color, '#') or
-				starts-with($color, '%'),
-			$color,
-			if(
-				starts-with($color, 'badge'),
-				str-insert($color, '.', 1),
-				str-insert($color, '.badge-', 1)
-			)
+			index($deprecated-keys, '#{$color}') != null,
+			str-insert($color, '.badge-', 1),
+			if
+				(
+					starts-with($color, 'badge'),
+					str-insert($color, '.', 1),
+					$color
+				)
 		);
 
 		@if (starts-with($color, '%') or map-get($value, extend)) {
 			#{$selector} {
 				@include clay-badge-variant($value);
 			}
-		} @else {
+		} @else if
+			(
+				starts-with($color, 'badge') or
+					index($deprecated-keys, '#{$color}') !=
+					null
+			)
+		{
 			$placeholder: if(
 				starts-with($color, '.') or starts-with($color, '#'),
 				'%#{str-slice($color, 2)}',
@@ -138,6 +146,10 @@
 
 			#{$selector} {
 				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-badge-variant($value);
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -30,12 +30,8 @@ fieldset:disabled a.btn {
 			#{$selector} {
 				@include clay-button-variant($value);
 			}
-		} @else {
-			$placeholder: if(
-				starts-with($size, 'btn-'),
-				'%clay-#{$size}',
-				'%#{str-slice($size, 2)}'
-			);
+		} @else if (starts-with($size, 'btn-')) {
+			$placeholder: '%clay-#{$size}';
 
 			#{$placeholder} {
 				@include clay-button-variant($value);
@@ -43,6 +39,10 @@ fieldset:disabled a.btn {
 
 			#{$selector} {
 				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-button-variant($value);
 			}
 		}
 	}
@@ -97,12 +97,8 @@ input[type='button'] {
 			#{$selector} {
 				@include clay-button-variant($value);
 			}
-		} @else {
-			$placeholder: if(
-				starts-with($size, 'btn-monospaced'),
-				'%clay-#{$size}',
-				'%#{str-slice($size, 2)}'
-			);
+		} @else if (starts-with($size, 'btn-monospaced')) {
+			$placeholder: '%clay-#{$size}';
 
 			#{$placeholder} {
 				@include clay-button-variant($value);
@@ -110,6 +106,10 @@ input[type='button'] {
 
 			#{$selector} {
 				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-button-variant($value);
 			}
 		}
 	}
@@ -135,7 +135,7 @@ input[type='button'] {
 			#{$selector} {
 				@include clay-button-variant($value);
 			}
-		} @else {
+		} @else if (starts-with($color, 'btn-')) {
 			$placeholder: '%#{str-slice($selector, 2)}';
 
 			$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
@@ -150,6 +150,10 @@ input[type='button'] {
 
 			#{$placeholder-focus} {
 				@include clay-button-variant(map-get($value, focus));
+			}
+		} @else {
+			#{$selector} {
+				@include clay-button-variant($value);
 			}
 		}
 	}
@@ -175,7 +179,7 @@ input[type='button'] {
 			#{$selector} {
 				@include clay-button-variant($value);
 			}
-		} @else {
+		} @else if (starts-with($color, 'btn-outline')) {
 			$placeholder: '%#{str-slice($selector, 2)}';
 
 			$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
@@ -190,6 +194,10 @@ input[type='button'] {
 
 			#{$placeholder-focus} {
 				@include clay-button-variant(map-get($value, focus));
+			}
+		} @else {
+			#{$selector} {
+				@include clay-button-variant($value);
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -297,14 +297,16 @@ select.form-control[multiple] {
 // Form Control Select Variants
 
 @each $key, $value in $form-control-select-palette {
-	$selector: if(
-		starts-with($key, '.') or starts-with($key, '#'),
-		$key,
-		str-insert($key, '.', 1)
-	);
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($key, '.') or starts-with($key, '#'),
+			$key,
+			str-insert($key, '.', 1)
+		);
 
-	#{$selector} {
-		@include clay-select-variant($value);
+		#{$selector} {
+			@include clay-select-variant($value);
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_labels.scss
+++ b/packages/clay-css/src/scss/components/_labels.scss
@@ -88,26 +88,22 @@
 
 // Label Sizes
 
-@each $selector, $value in $label-sizes {
+@each $size, $value in $label-sizes {
 	@if not clay-is-map-unset($value) {
 		$selector: if(
-			starts-with($selector, '.') or
-				starts-with($selector, '#') or
-				starts-with($selector, '%'),
-			$selector,
-			str-insert($selector, '.', 1)
+			starts-with($size, '.') or
+				starts-with($size, '#') or
+				starts-with($size, '%'),
+			$size,
+			str-insert($size, '.', 1)
 		);
 
-		@if (starts-with($selector, '%') or map-get($value, extend)) {
+		@if (starts-with($size, '%') or map-get($value, extend)) {
 			#{$selector} {
 				@include clay-label-variant($value);
 			}
-		} @else {
-			$placeholder: if(
-				starts-with($selector, '.') or starts-with($selector, '#'),
-				'%#{str-slice($selector, 2)}',
-				'%#{$selector}'
-			);
+		} @else if (starts-with($size, 'label-')) {
+			$placeholder: '%#{size}';
 
 			#{$placeholder} {
 				@include clay-label-variant($value);
@@ -115,6 +111,10 @@
 
 			#{$selector} {
 				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-label-variant($value);
 			}
 		}
 	}
@@ -124,6 +124,9 @@
 
 @each $color, $value in $label-palette {
 	@if not clay-is-map-unset($value) {
+		$deprecated-keys: 'primary', 'secondary', 'success', 'info', 'warning',
+			'danger', 'dark', 'light';
+
 		$selector: if(
 			starts-with($color, '.') or
 				starts-with($color, '#') or
@@ -136,12 +139,14 @@
 			#{$selector} {
 				@include clay-label-variant($value);
 			}
-		} @else {
-			$placeholder: if(
-				starts-with($color, '.') or starts-with($color, '#'),
-				'%#{str-slice($color, 2)}',
-				'%label-#{$color}'
-			);
+		} @else if
+			(
+				starts-with($color, 'inverse-') or
+					index($deprecated-keys, '#{$color}') !=
+					null
+			)
+		{
+			$placeholder: '%label-#{$color}';
 
 			#{$placeholder} {
 				@include clay-label-variant($value);
@@ -149,6 +154,10 @@
 
 			#{$selector} {
 				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-label-variant($value);
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/components/_modals.scss
+++ b/packages/clay-css/src/scss/components/_modals.scss
@@ -491,7 +491,16 @@
 
 @each $color, $value in $modal-palette {
 	@if not clay-is-map-unset($value) {
-		.modal-#{$color} {
+		$deprecated-keys: 'primary', 'secondary', 'success', 'info', 'warning',
+			'danger', 'dark', 'light';
+
+		$selector: if(
+			index($deprecated-keys, '#{$color}') != null,
+			str-insert($color, '.modal-', 1),
+			$color
+		);
+
+		#{$selector} {
 			@include clay-modal-variant($value);
 		}
 	}

--- a/packages/clay-css/src/scss/components/_stickers.scss
+++ b/packages/clay-css/src/scss/components/_stickers.scss
@@ -53,26 +53,22 @@
 
 // Sticker Sizes
 
-@each $selector, $value in $sticker-sizes {
+@each $size, $value in $sticker-sizes {
 	@if not clay-is-map-unset($value) {
 		$selector: if(
-			starts-with($selector, '.') or
-				starts-with($selector, '#') or
-				starts-with($selector, '%'),
-			$selector,
-			str-insert($selector, '.', 1)
+			starts-with($size, '.') or
+				starts-with($size, '#') or
+				starts-with($size, '%'),
+			$size,
+			str-insert($size, '.', 1)
 		);
 
-		@if (starts-with($selector, '%') or map-get($value, extend)) {
+		@if (starts-with($size, '%') or map-get($value, extend)) {
 			#{$selector} {
 				@include clay-sticker-variant($value);
 			}
-		} @else {
-			$placeholder: if(
-				starts-with($selector, '.') or starts-with($selector, '#'),
-				'%#{str-slice($selector, 2)}',
-				'%#{$selector}'
-			);
+		} @else if(starts-with($size, 'sticker-')) {
+			$placeholder: '%#{$size}';
 
 			#{$placeholder} {
 				@include clay-sticker-variant($value);
@@ -80,6 +76,10 @@
 
 			#{$selector} {
 				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-sticker-variant($value);
 			}
 		}
 	}
@@ -89,6 +89,9 @@
 
 @each $color, $value in $sticker-palette {
 	@if not clay-is-map-unset($value) {
+		$deprecated-keys: 'primary', 'secondary', 'success', 'info', 'warning',
+			'danger', 'dark', 'light';
+
 		$selector: if(
 			starts-with($color, '.') or
 				starts-with($color, '#') or
@@ -101,12 +104,8 @@
 			#{$selector} {
 				@include clay-sticker-variant($value);
 			}
-		} @else {
-			$placeholder: if(
-				starts-with($color, '.') or starts-with($color, '#'),
-				'%#{str-slice($color, 2)}',
-				'%sticker-#{$color}'
-			);
+		} @else if (index($deprecated-keys, '#{$color}') != null) {
+			$placeholder: '%sticker-#{$color}';
 
 			#{$placeholder} {
 				@include clay-sticker-variant($value);
@@ -114,6 +113,10 @@
 
 			#{$selector} {
 				@extend #{$placeholder} !optional;
+			}
+		} @else {
+			#{$selector} {
+				@include clay-sticker-variant($value);
 			}
 		}
 	}


### PR DESCRIPTION
fixes #5503

I wrote the issue only for buttons, but there are several places where we do this. This pr will only generate Sass placeholders for certain key names.

```
primary,
secondary,
success,
info,
warning,
danger,
dark,
light
btn-,
label-,
sticker-,
etc
```

Key names such as, `'.btn.btn-dialect'` will only generate the selector and won't encounter the Sass can't extend complex selectors error. There are a couple minor fixes I missed in previous prs.