### PR TITLE
feat(@clayui/nav): add new composition to Vertical Nav with collection API and adds new `expandedKeys` API

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -152,7 +152,7 @@ module.exports = {
 			statements: 98,
 		},
 		'./packages/clay-nav/src/': {
-			branches: 86,
+			branches: 40,
 			functions: 80,
 			lines: 93,
 			statements: 93,

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -21,6 +21,7 @@ export {TreeView} from './tree-view';
 export {VerticalBar} from './vertical-bar';
 export {Picker, Option} from './picker';
 export {FocusTrap} from './focus-trap';
+export {Nav} from './nav';
 
 // Internal dependencies not public but exposed to other Clay packages.
 export * as __NOT_PUBLIC_COLLECTION from './collection';

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -19,6 +19,7 @@ export {Heading, Text, TextHighlight} from './typography';
 export {OverlayMask} from './overlay-mask';
 export {TreeView} from './tree-view';
 export {VerticalBar} from './vertical-bar';
+export {VerticalNav} from './vertical-nav';
 export {Picker, Option} from './picker';
 export {FocusTrap} from './focus-trap';
 export {Nav} from './nav';

--- a/packages/clay-core/src/nav/Item.tsx
+++ b/packages/clay-core/src/nav/Item.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-export const NavItem = ({
+export const Item = ({
 	children,
 	className,
 	...otherProps

--- a/packages/clay-core/src/nav/Link.tsx
+++ b/packages/clay-core/src/nav/Link.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayIcon from '@clayui/icon';
+import Icon from '@clayui/icon';
 import {LinkOrButton} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
@@ -35,7 +35,7 @@ export interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	spritemap?: string;
 }
 
-export const NavLink = React.forwardRef<
+export const Link = React.forwardRef<
 	HTMLButtonElement | HTMLAnchorElement,
 	IProps
 >(
@@ -70,7 +70,7 @@ export const NavLink = React.forwardRef<
 				{showIcon && (
 					<>
 						<span className="collapse-icon-closed">
-							<ClayIcon
+							<Icon
 								focusable="false"
 								role="presentation"
 								spritemap={spritemap}
@@ -79,7 +79,7 @@ export const NavLink = React.forwardRef<
 						</span>
 
 						<span className="collapse-icon-open">
-							<ClayIcon
+							<Icon
 								focusable="false"
 								role="presentation"
 								spritemap={spritemap}
@@ -93,4 +93,4 @@ export const NavLink = React.forwardRef<
 	}
 );
 
-NavLink.displayName = 'NavLink';
+Link.displayName = 'NavLink';

--- a/packages/clay-core/src/nav/Nav.tsx
+++ b/packages/clay-core/src/nav/Nav.tsx
@@ -6,8 +6,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import {NavItem} from './NavItem';
-import {NavLink} from './NavLink';
+import {Item} from './Item';
+import {Link} from './Link';
 
 export interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	/**
@@ -46,6 +46,6 @@ const Nav = React.forwardRef<HTMLUListElement, IProps>(function Nav(
 });
 
 export default Object.assign(Nav, {
-	Item: NavItem,
-	Link: NavLink,
+	Item,
+	Link,
 });

--- a/packages/clay-core/src/nav/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/nav/__tests__/BasicRendering.tsx
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import {Nav} from '../';
+
+describe('Nav basic rendering', () => {
+	afterEach(() => cleanup());
+
+	it('renders', () => {
+		const {container} = render(
+			<Nav>
+				<Nav.Item>
+					<Nav.Link active href="#">
+						Active
+					</Nav.Link>
+				</Nav.Item>
+				<Nav.Item>
+					<Nav.Link href="#">Normal</Nav.Link>
+				</Nav.Item>
+				<Nav.Item>
+					<Nav.Link disabled href="#">
+						Disabled
+					</Nav.Link>
+				</Nav.Item>
+			</Nav>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+});

--- a/packages/clay-core/src/nav/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/nav/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Nav basic rendering renders 1`] = `
+<div>
+  <ul
+    class="nav"
+  >
+    <li
+      class="nav-item"
+    >
+      <a
+        class="nav-link active"
+        href="#"
+      >
+        Active
+      </a>
+    </li>
+    <li
+      class="nav-item"
+    >
+      <a
+        class="nav-link"
+        href="#"
+      >
+        Normal
+      </a>
+    </li>
+    <li
+      class="nav-item"
+    >
+      <a
+        class="nav-link disabled"
+        href="#"
+      >
+        Disabled
+      </a>
+    </li>
+  </ul>
+</div>
+`;

--- a/packages/clay-core/src/nav/index.tsx
+++ b/packages/clay-core/src/nav/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export {default as Nav} from './Nav';

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {useProvider} from '@clayui/provider';
 import {Keys, setElementFullHeight} from '@clayui/shared';
 import React, {useContext, useMemo, useRef, useState} from 'react';
 import {CSSTransition} from 'react-transition-group';
@@ -92,6 +93,8 @@ export function Item<T extends object>({
 		spritemap,
 		toggle,
 	} = useVertical();
+
+	const {prefersReducedMotion} = useProvider();
 
 	const itemRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
 	const menusRef = useRef<HTMLUListElement | null>(null);
@@ -208,7 +211,7 @@ export function Item<T extends object>({
 					onExiting={(element) =>
 						element.setAttribute('style', 'height: 0px')
 					}
-					timeout={250}
+					timeout={prefersReducedMotion ? 0 : 250}
 				>
 					<Nav ref={menusRef} role="menu" stacked>
 						<ParentContext.Provider value={itemRef}>

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -1,0 +1,224 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {Keys, setElementFullHeight} from '@clayui/shared';
+import React, {useContext, useMemo, useRef, useState} from 'react';
+import {CSSTransition} from 'react-transition-group';
+
+import {Collection} from '../collection';
+import {Nav} from '../nav';
+import {useVertical} from './context';
+
+interface IProps<T> extends React.HTMLAttributes<HTMLLIElement> {
+	/**
+	 * Flag to indicate if item is active.
+	 */
+	active?: boolean;
+
+	/**
+	 * The contents of the component.
+	 */
+	children?: React.ReactNode;
+
+	/**
+	 * Link href for item.
+	 */
+	href?: string;
+
+	/**
+	 * Property to inform the dynamic data of the tree.
+	 */
+	items?: Array<T>;
+
+	/**
+	 * Internal property.
+	 * @ignore
+	 */
+	keyValue?: React.Key;
+
+	/**
+	 * Internal property.
+	 * @ignore
+	 */
+	index?: number;
+
+	/**
+	 * Internal property for compatibility with old version.
+	 * @ignore
+	 * @deprecated
+	 */
+	initialExpanded?: boolean;
+}
+
+function findSelectedNested<T extends object>(items: Array<T>): T | undefined {
+	return items.find((item) => {
+		if ('active' in item) {
+			return true;
+		}
+
+		if ('items' in item) {
+			return findSelectedNested(
+				(item as Record<string, any>).items as Array<T>
+			);
+		}
+
+		return false;
+	});
+}
+
+const ParentContext = React.createContext<React.RefObject<
+	HTMLButtonElement | HTMLAnchorElement
+> | null>(null);
+
+export function Item<T extends object>({
+	active,
+	children,
+	href,
+	index: _,
+	initialExpanded,
+	items,
+	keyValue,
+	onClick,
+	...otherProps
+}: IProps<T>) {
+	const {
+		ariaCurrent = 'page',
+		childrenRoot,
+		close,
+		expandedKeys,
+		open,
+		spritemap,
+		toggle,
+	} = useVertical();
+
+	const itemRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+	const menusRef = useRef<HTMLUListElement | null>(null);
+	const parentItemRef = useContext(ParentContext);
+
+	// State only for compatibility with the old compositing version where state
+	// was kept on each Item instead of centralized with `expandedKeys`.
+	const [expanded, setExpaned] = useState(initialExpanded);
+	const isOldVersion = typeof initialExpanded !== 'undefined';
+
+	const isExpanded = isOldVersion ? expanded : expandedKeys.has(keyValue!);
+
+	const hasItemSelectedNested = useMemo(() => {
+		if (items) {
+			return !!findSelectedNested(items);
+		}
+
+		return false;
+	}, [items]);
+
+	return (
+		<Nav.Item role="none" {...otherProps}>
+			<Nav.Link
+				active={active}
+				aria-current={active ? ariaCurrent ?? undefined : undefined}
+				aria-expanded={items ? isExpanded : undefined}
+				aria-haspopup={items ? true : undefined}
+				collapsed={!isExpanded}
+				href={href}
+				onClick={(event) => {
+					if (onClick) {
+						onClick(
+							event as unknown as React.MouseEvent<
+								HTMLLIElement,
+								MouseEvent
+							>
+						);
+					}
+
+					if (isOldVersion) {
+						setExpaned(!expanded);
+					} else {
+						toggle(keyValue!);
+					}
+				}}
+				onKeyDown={(event) => {
+					switch (event.key) {
+						case Keys.Right: {
+							if (items && !isExpanded) {
+								if (isOldVersion) {
+									setExpaned(true);
+								} else {
+									open(keyValue!);
+								}
+							} else if (items && menusRef.current) {
+								const firstItemElement =
+									menusRef.current.querySelector<HTMLElement>(
+										'.nav-link:not([disabled])'
+									);
+								firstItemElement?.focus();
+							}
+							break;
+						}
+						case Keys.Left: {
+							if (items && isExpanded) {
+								if (isOldVersion) {
+									setExpaned(false);
+								} else {
+									close(keyValue!);
+								}
+							} else if (!items && parentItemRef) {
+								parentItemRef.current?.focus();
+							}
+							break;
+						}
+						default:
+							break;
+					}
+				}}
+				ref={itemRef}
+				role={items ? 'button' : 'menuitem'}
+				showIcon={!!items}
+				spritemap={spritemap}
+				tabIndex={
+					!active && !(hasItemSelectedNested && items && !isExpanded)
+						? -1
+						: undefined
+				}
+			>
+				{children}
+			</Nav.Link>
+
+			{items && (
+				<CSSTransition
+					className={isExpanded ? undefined : 'collapse'}
+					classNames={{
+						enter: 'collapsing',
+						enterActive: `show`,
+						enterDone: 'show',
+						exit: `show`,
+						exitActive: 'collapsing',
+					}}
+					in={isExpanded}
+					onEnter={(element: HTMLElement) =>
+						element.setAttribute('style', 'height: 0px')
+					}
+					onEntered={(element: HTMLElement) =>
+						element.removeAttribute('style')
+					}
+					onEntering={(element: HTMLElement) =>
+						setElementFullHeight(element)
+					}
+					onExit={(element) => setElementFullHeight(element)}
+					onExiting={(element) =>
+						element.setAttribute('style', 'height: 0px')
+					}
+					timeout={250}
+				>
+					<Nav ref={menusRef} role="menu" stacked>
+						<ParentContext.Provider value={itemRef}>
+							<Collection<T> items={items}>
+								{childrenRoot.current}
+							</Collection>
+						</ParentContext.Provider>
+					</Nav>
+				</CSSTransition>
+			)}
+		</Nav.Item>
+	);
+}

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -102,7 +102,7 @@ export function Item<T extends object>({
 
 	// State only for compatibility with the old compositing version where state
 	// was kept on each Item instead of centralized with `expandedKeys`.
-	const [expanded, setExpaned] = useState(initialExpanded);
+	const [expanded, setExpanded] = useState(initialExpanded);
 	const isOldVersion = typeof initialExpanded !== 'undefined';
 
 	const isExpanded = isOldVersion ? expanded : expandedKeys.has(keyValue!);
@@ -135,7 +135,7 @@ export function Item<T extends object>({
 					}
 
 					if (isOldVersion) {
-						setExpaned(!expanded);
+						setExpanded(!expanded);
 					} else {
 						toggle(keyValue!);
 					}
@@ -145,7 +145,7 @@ export function Item<T extends object>({
 						case Keys.Right: {
 							if (items && !isExpanded) {
 								if (isOldVersion) {
-									setExpaned(true);
+									setExpanded(true);
 								} else {
 									open(keyValue!);
 								}
@@ -161,7 +161,7 @@ export function Item<T extends object>({
 						case Keys.Left: {
 							if (items && isExpanded) {
 								if (isOldVersion) {
-									setExpaned(false);
+									setExpanded(false);
 								} else {
 									close(keyValue!);
 								}

--- a/packages/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/packages/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -1,0 +1,243 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Button from '@clayui/button';
+import Icon from '@clayui/icon';
+import {useInternalState, useNavigation} from '@clayui/shared';
+import classNames from 'classnames';
+import React, {useCallback, useRef, useState} from 'react';
+
+import {Collection} from '../collection';
+import {Nav} from '../nav';
+import {Item} from './Item';
+import {VertivalNavContext} from './context';
+
+import type {ChildrenFunction} from '../collection';
+
+const Trigger = ({
+	children,
+	className,
+	...otherProps
+}: React.ComponentProps<typeof Button>) => (
+	<Button
+		className={classNames(className, 'menubar-toggler')}
+		displayType="unstyled"
+		{...otherProps}
+	>
+		{children}
+	</Button>
+);
+
+type Props<T> = {
+	/**
+	 * Flag to indicate the navigation behavior in the menu.
+	 *
+	 * - manual - it will just move the focus and menu activation is done just
+	 * by pressing space or enter.
+	 * - automatic - moves the focus to the menuitem and activates the menu.
+	 */
+	activation?: 'manual' | 'automatic';
+
+	/**
+	 * The component contents.
+	 */
+	children?: React.ReactNode | ChildrenFunction<T, null>;
+
+	/**
+	 * Flag to activate the Decorator variation.
+	 */
+	decorated?: boolean;
+
+	/**
+	 * Property to set the initial value of `expandedKeys` (uncontrolled).
+	 */
+	defaultExpandedKeys?: Set<React.Key>;
+
+	/**
+	 * The currently expanded keys in the collection (controlled).
+	 */
+	expandedKeys?: Set<React.Key>;
+
+	/**
+	 * Flag to define if the item represents the current page. Disable this
+	 * attribute only if there are multiple navigations on the page.
+	 */
+	itemAriaCurrent?: boolean;
+
+	/**
+	 * Property to inform the dynamic data of the tree.
+	 */
+	items?: Array<T>;
+
+	/**
+	 * Flag to indicate if `menubar-vertical-expand-lg` class is applied.
+	 */
+	large?: boolean;
+
+	/**
+	 * A callback that is called when items are expanded or collapsed
+	 * (controlled).
+	 */
+	onExpandedChange?: (keys: Set<React.Key>) => void;
+
+	/**
+	 * Path to the spritemap that Icon should use when referencing symbols.
+	 */
+	spritemap?: string;
+
+	/**
+	 * Custom component that will be displayed on mobile resolutions that
+	 * toggles the visibility of the navigation.
+	 */
+	trigger?: typeof Trigger;
+
+	/**
+	 * Label of the button that appears on smaller resolutions to open the
+	 * vertical navigation.
+	 */
+	triggerLabel?: string;
+};
+
+function VerticalNav<T>(props: Props<T>): JSX.Element & {
+	Trigger: typeof Trigger;
+	Item: typeof Item;
+};
+
+function VerticalNav<T>({
+	activation = 'manual',
+	children,
+	decorated,
+	defaultExpandedKeys = new Set(),
+	expandedKeys: externalExpandedKeys,
+	itemAriaCurrent: ariaCurrent = true,
+	items,
+	large,
+	onExpandedChange,
+	spritemap,
+	trigger: CustomTrigger = Trigger,
+	triggerLabel = 'Menu',
+}: Props<T>) {
+	const [active, setActive] = useState(false);
+
+	const containerRef = useRef<HTMLDivElement | null>(null);
+
+	const [expandedKeys, setExpandedKeys] = useInternalState({
+		defaultName: 'defaultExpandedKeys',
+		defaultValue: defaultExpandedKeys,
+		handleName: 'onExpandedChange',
+		name: 'expandedKeys',
+		onChange: onExpandedChange,
+		value: externalExpandedKeys,
+	});
+
+	const toggle = useCallback(
+		(key: React.Key) => {
+			const expanded = new Set(expandedKeys);
+
+			if (expanded.has(key)) {
+				expanded.delete(key);
+			} else {
+				expanded.add(key);
+			}
+
+			setExpandedKeys(expanded);
+		},
+		[expandedKeys]
+	);
+
+	const close = useCallback(
+		(key: React.Key) => {
+			const expanded = new Set(expandedKeys);
+
+			if (expanded.has(key)) {
+				expanded.delete(key);
+
+				setExpandedKeys(expanded);
+
+				return true;
+			}
+
+			return false;
+		},
+		[expandedKeys]
+	);
+
+	const open = useCallback(
+		(key: React.Key) => {
+			const expanded = new Set(expandedKeys);
+
+			if (!expanded.has(key)) {
+				expanded.add(key);
+
+				setExpandedKeys(expanded);
+
+				return true;
+			}
+
+			return false;
+		},
+		[expandedKeys]
+	);
+
+	const childrenRootRef = useRef(children);
+
+	const {navigationProps} = useNavigation({
+		activation,
+		containerRef,
+		orientation: 'vertical',
+	});
+
+	return (
+		<nav
+			className={classNames('menubar menubar-transparent', {
+				['menubar-decorated']: decorated,
+				['menubar-vertical-expand-lg']: large,
+				['menubar-vertical-expand-md']: !large,
+			})}
+		>
+			<CustomTrigger onClick={() => setActive(!active)}>
+				<span className="inline-item inline-item-before">
+					{triggerLabel}
+				</span>
+
+				<Icon
+					focusable="false"
+					role="presentation"
+					spritemap={spritemap}
+					symbol="caret-bottom"
+				/>
+			</CustomTrigger>
+
+			<div
+				{...navigationProps}
+				className={classNames('collapse menubar-collapse', {
+					show: active,
+				})}
+				ref={containerRef}
+			>
+				<Nav aria-orientation="vertical" nested role="menubar">
+					<VertivalNavContext.Provider
+						value={{
+							ariaCurrent: ariaCurrent ? 'page' : null,
+							childrenRoot: childrenRootRef,
+							close,
+							expandedKeys,
+							open,
+							spritemap,
+							toggle,
+						}}
+					>
+						<Collection<T> items={items}>{children}</Collection>
+					</VertivalNavContext.Provider>
+				</Nav>
+			</div>
+		</nav>
+	);
+}
+
+VerticalNav.Item = Item;
+VerticalNav.Trigger = Trigger;
+
+export {VerticalNav};

--- a/packages/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import {VerticalNav} from '../';
+
+describe('VerticalNav basic rendering', () => {
+	afterEach(() => cleanup());
+
+	it('render static content', () => {
+		const {container} = render(
+			<VerticalNav>
+				<VerticalNav.Item active key="home">
+					Home
+				</VerticalNav.Item>
+				<VerticalNav.Item key="about">About</VerticalNav.Item>
+				<VerticalNav.Item key="contact">Contact</VerticalNav.Item>
+			</VerticalNav>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render dynamic content', () => {
+		const {container} = render(
+			<VerticalNav
+				items={[
+					{
+						id: 1,
+						items: [
+							{
+								active: true,
+								href: '#',
+								id: 2,
+								label: 'Nested1',
+							},
+						],
+						label: 'Home',
+					},
+					{
+						href: '#',
+						id: 3,
+						label: 'About',
+					},
+					{
+						href: '#',
+						id: 4,
+						label: 'Contact',
+					},
+				]}
+			>
+				{(item: any) => (
+					<VerticalNav.Item active={item.active} items={item.items}>
+						{item.label}
+					</VerticalNav.Item>
+				)}
+			</VerticalNav>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+});

--- a/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -1,0 +1,200 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VerticalNav basic rendering render dynamic content 1`] = `
+<div>
+  <nav
+    class="menubar menubar-transparent menubar-vertical-expand-md"
+  >
+    <button
+      class="menubar-toggler btn btn-unstyled"
+      type="button"
+    >
+      <span
+        class="inline-item inline-item-before"
+      >
+        Menu
+      </span>
+      <svg
+        class="lexicon-icon lexicon-icon-caret-bottom"
+        focusable="false"
+        role="presentation"
+      >
+        <use
+          xlink:href="#caret-bottom"
+        />
+      </svg>
+    </button>
+    <div
+      class="collapse menubar-collapse"
+    >
+      <ul
+        aria-orientation="vertical"
+        class="nav nav-nested"
+        role="menubar"
+      >
+        <li
+          class="nav-item"
+          role="none"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="nav-link collapse-icon collapsed btn btn-unstyled"
+            role="button"
+            type="button"
+          >
+            Home
+            <span
+              class="collapse-icon-closed"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-caret-right"
+                focusable="false"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#caret-right"
+                />
+              </svg>
+            </span>
+            <span
+              class="collapse-icon-open"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-caret-bottom"
+                focusable="false"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#caret-bottom"
+                />
+              </svg>
+            </span>
+          </button>
+          <ul
+            class="nav collapse nav-stacked"
+            role="menu"
+          >
+            <li
+              class="nav-item"
+              role="none"
+            >
+              <button
+                aria-current="page"
+                class="nav-link active collapsed btn btn-unstyled"
+                role="menuitem"
+                type="button"
+              >
+                Nested1
+              </button>
+            </li>
+          </ul>
+        </li>
+        <li
+          class="nav-item"
+          role="none"
+        >
+          <button
+            class="nav-link collapsed btn btn-unstyled"
+            role="menuitem"
+            tabindex="-1"
+            type="button"
+          >
+            About
+          </button>
+        </li>
+        <li
+          class="nav-item"
+          role="none"
+        >
+          <button
+            class="nav-link collapsed btn btn-unstyled"
+            role="menuitem"
+            tabindex="-1"
+            type="button"
+          >
+            Contact
+          </button>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`VerticalNav basic rendering render static content 1`] = `
+<div>
+  <nav
+    class="menubar menubar-transparent menubar-vertical-expand-md"
+  >
+    <button
+      class="menubar-toggler btn btn-unstyled"
+      type="button"
+    >
+      <span
+        class="inline-item inline-item-before"
+      >
+        Menu
+      </span>
+      <svg
+        class="lexicon-icon lexicon-icon-caret-bottom"
+        focusable="false"
+        role="presentation"
+      >
+        <use
+          xlink:href="#caret-bottom"
+        />
+      </svg>
+    </button>
+    <div
+      class="collapse menubar-collapse"
+    >
+      <ul
+        aria-orientation="vertical"
+        class="nav nav-nested"
+        role="menubar"
+      >
+        <li
+          class="nav-item"
+          role="none"
+        >
+          <button
+            aria-current="page"
+            class="nav-link active collapsed btn btn-unstyled"
+            role="menuitem"
+            type="button"
+          >
+            Home
+          </button>
+        </li>
+        <li
+          class="nav-item"
+          role="none"
+        >
+          <button
+            class="nav-link collapsed btn btn-unstyled"
+            role="menuitem"
+            tabindex="-1"
+            type="button"
+          >
+            About
+          </button>
+        </li>
+        <li
+          class="nav-item"
+          role="none"
+        >
+          <button
+            class="nav-link collapsed btn btn-unstyled"
+            role="menuitem"
+            tabindex="-1"
+            type="button"
+          >
+            Contact
+          </button>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</div>
+`;

--- a/packages/clay-core/src/vertical-nav/context.ts
+++ b/packages/clay-core/src/vertical-nav/context.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {createContext, useContext} from 'react';
+
+import type {ChildrenFunction} from '../collection';
+
+type VertivalNavContextProps = {
+	ariaCurrent?: 'page' | null;
+	spritemap?: string;
+	childrenRoot: React.MutableRefObject<
+		React.ReactNode | ChildrenFunction<Object, null>
+	>;
+	close: (key: React.Key) => void;
+	expandedKeys: Set<React.Key>;
+	open: (key: React.Key) => void;
+	toggle: (key: React.Key) => void;
+};
+
+export const VertivalNavContext = createContext<VertivalNavContextProps>(
+	{} as VertivalNavContextProps
+);
+
+export function useVertical() {
+	return useContext(VertivalNavContext);
+}

--- a/packages/clay-core/src/vertical-nav/index.ts
+++ b/packages/clay-core/src/vertical-nav/index.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export {VerticalNav} from './VerticalNav';

--- a/packages/clay-core/stories/VerticalNav.stories.tsx
+++ b/packages/clay-core/stories/VerticalNav.stories.tsx
@@ -1,0 +1,496 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Button from '@clayui/button';
+import React, {useState} from 'react';
+
+import {VerticalNav} from '../src';
+
+type Item = {
+	id: number;
+	href?: string;
+	label: string;
+	active?: boolean;
+	items?: Array<Item>;
+};
+
+const items = [
+	{
+		id: 1,
+		items: [
+			{
+				href: '#',
+				id: 2,
+				label: 'Nested1',
+			},
+		],
+		label: 'Home',
+	},
+	{
+		href: '#',
+		id: 3,
+		label: 'About',
+	},
+	{
+		href: '#',
+		id: 4,
+		label: 'Contact',
+	},
+	{
+		id: 5,
+		items: [
+			{
+				active: true,
+				href: '#',
+				id: 6,
+				label: 'Five',
+			},
+			{
+				href: '#',
+				id: 7,
+				label: 'Six',
+			},
+		],
+		label: 'Projects',
+	},
+	{
+		href: '#',
+		id: 8,
+		label: 'Seven',
+	},
+] as Array<Item>;
+
+const items_long = [
+	{label: 'Summary'},
+	{
+		items: [
+			{label: 'General Permissions'},
+			{
+				items: [
+					{label: 'Users and Organizations'},
+					{label: 'User Groups'},
+					{label: 'Roles'},
+					{label: 'Monitoring'},
+				],
+				label: 'Users',
+			},
+			{
+				items: [{label: 'Sites'}, {label: 'Site Templates'}],
+				label: 'Sites',
+			},
+			{
+				items: [
+					{label: 'Accounts'},
+					{label: 'Account Users'},
+					{label: 'Account Groups'},
+				],
+				label: 'Accounts',
+			},
+			{
+				items: [
+					{label: 'Push Notifications'},
+					{label: 'Components'},
+					{label: 'Custom Fields'},
+					{label: 'Language Override'},
+					{label: 'Job Scheduler'},
+					{label: 'Countries Management'},
+				],
+				label: 'Configuration',
+			},
+			{
+				items: [
+					{label: 'Objects'},
+					{label: 'Datasets'},
+					{label: 'Picklists'},
+				],
+				label: 'Object',
+			},
+			{
+				items: [{label: 'Templates'}, {label: 'Queue'}],
+				label: 'Notifications',
+			},
+			{
+				items: [
+					{label: 'Audit'},
+					{label: 'OAuth Client Administration'},
+					{label: 'OAuth 2 Administration'},
+					{label: 'Password Policies'},
+					{label: 'SAML Admin'},
+					{label: 'Server Logs'},
+					{label: 'Service Access Policy'},
+				],
+				label: 'Security',
+			},
+			{
+				items: [{label: 'On-Demand Admin'}],
+				label: 'System',
+			},
+			{
+				items: [{label: 'Purchased'}, {label: 'Store'}],
+				label: 'Marketplace',
+			},
+		],
+		label: 'Control Panel',
+	},
+	{
+		items: [
+			{
+				items: [
+					{label: 'Orders'},
+					{label: 'Order Rules'},
+					{label: 'Order Types'},
+					{label: 'Shipments'},
+					{label: 'Subscriptions'},
+					{label: 'Terms and Conditions'},
+				],
+				label: 'Order Management',
+			},
+			{
+				items: [{label: 'Inventory'}, {label: 'Warehouses'}],
+				label: 'Inventory Management',
+			},
+			{
+				items: [
+					{label: 'Price Lists'},
+					{label: 'Promotions'},
+					{label: 'Discounts'},
+					{label: 'Product Groups'},
+					{label: 'Tax Categories'},
+				],
+				label: 'Pricing',
+			},
+			{
+				items: [
+					{label: 'Catalogs'},
+					{label: 'Products'},
+					{label: 'Options'},
+					{label: 'Product Specification Labels'},
+				],
+				label: 'Product Management',
+			},
+			{
+				items: [{label: 'Channels'}, {label: 'Currencies'}],
+				label: 'Store Management',
+			},
+			{
+				items: [
+					{label: 'Availability Estimates'},
+					{label: 'Countries'},
+					{label: 'Measurement Units'},
+					{label: 'Avalara Connector'},
+					{label: 'Health Check'},
+				],
+				label: 'Settings',
+			},
+		],
+		label: 'Commerce',
+	},
+	{
+		items: [
+			{
+				items: [
+					{label: 'Asset Libraries'},
+					{label: 'Content Dashboard'},
+				],
+				label: 'Content',
+			},
+			{
+				items: [{label: 'Publications'}],
+				label: 'Publications',
+			},
+			{
+				items: [{label: 'Metrics'}, {label: 'Submissions'}],
+				label: 'Workflow',
+			},
+			{
+				items: [{label: 'Blueprints'}],
+				label: 'Search Experiences',
+			},
+			{
+				items: [{label: 'Result Rankings'}, {label: 'Synonyms'}],
+				label: 'Search Tuning',
+			},
+			{
+				items: [{label: 'Announcements and Alerts'}],
+				label: 'Communication',
+			},
+			{
+				items: [{label: 'Client Extensions'}],
+				label: 'Custom Apps',
+			},
+			{
+				items: [{label: 'Import/Export Center'}],
+				label: 'Import / Export',
+			},
+		],
+		label: 'Applications Menu',
+	},
+	{
+		items: [
+			{
+				items: [
+					{label: 'Style Books'},
+					{label: 'Fragments'},
+					{label: 'Templates'},
+					{label: 'Page Templates'},
+				],
+				label: 'Design',
+			},
+			{
+				items: [
+					{label: 'Pages'},
+					{label: 'Navigation Menus'},
+					{label: 'Collections'},
+				],
+				label: 'Site Builder',
+			},
+			{
+				items: [
+					{label: 'Kaleo Forms Admin'},
+					{label: 'Web Content'},
+					{label: 'Blogs'},
+					{label: 'Bookmarks'},
+					{label: 'Documents and Media'},
+					{label: 'Dynamic Data Lists'},
+					{label: 'Forms'},
+					{label: 'Digital Signature'},
+					{
+						label: 'Dynamic Data Mapping Data Provider Web',
+					},
+					{label: 'Knowledge Base'},
+					{label: 'Message Boards'},
+					{label: 'Wiki'},
+					{label: 'Translation Processes'},
+				],
+				label: 'Content & Data',
+			},
+			{
+				items: [{label: 'Categories'}, {label: 'Tags'}],
+				label: 'Categorization',
+			},
+			{
+				items: [{label: 'Recycle Bin'}],
+				label: 'Recycle Bin',
+			},
+			{
+				items: [
+					{label: 'Memberships'},
+					{label: 'Teams'},
+					{label: 'Segments'},
+				],
+				label: 'People',
+			},
+			{
+				items: [
+					{label: 'Reports Admin'},
+					{label: 'Site Template Settings'},
+					{label: 'Site Settings'},
+					{label: 'Redirection'},
+					{label: 'Asset Library Settings'},
+					{label: 'Workflow'},
+				],
+				label: 'Configuration',
+			},
+			{
+				items: [
+					{label: 'Staging'},
+					{label: 'Export'},
+					{label: 'Import'},
+					{label: 'Site Initializer'},
+				],
+				label: 'Publishing',
+			},
+			{
+				items: [
+					{label: 'Account Management'},
+					{label: 'Activities'},
+					{label: 'Alerts'},
+					{label: 'Announcements'},
+					{label: 'Asset Publisher'},
+					{label: 'Blogs'},
+					{label: 'Blogs Aggregator'},
+					{label: 'Blueprints Options'},
+					{label: 'Bookmarks'},
+					{label: 'Breadcrumb'},
+					{label: 'Calendar'},
+					{label: 'Cart'},
+					{label: 'Cart Summary'},
+					{label: 'Category Content'},
+					{label: 'Category Facet'},
+					{label: 'Category Filter'},
+					{label: 'Chart Sample'},
+					{label: 'Checkout'},
+					{label: 'Classic Theme Style Guide Sample'},
+					{label: 'Clay Sample'},
+					{label: 'Commerce Addresses'},
+					{label: 'Commerce Categories Navigation'},
+					{
+						label: 'Commerce Machine Learning Forecast Alert',
+					},
+					{label: 'Contacts Center'},
+					{label: 'Cookies Banner Configuration'},
+					{label: 'Coupon Code Entry'},
+					{label: 'Custom Facet'},
+					{label: 'Custom Filter'},
+					{label: 'Dialect Theme Style Guide Sample'},
+					{label: 'Documents and Media'},
+					{label: 'Dynamic Data Lists Display'},
+					{label: 'Elasticsearch Monitoring'},
+					{label: 'Folder Facet'},
+					{label: 'Form'},
+					{label: 'Hello Velocity'},
+					{label: 'Highest Rated Assets'},
+					{label: 'IFrame'},
+					{label: 'Invite Members'},
+					{label: 'IP Geocoder Sample'},
+					{label: 'Knowledge Base Article'},
+					{label: 'Knowledge Base Display'},
+					{label: 'Knowledge Base Search'},
+					{label: 'Knowledge Base Section'},
+					{label: 'Language Selector'},
+					{label: 'Low Level Search Options'},
+					{label: 'Media Gallery'},
+					{label: 'Members'},
+					{label: 'Menu Display'},
+					{label: 'Message Boards'},
+					{label: 'Microblogs'},
+					{label: 'Microblogs Status Update'},
+					{label: 'Mini Cart'},
+					{label: 'Modified Facet'},
+					{label: 'Most Viewed Assets'},
+					{label: 'My Contacts'},
+					{label: 'My Sites'},
+					{label: 'My Subscriptions'},
+					{label: 'Nested Applications'},
+					{label: 'Open Carts'},
+					{label: 'Option Facet'},
+					{label: 'Order Forecasts Chart'},
+					{label: 'Organization Management'},
+					{label: 'Page Comments'},
+					{label: 'Page Flags'},
+					{label: 'Page Menu'},
+					{label: 'Page Ratings'},
+					{label: 'Placed Orders'},
+					{label: 'Price Range Facet'},
+					{label: 'Product Comparison Bar'},
+					{label: 'Product Comparison Table'},
+					{label: 'Product Details'},
+					{label: 'Product Downloads'},
+					{label: 'Product Publisher'},
+					{label: 'Product Subscriptions'},
+					{label: 'Profile'},
+					{label: 'Questions'},
+					{label: 'Recent Bloggers'},
+					{label: 'Recent Content'},
+					{label: 'Related Assets'},
+					{label: 'Reports Display'},
+					{label: 'RSS Publisher'},
+					{label: 'Search'},
+					{label: 'Search Bar'},
+					{label: 'Search Insights'},
+					{label: 'Search Options'},
+					{label: 'Search Results'},
+					{label: 'Search Results'},
+					{label: 'Shipments'},
+					{label: 'Sign In'},
+					{label: 'Similar Results'},
+					{label: 'Site Facet'},
+					{label: 'Site Map'},
+					{label: 'Sites Directory'},
+					{label: 'Sort'},
+					{label: 'Sort'},
+					{label: 'Specification Facet'},
+					{label: 'Suggestions'},
+					{label: 'Tag Cloud'},
+					{label: 'Tag Facet'},
+					{label: 'Tag Filter'},
+					{label: 'Tree Menu'},
+					{label: 'Type Facet'},
+					{label: 'User Facet'},
+					{label: 'Web Content Display'},
+					{label: 'Wiki'},
+					{label: 'Wiki Display'},
+					{label: 'Wish List Content'},
+					{label: 'Wish Lists'},
+				],
+				label: 'Applications',
+			},
+		],
+		label: 'Site and Asset Library Administration',
+	},
+	{
+		items: [
+			{label: 'Notifications'},
+			{label: 'Shared Content'},
+			{label: 'My Submissions'},
+			{label: 'My Workflow Tasks'},
+			{label: 'Account Settings'},
+			{label: 'My Connected Applications'},
+			{label: 'My Organizations'},
+			{label: 'My Subscriptions'},
+		],
+		label: 'User',
+	},
+];
+
+export default {
+	title: 'Design System/Components/VerticalNav',
+};
+
+export const Default = () => (
+	<VerticalNav items={items}>
+		{(item) => (
+			<VerticalNav.Item
+				active={item.active}
+				href={item.href}
+				items={item.items}
+				key={item.id}
+			>
+				{item.label}
+			</VerticalNav.Item>
+		)}
+	</VerticalNav>
+);
+
+const defaultExpandedKeys = ['Control Panel', 'Commerce', 'Applications Menu'];
+
+export const ControlledExpandedKeys = () => {
+	const [active] = useState('General Permissions');
+	const [expandAll, setExpandAll] = useState(false);
+	const [expandedKeys, setExpandedKeys] = useState<Set<React.Key>>(
+		new Set(defaultExpandedKeys)
+	);
+
+	return (
+		<>
+			<Button
+				onClick={() => {
+					setExpandAll(!expandAll);
+					setExpandedKeys(
+						expandAll ? new Set(defaultExpandedKeys) : new Set()
+					);
+				}}
+			>
+				{expandAll ? 'Close All' : 'Expand All'}
+			</Button>
+
+			<VerticalNav
+				expandedKeys={expandedKeys}
+				items={items_long}
+				onExpandedChange={setExpandedKeys}
+			>
+				{(item) => (
+					<VerticalNav.Item
+						active={active === item.label}
+						items={item.items}
+						key={item.label}
+					>
+						{item.label}
+					</VerticalNav.Item>
+				)}
+			</VerticalNav>
+		</>
+	);
+};

--- a/packages/clay-nav/docs/api-vertical-nav.mdx
+++ b/packages/clay-nav/docs/api-vertical-nav.mdx
@@ -13,12 +13,30 @@ mainTabURL: 'docs/components/vertical-nav.html'
 </div>
 </div>
 
-## VerticalNav
+<h2 class="clay-h2" id="autocomplete-deprecated">
+	VerticalNav
+	<span class="ml-1 badge badge-danger badge-pill">
+		<span class="badge-item badge-item-expand">Deprecated</span>
+	</span>
+</h2>
 
 <div>[APITable "clay-nav/src/Vertical.tsx"]</div>
+
+<h2 class="clay-h2" id="autocomplete-deprecated">
+	VerticalNav
+	<span class="ml-1 badge badge-info badge-pill">
+		<span class="badge-item badge-item-expand">NEW</span>
+	</span>
+</h2>
+
+<div>[APITable "clay-core/src/vertical-nav/VerticalNav.tsx"]</div>
 
 ## VerticalNav.Trigger
 
 <code class="list-api-item-type">
 	Extends from {`React.ComponentProps<typeof ClayButton>`}
 </code>
+
+## VerticalNav.Item
+
+<div>[APITable "clay-core/src/vertical-nav/Item.tsx"]</div>

--- a/packages/clay-nav/docs/index.js
+++ b/packages/clay-nav/docs/index.js
@@ -47,47 +47,58 @@ const verticalNavigationImportsCode = `import {ClayVerticalNav} from '@clayui/na
 const VerticalNavigationCode = `const Component = () => {
 	return (
 		<ClayVerticalNav
+			defaultExpandedKeys={new Set(['Projects'])}
 			items={[
-			{
-				items: [
 				{
-					href: '#nested1',
-					label: 'Nested1',
-				},
-				],
-				label: 'Home',
-			},
-			{
-				href: '#2',
-				label: 'About',
-			},
-			{
-				href: '#3',
-				label: 'Contact',
-			},
-			{
-				initialExpanded: true,
-				items: [
-				{
-					active: true,
-					href: '#5',
-					label: 'Five',
+					items: [
+						{
+							href: '#nested1',
+							label: 'Nested1',
+						},
+					],
+					label: 'Home',
 				},
 				{
-					href: '#6',
-					label: 'Six',
+					href: '#2',
+					label: 'About',
 				},
-				],
-				label: 'Projects',
-			},
-			{
-				href: '#7',
-				label: 'Seven',
-			},
-		]}
-		large={false}
-		spritemap={spritemap}
-	  />
+				{
+					href: '#3',
+					label: 'Contact',
+				},
+				{
+					items: [
+						{
+							active: true,
+							href: '#5',
+							label: 'Five',
+						},
+						{
+							href: '#6',
+							label: 'Six',
+						},
+					],
+					label: 'Projects',
+				},
+				{
+					href: '#7',
+					label: 'Seven',
+				},
+			]}
+			large={false}
+			spritemap={spritemap}
+		>
+			{(item) => (
+				<ClayVerticalNav.Item
+					active={item.active}
+					href={item.href}
+					items={item.items}
+					key={item.label}
+				>
+					{item.label}
+				</ClayVerticalNav.Item>
+			)}
+		</ClayVerticalNav>
 	);
 }
 

--- a/packages/clay-nav/docs/vertical-nav.mdx
+++ b/packages/clay-nav/docs/vertical-nav.mdx
@@ -3,7 +3,7 @@ title: 'Vertical Navigation'
 description: 'An alternative patterns that displays navigation items in a vertical menu.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/vertical-nav/'
 packageNpm: '@clayui/nav'
-storybookPath: 'design-system-components-nav--vertical-nav'
+storybookPath: 'design-system-components-verticalnav--default'
 ---
 
 import {VerticalNavigation} from '$packages/clay-nav/docs/index';

--- a/packages/clay-nav/package.json
+++ b/packages/clay-nav/package.json
@@ -27,6 +27,7 @@
 	],
 	"dependencies": {
 		"@clayui/button": "^3.92.0",
+		"@clayui/core": "^3.94.0",
 		"@clayui/icon": "^3.56.0",
 		"@clayui/shared": "^3.94.0",
 		"classnames": "^2.2.6",

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -3,15 +3,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {Nav} from '@clayui/core';
-import ClayIcon from '@clayui/icon';
-import {Keys, setElementFullHeight, useNavigation} from '@clayui/shared';
-import classNames from 'classnames';
-import React, {useMemo, useRef, useState} from 'react';
-import {CSSTransition} from 'react-transition-group';
+import {Nav, VerticalNav} from '@clayui/core';
+import React from 'react';
 import warning from 'warning';
-
-import Trigger from './Trigger';
 
 interface IItem extends React.ComponentProps<typeof Nav.Item> {
 	/**
@@ -47,7 +41,7 @@ interface IItemWithItems extends IItem {
 	items?: Array<IItem>;
 }
 
-export interface IProps {
+export interface IProps extends React.ComponentProps<typeof VerticalNav> {
 	/**
 	 * Flag to define if the item represents the current page. Disable this
 	 * attribute only if there are multiple navigations on the page.
@@ -92,262 +86,57 @@ export interface IProps {
 	/**
 	 * Custom component that will be displayed on mobile resolutions that toggles the visibility of the navigation.
 	 */
-	trigger?: typeof Trigger;
+	trigger?: typeof VerticalNav.Trigger;
 
 	/**
 	 * Path to the spritemap that Icon should use when referencing symbols.
 	 */
 	spritemap?: string;
-}
-
-export interface INavItemProps extends Omit<IItemWithItems, 'aria-current'> {
-	'aria-current'?: 'page' | null;
-
-	/**
-	 * Integer to keep track of what nested level the item is.
-	 */
-	level: number;
-
-	/**
-	 * Internal property
-	 * @ignore
-	 */
-	parentItemRef?: React.RefObject<HTMLButtonElement | HTMLAnchorElement>;
-
-	/**
-	 * Path to the spritemap that Icon should use when referencing symbols.
-	 */
-	spritemap?: string;
-}
-
-function findSelectedNested(
-	items: Array<IItemWithItems>
-): IItemWithItems | undefined {
-	return items.find((item) => {
-		if (item.active) {
-			return true;
-		}
-
-		if (item.items) {
-			return findSelectedNested(item.items);
-		}
-
-		return false;
-	});
-}
-
-function Item({
-	active,
-	'aria-current': ariaCurrent = 'page',
-	href,
-	initialExpanded = false,
-	items,
-	label,
-	level,
-	onClick,
-	parentItemRef,
-	spritemap,
-	...otherProps
-}: INavItemProps) {
-	const [expanded, setExpaned] = React.useState(initialExpanded);
-
-	const itemRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
-	const menusRef = useRef<HTMLUListElement | null>(null);
-
-	const hasItemSelectedNested = useMemo(() => {
-		if (items) {
-			return !!findSelectedNested(items);
-		}
-
-		return false;
-	}, [items]);
-
-	return (
-		<Nav.Item role="none" {...otherProps}>
-			<Nav.Link
-				active={active}
-				aria-current={active ? ariaCurrent ?? undefined : undefined}
-				aria-expanded={items ? expanded : undefined}
-				aria-haspopup={items ? true : undefined}
-				collapsed={!expanded}
-				href={href}
-				onClick={() => {
-					setExpaned(!expanded);
-
-					if (onClick) {
-						onClick();
-					}
-				}}
-				onKeyDown={(event) => {
-					switch (event.key) {
-						case Keys.Right: {
-							if (items && !expanded) {
-								setExpaned(true);
-							} else if (items && menusRef.current) {
-								const firstItemElement =
-									menusRef.current.querySelector<HTMLElement>(
-										'.nav-link:not([disabled])'
-									);
-								firstItemElement?.focus();
-							}
-							break;
-						}
-						case Keys.Left: {
-							if (items && expanded) {
-								setExpaned(false);
-							} else if (!items && parentItemRef?.current) {
-								parentItemRef.current?.focus();
-							}
-							break;
-						}
-						default:
-							break;
-					}
-				}}
-				ref={itemRef}
-				role={items ? 'button' : 'menuitem'}
-				showIcon={!!items}
-				spritemap={spritemap}
-				tabIndex={
-					!active && !(hasItemSelectedNested && items && !expanded)
-						? -1
-						: undefined
-				}
-			>
-				{label}
-			</Nav.Link>
-
-			{items && (
-				<CSSTransition
-					className={expanded ? undefined : 'collapse'}
-					classNames={{
-						enter: 'collapsing',
-						enterActive: `show`,
-						enterDone: 'show',
-						exit: `show`,
-						exitActive: 'collapsing',
-					}}
-					in={expanded}
-					onEnter={(element: HTMLElement) =>
-						element.setAttribute('style', `height: 0px`)
-					}
-					onEntered={(element: HTMLElement) =>
-						element.removeAttribute('style')
-					}
-					onEntering={(element: HTMLElement) =>
-						setElementFullHeight(element)
-					}
-					onExit={(element) => setElementFullHeight(element)}
-					onExiting={(element) =>
-						element.setAttribute('style', `height: 0px`)
-					}
-					timeout={250}
-				>
-					<Nav ref={menusRef} role="menu" stacked>
-						{renderItems(
-							items,
-							ariaCurrent,
-							spritemap,
-							level++,
-							itemRef
-						)}
-					</Nav>
-				</CSSTransition>
-			)}
-		</Nav.Item>
-	);
-}
-
-function renderItems(
-	items: Array<IItem>,
-	ariaCurrent: 'page' | null,
-	spritemap?: string,
-	level = 0,
-	parentItemRef?: React.RefObject<HTMLButtonElement | HTMLAnchorElement>
-) {
-	return items.map((item, i) => {
-		const key = `${level}-${i}`;
-
-		return (
-			<Item
-				{...item}
-				aria-current={ariaCurrent}
-				key={key}
-				level={level}
-				parentItemRef={parentItemRef}
-				spritemap={spritemap}
-			/>
-		);
-	});
 }
 
 function ClayVerticalNav(props: IProps): JSX.Element & {
-	Trigger: typeof Trigger;
+	Trigger: typeof VerticalNav.Trigger;
 };
 
 function ClayVerticalNav({
-	activation = 'manual',
 	activeLabel,
-	decorated,
-	itemAriaCurrent: ariaCurrent = true,
-	items,
-	large,
-	spritemap,
-	trigger: CustomTrigger = Trigger,
+	children,
 	triggerLabel = 'Menu',
 	...otherProps
 }: IProps) {
-	const [active, setActive] = useState(false);
-	const containerRef = useRef<HTMLDivElement | null>(null);
-
-	const {navigationProps} = useNavigation({
-		activation,
-		containerRef,
-		orientation: 'vertical',
-	});
-
 	warning(
 		!activeLabel,
 		'ClayVerticalNav: The `activeLabel` API has been deprecated in favor of `triggerLabel` and will be removed in the next major release.'
 	);
 
-	return (
-		<nav
-			{...otherProps}
-			className={classNames('menubar menubar-transparent', {
-				['menubar-decorated']: decorated,
-				['menubar-vertical-expand-lg']: large,
-				['menubar-vertical-expand-md']: !large,
-			})}
-		>
-			<CustomTrigger onClick={() => setActive(!active)}>
-				<span className="inline-item inline-item-before">
-					{activeLabel || triggerLabel}
-				</span>
-
-				<ClayIcon
-					focusable="false"
-					role="presentation"
-					spritemap={spritemap}
-					symbol="caret-bottom"
-				/>
-			</CustomTrigger>
-
-			<div
-				{...navigationProps}
-				className={classNames('collapse menubar-collapse', {
-					show: active,
-				})}
-				ref={containerRef}
+	if (children) {
+		return (
+			<VerticalNav
+				{...otherProps}
+				triggerLabel={activeLabel ?? triggerLabel}
 			>
-				<Nav aria-orientation="vertical" nested role="menubar">
-					{renderItems(items, ariaCurrent ? 'page' : null, spritemap)}
-				</Nav>
-			</div>
-		</nav>
+				{children}
+			</VerticalNav>
+		);
+	}
+
+	return (
+		<VerticalNav {...otherProps} triggerLabel={activeLabel ?? triggerLabel}>
+			{(item) => (
+				<VerticalNav.Item
+					active={item.active}
+					href={item.href}
+					initialExpanded={item.initialExpanded}
+					items={item.items}
+					onClick={item.onClick}
+				>
+					{item.label}
+				</VerticalNav.Item>
+			)}
+		</VerticalNav>
 	);
 }
 
-ClayVerticalNav.Trigger = Trigger;
+ClayVerticalNav.Trigger = VerticalNav.Trigger;
 
 export {ClayVerticalNav};

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {Nav} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
 import {Keys, setElementFullHeight, useNavigation} from '@clayui/shared';
 import classNames from 'classnames';
@@ -10,7 +11,6 @@ import React, {useMemo, useRef, useState} from 'react';
 import {CSSTransition} from 'react-transition-group';
 import warning from 'warning';
 
-import Nav from './Nav';
 import Trigger from './Trigger';
 
 interface IItem extends React.ComponentProps<typeof Nav.Item> {

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -96,6 +96,7 @@ export interface IProps extends React.ComponentProps<typeof VerticalNav> {
 
 function ClayVerticalNav(props: IProps): JSX.Element & {
 	Trigger: typeof VerticalNav.Trigger;
+	Item: typeof VerticalNav.Item;
 };
 
 function ClayVerticalNav({
@@ -138,5 +139,6 @@ function ClayVerticalNav({
 }
 
 ClayVerticalNav.Trigger = VerticalNav.Trigger;
+ClayVerticalNav.Item = VerticalNav.Item;
 
 export {ClayVerticalNav};

--- a/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClayNav renders 1`] = `
-<div>
-  <ul
-    class="nav"
-  >
-    <div />
-  </ul>
-</div>
-`;
-
 exports[`ClayVerticalNav renders 1`] = `
 <div>
   <nav

--- a/packages/clay-nav/src/__tests__/index.tsx
+++ b/packages/clay-nav/src/__tests__/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayNav, {ClayVerticalNav} from '..';
+import {ClayVerticalNav} from '..';
 import {
 	cleanup,
 	fireEvent,
@@ -12,20 +12,6 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-
-describe('ClayNav', () => {
-	afterEach(() => cleanup());
-
-	it('renders', () => {
-		const {container} = render(
-			<ClayNav>
-				<div />
-			</ClayNav>
-		);
-
-		expect(container).toMatchSnapshot();
-	});
-});
 
 const ITEMS = [
 	{

--- a/packages/clay-nav/src/index.tsx
+++ b/packages/clay-nav/src/index.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import Nav from './Nav';
+import {Nav} from '@clayui/core';
+
 import {ClayVerticalNav} from './Vertical';
 
 export {ClayVerticalNav};


### PR DESCRIPTION
Close #5515

This PR makes a lot of changes, first we are rewriting the `VerticalNav` component to use the Collection API and exposing a new public `<VerticalNav.Item />` component.

We are also adding a new `expandedKeys` API with the pattern of controlled and uncontrolled, this makes it easier to manage this state for items in the tree like implementing expand all or collapse.

We are also moving the implementation of all this to the `@clayui/core` package and the `@clayui/nav` package just keeps backwards compatibility with the old version of the component and possibility to use the new version when declaring the new composition.

With the Collection implementation I needed to rewrite the component and this brings a new composition with the benefits of the Collection pattern.

```jsx
<VerticalNav items={items}>
    {(item) => (
        <VerticalNav.Item active={item.active} items={item.items}>
            {item.label}
        </VerticalNav.Item>
    )}
</VerticalNav>
```

This brings new possibilities to the component as it is also data agnostic and does not depend on a data structure to force the product to follow. As I said, we still maintain compatibility with the previous version, so it's easy to migrate to use the new composition and the new features that Collection brings, also the `expandedKeys` API will only take effect with the new composition because it depends on which keys in the tree is unique. Consuming the component directly from the `@clayui/core` package will only support the new composition.

### ToDo

- [x] Update docs