### PR TITLE
fix(@clayui/css): fix syntax error

### DIFF
--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.89.0
+ * Clay 3.95.0
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>

--- a/packages/clay-css/src/scss/components/_badges.scss
+++ b/packages/clay-css/src/scss/components/_badges.scss
@@ -115,12 +115,7 @@
 		$selector: if(
 			index($deprecated-keys, '#{$color}') != null,
 			str-insert($color, '.badge-', 1),
-			if
-				(
-					starts-with($color, 'badge'),
-					str-insert($color, '.', 1),
-					$color
-				)
+			if(starts-with($color, 'badge'), str-insert($color, '.', 1), $color)
 		);
 
 		@if (starts-with($color, '%') or map-get($value, extend)) {


### PR DESCRIPTION
This bug was discovered with build failure when updating Clay in DXP https://github.com/liferay-peds/liferay-portal/pull/53.

It's strange that this is not reproducible in Clay's build, maybe our build is not throwing the console errors or failing the build correctly, we need to investigate if this is an issue in our build or the DXP later.