### PR TITLE
fix(@clayui/core): fixes bug with not having a focusable item when there is no active item

### DIFF
--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -46,6 +46,7 @@ export type CollectionState = {
 	getItem: (key: React.Key) => {value: string; index: number};
 	getItems: () => Array<React.Key>;
 	getLastItem: () => {key: React.Key; value: string; index: number};
+	hasItem: (key: React.Key) => boolean;
 	size?: number;
 	virtualize: boolean;
 };

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -96,6 +96,17 @@ export type Props<P, K> = {
 	 */
 	notFound?: JSX.Element;
 
+	/**
+	 * Flag to enable force updating the root collection when layout creation
+	 * is done at render time from nested collections instead of assembling
+	 * everything in the root.
+	 *
+	 * NOTE: This can be slow when you have a large list and is not necessary
+	 * when you don't have nested collections or the collections are group
+	 * primitives when the nested items are created in the root.
+	 */
+	forceDeepRootUpdate?: boolean;
+
 	suppressTextValueWarning?: boolean;
 
 	virtualizer?: Virtualizer<HTMLElement, Element>;

--- a/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -102,7 +102,7 @@ exports[`Picker basic rendering renders open component by default 1`] = `
       aria-activedescendant="Apple"
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-owns="clay-id-6"
+      aria-owns="clay-id-12"
       class="form-control form-control-select form-control-select-secondary show"
       role="combobox"
       style=""
@@ -134,7 +134,7 @@ exports[`Picker basic rendering renders open component by default 1`] = `
     >
       <ul
         class="inline-scroller list-unstyled"
-        id="clay-id-6"
+        id="clay-id-12"
         role="listbox"
         tabindex="-1"
       >

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -13,8 +13,8 @@ exports[`TreeView basic rendering render dynamic content 1`] = `
     >
       <div
         aria-expanded="false"
-        aria-labelledby="clay-id-13"
-        aria-owns="clay-id-14"
+        aria-labelledby="clay-id-15"
+        aria-owns="clay-id-16"
         class="treeview-link"
         data-id="string,Root"
         role="treeitem"
@@ -67,7 +67,7 @@ exports[`TreeView basic rendering render dynamic content 1`] = `
             >
               <span
                 class="component-text"
-                id="clay-id-13"
+                id="clay-id-15"
                 tabindex="-1"
               >
                 Root
@@ -94,8 +94,8 @@ exports[`TreeView basic rendering render nested dynamic content 1`] = `
     >
       <div
         aria-expanded="false"
-        aria-labelledby="clay-id-22"
-        aria-owns="clay-id-23"
+        aria-labelledby="clay-id-25"
+        aria-owns="clay-id-26"
         class="treeview-link"
         data-id="string,Foo"
         role="treeitem"
@@ -148,7 +148,7 @@ exports[`TreeView basic rendering render nested dynamic content 1`] = `
             >
               <span
                 class="component-text"
-                id="clay-id-22"
+                id="clay-id-25"
                 tabindex="-1"
               >
                 Foo
@@ -175,8 +175,8 @@ exports[`TreeView basic rendering render static content 1`] = `
     >
       <div
         aria-expanded="false"
-        aria-labelledby="clay-id-4"
-        aria-owns="clay-id-5"
+        aria-labelledby="clay-id-5"
+        aria-owns="clay-id-6"
         class="treeview-link"
         data-id="string,$.0"
         role="treeitem"
@@ -229,7 +229,7 @@ exports[`TreeView basic rendering render static content 1`] = `
             >
               <span
                 class="component-text"
-                id="clay-id-4"
+                id="clay-id-5"
                 tabindex="-1"
               >
                 Root
@@ -255,8 +255,8 @@ exports[`TreeView basic rendering render with actions 1`] = `
       role="none"
     >
       <div
-        aria-labelledby="clay-id-58"
-        aria-owns="clay-id-59"
+        aria-labelledby="clay-id-65"
+        aria-owns="clay-id-66"
         class="treeview-link"
         data-id="string,$.0"
         role="treeitem"
@@ -276,7 +276,7 @@ exports[`TreeView basic rendering render with actions 1`] = `
             >
               <span
                 class="component-text"
-                id="clay-id-58"
+                id="clay-id-65"
                 tabindex="-1"
               >
                 Root
@@ -346,8 +346,8 @@ exports[`TreeView basic rendering render with checkbox 1`] = `
     >
       <div
         aria-expanded="false"
-        aria-labelledby="clay-id-85"
-        aria-owns="clay-id-86"
+        aria-labelledby="clay-id-96"
+        aria-owns="clay-id-97"
         class="treeview-link"
         data-id="string,$.0"
         role="treeitem"
@@ -417,7 +417,7 @@ exports[`TreeView basic rendering render with checkbox 1`] = `
             >
               <span
                 class="component-text"
-                id="clay-id-85"
+                id="clay-id-96"
                 tabindex="-1"
               >
                 Root
@@ -444,8 +444,8 @@ exports[`TreeView basic rendering render with item active 1`] = `
     >
       <div
         aria-expanded="false"
-        aria-labelledby="clay-id-142"
-        aria-owns="clay-id-143"
+        aria-labelledby="clay-id-160"
+        aria-owns="clay-id-161"
         class="treeview-link active"
         data-id="string,$.0"
         role="treeitem"
@@ -515,7 +515,7 @@ exports[`TreeView basic rendering render with item active 1`] = `
             >
               <span
                 class="component-text"
-                id="clay-id-142"
+                id="clay-id-160"
                 tabindex="-1"
               >
                 Root
@@ -542,8 +542,8 @@ exports[`TreeView basic rendering render with text 1`] = `
     >
       <div
         aria-expanded="false"
-        aria-labelledby="clay-id-94"
-        aria-owns="clay-id-95"
+        aria-labelledby="clay-id-106"
+        aria-owns="clay-id-107"
         class="treeview-link"
         data-id="string,$.0"
         role="treeitem"
@@ -613,7 +613,7 @@ exports[`TreeView basic rendering render with text 1`] = `
             >
               <span
                 class="component-text"
-                id="clay-id-94"
+                id="clay-id-106"
                 tabindex="-1"
               >
                 <span

--- a/packages/clay-core/src/vertical-bar/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/vertical-bar/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -18,10 +18,10 @@ exports[`VerticalBar basic rendering render component in left position 1`] = `
           role="none"
         >
           <button
-            aria-controls="clay-id-5-verticalbar-tabpanel-$.0"
+            aria-controls="clay-id-13-verticalbar-tabpanel-$.0"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-5-verticalbar-tab-$.0"
+            id="clay-id-13-verticalbar-tab-$.0"
             role="tab"
             type="button"
           >
@@ -40,10 +40,10 @@ exports[`VerticalBar basic rendering render component in left position 1`] = `
           role="none"
         >
           <button
-            aria-controls="clay-id-5-verticalbar-tabpanel-$.1"
+            aria-controls="clay-id-13-verticalbar-tabpanel-$.1"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-5-verticalbar-tab-$.1"
+            id="clay-id-13-verticalbar-tab-$.1"
             role="tab"
             tabindex="-1"
             type="button"
@@ -82,10 +82,10 @@ exports[`VerticalBar basic rendering render dark theme 1`] = `
           role="none"
         >
           <button
-            aria-controls="clay-id-4-verticalbar-tabpanel-$.0"
+            aria-controls="clay-id-10-verticalbar-tabpanel-$.0"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-4-verticalbar-tab-$.0"
+            id="clay-id-10-verticalbar-tab-$.0"
             role="tab"
             type="button"
           >
@@ -104,10 +104,10 @@ exports[`VerticalBar basic rendering render dark theme 1`] = `
           role="none"
         >
           <button
-            aria-controls="clay-id-4-verticalbar-tabpanel-$.1"
+            aria-controls="clay-id-10-verticalbar-tabpanel-$.1"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-4-verticalbar-tab-$.1"
+            id="clay-id-10-verticalbar-tab-$.1"
             role="tab"
             tabindex="-1"
             type="button"
@@ -146,10 +146,10 @@ exports[`VerticalBar basic rendering render dynamic content 1`] = `
           role="none"
         >
           <button
-            aria-controls="clay-id-2-verticalbar-tabpanel-Tag"
+            aria-controls="clay-id-4-verticalbar-tabpanel-Tag"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-2-verticalbar-tab-Tag"
+            id="clay-id-4-verticalbar-tab-Tag"
             role="tab"
             type="button"
           >
@@ -168,10 +168,10 @@ exports[`VerticalBar basic rendering render dynamic content 1`] = `
           role="none"
         >
           <button
-            aria-controls="clay-id-2-verticalbar-tabpanel-Message"
+            aria-controls="clay-id-4-verticalbar-tabpanel-Message"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-2-verticalbar-tab-Message"
+            id="clay-id-4-verticalbar-tab-Message"
             role="tab"
             tabindex="-1"
             type="button"
@@ -191,10 +191,10 @@ exports[`VerticalBar basic rendering render dynamic content 1`] = `
           role="none"
         >
           <button
-            aria-controls="clay-id-2-verticalbar-tabpanel-Effects"
+            aria-controls="clay-id-4-verticalbar-tabpanel-Effects"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-2-verticalbar-tab-Effects"
+            id="clay-id-4-verticalbar-tab-Effects"
             role="tab"
             tabindex="-1"
             type="button"
@@ -233,10 +233,10 @@ exports[`VerticalBar basic rendering render light theme 1`] = `
           role="none"
         >
           <button
-            aria-controls="clay-id-3-verticalbar-tabpanel-$.0"
+            aria-controls="clay-id-7-verticalbar-tabpanel-$.0"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-3-verticalbar-tab-$.0"
+            id="clay-id-7-verticalbar-tab-$.0"
             role="tab"
             type="button"
           >
@@ -255,10 +255,10 @@ exports[`VerticalBar basic rendering render light theme 1`] = `
           role="none"
         >
           <button
-            aria-controls="clay-id-3-verticalbar-tabpanel-$.1"
+            aria-controls="clay-id-7-verticalbar-tabpanel-$.1"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-3-verticalbar-tab-$.1"
+            id="clay-id-7-verticalbar-tab-$.1"
             role="tab"
             tabindex="-1"
             type="button"
@@ -349,9 +349,9 @@ exports[`VerticalBar basic rendering renders the component with the active panel
     class="c-slideout c-slideout-shown c-slideout-end c-slideout-fixed"
   >
     <div
-      aria-labelledby="clay-id-6-verticalbar-tab-$.0"
+      aria-labelledby="clay-id-16-verticalbar-tab-$.0"
       class="sidebar c-slideout-show sidebar-light"
-      id="clay-id-6-verticalbar-tabpanel-$.0"
+      id="clay-id-16-verticalbar-tabpanel-$.0"
       role="tabpanel"
       style="width: 320px;"
     >
@@ -370,10 +370,10 @@ exports[`VerticalBar basic rendering renders the component with the active panel
           role="none"
         >
           <button
-            aria-controls="clay-id-6-verticalbar-tabpanel-$.0"
+            aria-controls="clay-id-16-verticalbar-tabpanel-$.0"
             aria-selected="true"
             class="tbar-btn tbar-btn-monospaced active btn"
-            id="clay-id-6-verticalbar-tab-$.0"
+            id="clay-id-16-verticalbar-tab-$.0"
             role="tab"
             type="button"
           >
@@ -392,10 +392,10 @@ exports[`VerticalBar basic rendering renders the component with the active panel
           role="none"
         >
           <button
-            aria-controls="clay-id-6-verticalbar-tabpanel-$.1"
+            aria-controls="clay-id-16-verticalbar-tabpanel-$.1"
             aria-selected="false"
             class="tbar-btn tbar-btn-monospaced btn"
-            id="clay-id-6-verticalbar-tab-$.1"
+            id="clay-id-16-verticalbar-tab-$.1"
             role="tab"
             tabindex="-1"
             type="button"

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -15,6 +15,8 @@ import {useVertical} from './context';
 interface IProps<T> extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Flag to indicate if item is active.
+	 * @deprecated since version 3.94.0 - uses the `active` property on the
+	 * root component.
 	 */
 	active?: boolean;
 
@@ -74,7 +76,7 @@ const ParentContext = React.createContext<React.RefObject<
 > | null>(null);
 
 export function Item<T extends object>({
-	active,
+	active: depreactedActive,
 	children,
 	href,
 	index: _,
@@ -85,6 +87,7 @@ export function Item<T extends object>({
 	...otherProps
 }: IProps<T>) {
 	const {
+		activeKey,
 		ariaCurrent = 'page',
 		childrenRoot,
 		close,
@@ -114,6 +117,8 @@ export function Item<T extends object>({
 
 		return false;
 	}, [items]);
+
+	const active = depreactedActive ?? activeKey === keyValue;
 
 	return (
 		<Nav.Item role="none" {...otherProps}>

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -224,7 +224,7 @@ export function Item<T extends object>({
 				>
 					<Nav ref={menusRef} role="menu" stacked>
 						<ParentContext.Provider value={itemRef}>
-							<Collection<T> items={items}>
+							<Collection<T> items={items} parentKey={keyValue}>
 								{childrenRoot.current}
 							</Collection>
 						</ParentContext.Provider>

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -92,6 +92,7 @@ export function Item<T extends object>({
 		childrenRoot,
 		close,
 		expandedKeys,
+		firstKey,
 		open,
 		spritemap,
 		toggle,
@@ -184,7 +185,9 @@ export function Item<T extends object>({
 				showIcon={!!items}
 				spritemap={spritemap}
 				tabIndex={
-					!active && !(hasItemSelectedNested && items && !isExpanded)
+					!active &&
+					!(hasItemSelectedNested && items && !isExpanded) &&
+					!(firstKey === keyValue && typeof activeKey === 'undefined')
 						? -1
 						: undefined
 				}
@@ -217,6 +220,7 @@ export function Item<T extends object>({
 						element.setAttribute('style', 'height: 0px')
 					}
 					timeout={prefersReducedMotion ? 0 : 250}
+					unmountOnExit
 				>
 					<Nav ref={menusRef} role="menu" stacked>
 						<ParentContext.Provider value={itemRef}>
@@ -230,3 +234,5 @@ export function Item<T extends object>({
 		</Nav.Item>
 	);
 }
+
+Item.displayName = 'Item';

--- a/packages/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/packages/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -5,7 +5,11 @@
 
 import Button from '@clayui/button';
 import Icon from '@clayui/icon';
-import {useInternalState, useNavigation} from '@clayui/shared';
+import {
+	InternalDispatch,
+	useInternalState,
+	useNavigation,
+} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useCallback, useRef, useState} from 'react';
 
@@ -31,6 +35,11 @@ const Trigger = ({
 );
 
 type Props<T> = {
+	/**
+	 * Flag to define which item has the active state/current page.
+	 */
+	active?: React.Key;
+
 	/**
 	 * Flag to indicate the navigation behavior in the menu.
 	 *
@@ -80,7 +89,7 @@ type Props<T> = {
 	 * A callback that is called when items are expanded or collapsed
 	 * (controlled).
 	 */
-	onExpandedChange?: (keys: Set<React.Key>) => void;
+	onExpandedChange?: InternalDispatch<Set<React.Key>>;
 
 	/**
 	 * Path to the spritemap that Icon should use when referencing symbols.
@@ -106,6 +115,7 @@ function VerticalNav<T>(props: Props<T>): JSX.Element & {
 };
 
 function VerticalNav<T>({
+	active,
 	activation = 'manual',
 	children,
 	decorated,
@@ -119,7 +129,7 @@ function VerticalNav<T>({
 	trigger: CustomTrigger = Trigger,
 	triggerLabel = 'Menu',
 }: Props<T>) {
-	const [active, setActive] = useState(false);
+	const [isOpen, setIsOpen] = useState(false);
 
 	const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -197,7 +207,7 @@ function VerticalNav<T>({
 				['menubar-vertical-expand-md']: !large,
 			})}
 		>
-			<CustomTrigger onClick={() => setActive(!active)}>
+			<CustomTrigger onClick={() => setIsOpen(!isOpen)}>
 				<span className="inline-item inline-item-before">
 					{triggerLabel}
 				</span>
@@ -213,13 +223,14 @@ function VerticalNav<T>({
 			<div
 				{...navigationProps}
 				className={classNames('collapse menubar-collapse', {
-					show: active,
+					show: isOpen,
 				})}
 				ref={containerRef}
 			>
 				<Nav aria-orientation="vertical" nested role="menubar">
 					<VertivalNavContext.Provider
 						value={{
+							activeKey: active,
 							ariaCurrent: ariaCurrent ? 'page' : null,
 							childrenRoot: childrenRootRef,
 							close,

--- a/packages/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/packages/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -13,7 +13,7 @@ import {
 import classNames from 'classnames';
 import React, {useCallback, useRef, useState} from 'react';
 
-import {Collection} from '../collection';
+import {Collection, useCollection} from '../collection';
 import {Nav} from '../nav';
 import {Item} from './Item';
 import {VertivalNavContext} from './context';
@@ -199,6 +199,17 @@ function VerticalNav<T>({
 		orientation: 'vertical',
 	});
 
+	const collection = useCollection<T>({
+		children,
+
+		// Avoid collection list is obsolete because we have collection nesting
+		// which is not based on group primitive like Picker with groups
+		// or DropDown.
+		forceDeepRootUpdate: true,
+		items,
+		suppressTextValueWarning: false,
+	});
+
 	return (
 		<nav
 			className={classNames('menubar menubar-transparent', {
@@ -230,17 +241,21 @@ function VerticalNav<T>({
 				<Nav aria-orientation="vertical" nested role="menubar">
 					<VertivalNavContext.Provider
 						value={{
-							activeKey: active,
+							activeKey:
+								active && collection.hasItem(active)
+									? active
+									: undefined,
 							ariaCurrent: ariaCurrent ? 'page' : null,
 							childrenRoot: childrenRootRef,
 							close,
 							expandedKeys,
+							firstKey: collection.getFirstItem().key,
 							open,
 							spritemap,
 							toggle,
 						}}
 					>
-						<Collection<T> items={items}>{children}</Collection>
+						<Collection<T> collection={collection} />
 					</VertivalNavContext.Provider>
 				</Nav>
 			</div>

--- a/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -71,24 +71,6 @@ exports[`VerticalNav basic rendering render dynamic content 1`] = `
               </svg>
             </span>
           </button>
-          <ul
-            class="nav collapse nav-stacked"
-            role="menu"
-          >
-            <li
-              class="nav-item"
-              role="none"
-            >
-              <button
-                aria-current="page"
-                class="nav-link active collapsed btn btn-unstyled"
-                role="menuitem"
-                type="button"
-              >
-                Nested1
-              </button>
-            </li>
-          </ul>
         </li>
         <li
           class="nav-item"

--- a/packages/clay-core/src/vertical-nav/context.ts
+++ b/packages/clay-core/src/vertical-nav/context.ts
@@ -16,6 +16,7 @@ type VertivalNavContextProps = {
 	>;
 	close: (key: React.Key) => void;
 	expandedKeys: Set<React.Key>;
+	firstKey: React.Key;
 	open: (key: React.Key) => void;
 	toggle: (key: React.Key) => void;
 };

--- a/packages/clay-core/src/vertical-nav/context.ts
+++ b/packages/clay-core/src/vertical-nav/context.ts
@@ -8,7 +8,7 @@ import {createContext, useContext} from 'react';
 import type {ChildrenFunction} from '../collection';
 
 type VertivalNavContextProps = {
-	activeKey?: React.Key;
+	activeKey?: React.Key | null;
 	ariaCurrent?: 'page' | null;
 	spritemap?: string;
 	childrenRoot: React.MutableRefObject<

--- a/packages/clay-core/src/vertical-nav/context.ts
+++ b/packages/clay-core/src/vertical-nav/context.ts
@@ -8,6 +8,7 @@ import {createContext, useContext} from 'react';
 import type {ChildrenFunction} from '../collection';
 
 type VertivalNavContextProps = {
+	activeKey?: React.Key;
 	ariaCurrent?: 'page' | null;
 	spritemap?: string;
 	childrenRoot: React.MutableRefObject<

--- a/packages/clay-core/stories/VerticalNav.stories.tsx
+++ b/packages/clay-core/stories/VerticalNav.stories.tsx
@@ -42,7 +42,6 @@ const items = [
 		id: 5,
 		items: [
 			{
-				active: true,
 				href: '#',
 				id: 6,
 				label: 'Five',
@@ -440,14 +439,9 @@ export default {
 };
 
 export const Default = () => (
-	<VerticalNav items={items}>
+	<VerticalNav active={6} items={items}>
 		{(item) => (
-			<VerticalNav.Item
-				active={item.active}
-				href={item.href}
-				items={item.items}
-				key={item.id}
-			>
+			<VerticalNav.Item href={item.href} items={item.items} key={item.id}>
 				{item.label}
 			</VerticalNav.Item>
 		)}
@@ -477,16 +471,13 @@ export const ControlledExpandedKeys = () => {
 			</Button>
 
 			<VerticalNav
+				active={active}
 				expandedKeys={expandedKeys}
 				items={items_long}
 				onExpandedChange={setExpandedKeys}
 			>
 				{(item) => (
-					<VerticalNav.Item
-						active={active === item.label}
-						items={item.items}
-						key={item.label}
-					>
+					<VerticalNav.Item items={item.items} key={item.label}>
 						{item.label}
 					</VerticalNav.Item>
 				)}

--- a/packages/clay-nav/docs/index.js
+++ b/packages/clay-nav/docs/index.js
@@ -47,11 +47,14 @@ const verticalNavigationImportsCode = `import {ClayVerticalNav} from '@clayui/na
 const VerticalNavigationCode = `const Component = () => {
 	return (
 		<ClayVerticalNav
-			defaultExpandedKeys={new Set(['Projects'])}
+			active={6}
+			defaultExpandedKeys={new Set([5])}
 			items={[
 				{
+					id: 1,
 					items: [
 						{
+							id: 2,
 							href: '#nested1',
 							label: 'Nested1',
 						},
@@ -59,21 +62,25 @@ const VerticalNavigationCode = `const Component = () => {
 					label: 'Home',
 				},
 				{
+					id: 3,
 					href: '#2',
 					label: 'About',
 				},
 				{
+					id: 4,
 					href: '#3',
 					label: 'Contact',
 				},
 				{
+					id: 5,
 					items: [
 						{
-							active: true,
+							id: 6,
 							href: '#5',
 							label: 'Five',
 						},
 						{
+							id: 7,
 							href: '#6',
 							label: 'Six',
 						},
@@ -81,6 +88,7 @@ const VerticalNavigationCode = `const Component = () => {
 					label: 'Projects',
 				},
 				{
+					id: 8,
 					href: '#7',
 					label: 'Seven',
 				},
@@ -90,10 +98,9 @@ const VerticalNavigationCode = `const Component = () => {
 		>
 			{(item) => (
 				<ClayVerticalNav.Item
-					active={item.active}
 					href={item.href}
 					items={item.items}
-					key={item.label}
+					key={item.id}
 				>
 					{item.label}
 				</ClayVerticalNav.Item>

--- a/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -41,7 +41,6 @@ exports[`ClayVerticalNav renders 1`] = `
             aria-haspopup="true"
             class="nav-link collapse-icon btn btn-unstyled"
             role="button"
-            tabindex="-1"
             type="button"
           >
             Home

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -149,7 +149,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
   >
     <div
       class="pagination-results"
-      id="clay-id-3"
+      id="clay-id-5"
     >
       Showing 1 to 10 of 100
     </div>
@@ -267,7 +267,7 @@ exports[`ClayPaginationBar totalItems with 0 will render the pagination bar with
   >
     <div
       class="pagination-results"
-      id="clay-id-4"
+      id="clay-id-7"
     >
       Showing 1 to 1 of 1
     </div>


### PR DESCRIPTION
Fixes #5516

This PR makes more changes besides fixing the related bug in the issue, as part of being data agnostic I'm deprecating Item's `active` API instead it's just necessary to set the state of `active` in the component root, this makes it simpler than traversing the tree and setting the property to `active` it also lessens the data payload.

I had to make some internal changes to the Collection API because of how Collection nesting works in this component which is different from components like Picker or DropDown. I added comments in the code about some specs.

I still have to do some more backwards compatibility testing and fix the tests.