### PR TITLE
fix(@clayui/shared): fix Picker menu positioning error

### DIFF
--- a/packages/clay-shared/src/useOverlayPositon.ts
+++ b/packages/clay-shared/src/useOverlayPositon.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {useEffect, useLayoutEffect} from 'react';
+import React, {useCallback, useEffect, useLayoutEffect} from 'react';
 
 import {doAlign} from './doAlign';
 import {observeRect} from './observeRect';
@@ -95,37 +95,41 @@ export function useOverlayPosition(
 	}: Props,
 	deps: Array<any> = [isOpen]
 ) {
-	useIsomorphicLayoutEffect(() => {
-		function alignElement() {
-			if (triggerRef.current) {
-				let points = alignmentPosition;
+	const alignElement = useCallback(() => {
+		if (triggerRef.current && ref.current) {
+			let points = alignmentPosition;
 
-				if (typeof points === 'number') {
-					points = getAlignPoints(
-						points as keyof typeof ALIGN_INVERSE
-					);
-				}
-
-				if (ref.current) {
-					doAlign({
-						offset: getOffset(points),
-						overflow: {
-							adjustX: autoBestAlign,
-							adjustY: autoBestAlign,
-							alwaysByViewport: alignmentByViewport,
-						},
-						points,
-						sourceElement: ref.current,
-						targetElement: triggerRef.current,
-					});
-				}
+			if (typeof points === 'number') {
+				points = getAlignPoints(points as keyof typeof ALIGN_INVERSE);
 			}
-		}
 
+			doAlign({
+				offset: getOffset(points),
+				overflow: {
+					adjustX: autoBestAlign,
+					adjustY: autoBestAlign,
+					alwaysByViewport: alignmentByViewport,
+				},
+				points,
+				sourceElement: ref.current,
+				targetElement: triggerRef.current,
+			});
+		}
+	}, []);
+
+	useIsomorphicLayoutEffect(() => {
 		if (isOpen && triggerRef.current) {
 			alignElement();
 
 			return observeRect(triggerRef.current, alignElement);
+		}
+	}, deps);
+
+	useIsomorphicLayoutEffect(() => {
+		if (isOpen && ref.current) {
+			alignElement();
+
+			return observeRect(ref.current, alignElement);
 		}
 	}, deps);
 }


### PR DESCRIPTION
Fixes #5533

We made a recent change to recalculate the positioning of the Menu based on the `trigger` before it was based on the Menu this ends up breaking the behavior of opening the Menu when the trigger does not change its positioning when it is not related to the scroll of the container or the page but also we need this to recalculate the placement of the trigger compared to the scroll of some parent element so that the menu repositions correctly, so I'm also adding a second "listener" to recalculate the placement of the menu based on the position of the Menu as well.

This happens because the Picker will only render the menu when it is open, different from DropDown which had the behavior of always rendering the menu regardless of whether it is open or not, to calculate the positioning it is easier to have the element rendered in the DOM, in this case from the Picker when the menu is opened we try to calculate and we have a reference to the element but we don't know when the menu is rendered in the DOM, so it can happen to position the wrong element in the first attempt with the "listeners" for the trigger and the menu it can be recalculated again when in the DOM.