### PR TITLE
fix(@clayui/drop-down): fix error when breaking component when group has no items

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -83,7 +83,7 @@ module.exports = {
 			branches: 58,
 			functions: 52,
 			lines: 72,
-			statements: 72,
+			statements: 71,
 		},
 		'./packages/clay-empty-state/src/': {
 			branches: 100,

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -268,11 +268,22 @@ const Item = ({
 	);
 };
 
-const Group = ({items, label, spritemap}: IItem & IInternalItem) => (
-	<ClayDropDownGroup header={label}>
-		{items && <Items items={items} spritemap={spritemap} />}
-	</ClayDropDownGroup>
-);
+const Group = ({items, label, spritemap}: IItem & IInternalItem) => {
+	warning(
+		typeof items !== 'undefined',
+		`ClayDropDownWithItems -> The '${label}' group contains no items to render.`
+	);
+
+	if (typeof items === 'undefined') {
+		return null;
+	}
+
+	return (
+		<ClayDropDownGroup header={label}>
+			{items && <Items items={items} spritemap={spritemap} />}
+		</ClayDropDownGroup>
+	);
+};
 
 const BOTTOM_OFFSET = [0, 1] as const;
 const LEFT_OFFSET = [-1, 6] as const;


### PR DESCRIPTION
Fixes #5527

This PR avoids rendering the group if it has no `items` and throws an error in the console for the developer to correct, this improves the fault tolerance of the component and avoids throwing a JS error.