### PR TITLE
feat(@clayui/card): moves root `aria-label` to card titles

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -38,7 +38,7 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-card/src/': {
-			branches: 85,
+			branches: 82,
 			functions: 90,
 			lines: 95,
 			statements: 95,

--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -69,6 +69,7 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 }
 
 export const ClayCardWithHorizontal = ({
+	'aria-label': ariaLabel,
 	actions,
 	checkboxProps = {},
 	disabled,
@@ -94,7 +95,7 @@ export const ClayCardWithHorizontal = ({
 
 				<ClayLayout.ContentCol expand gutters>
 					<ClayCard.Description
-						aria-label={title}
+						aria-label={ariaLabel ?? title}
 						disabled={disabled}
 						displayType="title"
 						href={href}

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -116,6 +116,7 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 }
 
 export const ClayCardWithInfo = ({
+	'aria-label': ariaLabel,
 	actions,
 	checkboxProps = {},
 	description,
@@ -228,7 +229,7 @@ export const ClayCardWithInfo = ({
 				<ClayCard.Row>
 					<ClayLayout.ContentCol expand>
 						<ClayCard.Description
-							aria-label={title}
+							aria-label={ariaLabel ?? title}
 							disabled={disabled}
 							displayType="title"
 							href={href}

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -65,6 +65,7 @@ export interface IProps
 const noop = () => {};
 
 export const ClayCardWithNavigation = ({
+	'aria-label': ariaLabel,
 	children,
 	description,
 	horizontal = false,
@@ -146,7 +147,7 @@ export const ClayCardWithNavigation = ({
 								<ClayLayout.ContentCol expand>
 									<ClayLayout.ContentSection>
 										<ClayCard.Description
-											aria-label={title}
+											aria-label={ariaLabel ?? title}
 											displayType="title"
 											truncate
 										>

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -96,6 +96,7 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 }
 
 export const ClayCardWithUser = ({
+	'aria-label': ariaLabel,
 	actions,
 	checkboxProps = {},
 	description,
@@ -159,7 +160,7 @@ export const ClayCardWithUser = ({
 				<ClayCard.Row>
 					<ClayLayout.ContentCol expand>
 						<ClayCard.Description
-							aria-label={name}
+							aria-label={ariaLabel ?? name}
 							disabled={disabled}
 							displayType="title"
 							href={href}


### PR DESCRIPTION
Closes #5529

Instead of creating a new API to change the `aria-label` of the title we are using the existing `aria-label` property instead of adding it to the root of the component which will be a div which will have no effect it makes more sense to move this to the titles of the cards.