### PR TITLE
fix(@clayui/multi-select): fix error when not doing OOTB filter

### DIFF
--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -139,6 +139,17 @@ export interface IProps<T>
 	[key: string]: any;
 }
 
+const List = React.forwardRef<
+	HTMLUListElement,
+	React.HTMLAttributes<HTMLUListElement>
+>(function List({children, ...otherProps}, ref) {
+	return (
+		<ul {...otherProps} className="list-unstyled" ref={ref}>
+			{children}
+		</ul>
+	);
+});
+
 const ESCAPE_REGEXP = /[.*+?^${}()|[\]\\]/g;
 
 export const Autocomplete = React.forwardRef<
@@ -480,7 +491,7 @@ export const Autocomplete = React.forwardRef<
 							<Collection<T>
 								aria-label={otherProps['aria-label']}
 								aria-labelledby={otherProps['aria-labelledby']}
-								as={DropDown.ItemList}
+								as={List}
 								collection={collection}
 								id={ariaControlsId}
 								isLoading={isLoading}

--- a/packages/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
@@ -48,7 +48,6 @@ describe('MultiSelect incremental interactions', () => {
 		const {getByRole} = render(
 			<MultiSelect
 				defaultItems={labels}
-				defaultValue="one"
 				sourceItems={[
 					{
 						label: 'one',

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -229,10 +229,16 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 				label: 'label',
 				value: 'value',
 			},
+			loadingState,
 			menuRenderer: _m,
+			messages = {
+				loading: 'Loading...',
+				notFound: 'No results found',
+			},
 			onChange,
 			onClearAllButtonClick,
 			onItemsChange,
+			onLoadMore,
 			placeholder,
 			size,
 			sourceItems = null,
@@ -271,6 +277,8 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 
 		const ariaDescriptionId = useId();
 
+		const hasAsyncItems = !!onLoadMore || typeof loadingState === 'number';
+
 		return (
 			<div
 				className={classNames(
@@ -289,16 +297,18 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 					as={Labels}
 					closeButtonAriaLabel={closeButtonAriaLabel}
 					containerElementRef={containerRef}
+					defaultItems={!hasAsyncItems ? sourceItems : undefined}
 					filterKey={locator.label}
 					inputName={inputName}
-					items={sourceItems}
+					items={hasAsyncItems ? sourceItems : undefined}
 					labels={items}
 					lastChangesRef={lastChangesRef}
 					locator={locator}
 					menuTrigger="focus"
+					messages={messages}
 					onChange={setValue}
 					onFocusChange={setIsFocused}
-					onItemsChange={() => {}}
+					onItemsChange={hasAsyncItems ? () => {} : undefined}
 					onLabelsChange={setItems}
 					placeholder={placeholder}
 					ref={inputElementRef}


### PR DESCRIPTION
Fixes #5544

This PR fixes two problems, the first one that the OOTB filter was not working, it is disabled when the items come from an asynchronous communication that doesn't need a filter on the client but is done on the server. The second fix is that Autocomplete was rendering two collections instead of one, this caused unnecessary computational cost and also caused some bugs in the component.

I'll merge right away to make a release patch.