### PR TITLE
chore: update CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
         </h1>
     </div>
 
-[![Build Status](https://travis-ci.org/liferay/clay.svg?branch=master)](https://travis-ci.org/liferay/clay) [![Coverage Status](https://coveralls.io/repos/github/liferay/clay/badge.svg)](https://coveralls.io/github/liferay/clay)
+![Clay CI](https://github.com/liferay/clay/actions/workflows/main.yml/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/liferay/clay/badge.svg)](https://coveralls.io/github/liferay/clay)
 
 </div>
 


### PR DESCRIPTION
I don't think we ever got to update the CI status badge, because it's been a while since we moved our CI to GitHub Actions and it was still showing Travis CI information, strange it was still working but now we are showing the CI status from Github Actions.