### PR TITLE
fix(@clayui/css): Transitions should work for .input-group-item.focus

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -1,6 +1,5 @@
 $input-bg: $gray-200 !default;
 $input-border-color: $gray-300 !default;
-$input-border-radius: $border-radius !default;
 $input-border-width: 0.0625rem !default; // 1px
 
 $input-border-bottom-width: $input-border-width !default; // 1px
@@ -525,26 +524,7 @@ $input-group-item-margin-left: 0.5rem !default;
 $input-group-item: () !default;
 $input-group-item: map-deep-merge(
 	(
-		display: flex,
-		flex-grow: 1,
-		flex-wrap: wrap,
-		margin-left: $input-group-item-margin-left,
-		width: 1%,
-		word-wrap: break-word,
 		focus: (
-			border-radius: clay-enable-rounded($input-border-radius),
-			after: (
-				border-radius: inherit,
-				bottom: 0,
-				box-shadow: $input-focus-box-shadow,
-				content: '',
-				display: block,
-				left: 0,
-				pointer-events: none,
-				position: absolute,
-				right: 0,
-				top: 0,
-			),
 			input-group-prepend: (
 				border-bottom-right-radius: clay-enable-rounded(0),
 				border-top-right-radius: clay-enable-rounded(0),

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -76,7 +76,7 @@ $input: map-deep-merge(
 		padding-left: $input-padding-x,
 		padding-right: $input-padding-x,
 		padding-top: $input-padding-y,
-		transition: $input-transition,
+		transition: clay-enable-transitions($input-transition),
 		width: 100%,
 		mobile: (
 			font-size: $input-font-size-mobile,
@@ -339,7 +339,7 @@ $input-plaintext-readonly: map-deep-merge(
 	(
 		border-radius: $input-border-radius,
 		outline: 0,
-		transition: $input-transition,
+		transition: clay-enable-transitions($input-transition),
 		focus: (
 			box-shadow: $input-focus-box-shadow,
 		),
@@ -1433,19 +1433,22 @@ $input-group-item: map-deep-merge(
 		margin-left: $input-group-item-margin-left,
 		width: 1%,
 		word-wrap: break-word,
+		after: (
+			border-radius: inherit,
+			bottom: 0,
+			content: '',
+			display: block,
+			left: 0,
+			pointer-events: none,
+			position: absolute,
+			right: 0,
+			top: 0,
+			transition: clay-enable-transitions($input-transition),
+		),
 		focus: (
 			border-radius: clay-enable-rounded($input-border-radius),
 			after: (
-				border-radius: inherit,
-				bottom: 0,
 				box-shadow: $input-focus-box-shadow,
-				content: '',
-				display: block,
-				left: 0,
-				pointer-events: none,
-				position: absolute,
-				right: 0,
-				top: 0,
 			),
 			input-group-prepend: (
 				border-bottom-right-radius: clay-enable-rounded(0),


### PR DESCRIPTION
I thought I committed the changes in https://github.com/liferay/clay/pull/5510 but I didn't. These are the changes I was supposed to commit.

fixes #5487