### PR TITLE
fix(@clayui/css): Menubar removes negative margins in mobile and sync…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_menubar.scss
@@ -114,7 +114,7 @@ $menubar-vertical-transparent-md: map-deep-merge(
 					),
 				),
 				menubar-toggler: (
-					color: $gray-900,
+					color: $gray-600,
 					font-size: 0.875rem,
 					font-weight: $font-weight-semi-bold,
 					transition: box-shadow 0.15s ease-in-out,
@@ -247,7 +247,7 @@ $menubar-vertical-transparent-lg: map-deep-merge(
 					),
 				),
 				menubar-toggler: (
-					color: $gray-900,
+					color: $gray-600,
 					font-size: 0.875rem,
 					font-weight: $font-weight-semi-bold,
 					transition: box-shadow 0.15s ease-in-out,

--- a/packages/clay-css/src/scss/cadmin/components/_grid.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_grid.scss
@@ -248,18 +248,6 @@
 	.container-form-lg,
 	&.container-form-lg {
 		@include clay-container($cadmin-container-form-lg);
-
-		.menubar-vertical-expand-lg {
-			$cadmin-container-form-lg-breakpoint-down: clay-breakpoint-prev(
-				map-get($cadmin-container-form-lg, breakpoint-up)
-			);
-
-			@include media-breakpoint-down(
-				$cadmin-container-form-lg-breakpoint-down
-			) {
-				margin-top: -(map-get($cadmin-container-form-lg, padding-top-mobile));
-			}
-		}
 	}
 
 	.container-view,

--- a/packages/clay-css/src/scss/cadmin/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_menubar.scss
@@ -9,22 +9,14 @@ $cadmin-menubar-vertical-expand-md: map-deep-merge(
 		),
 		media-breakpoint-down: (
 			sm: (
-				align-items: center,
-				display: flex,
-				flex-wrap: wrap,
-				justify-content: space-between,
-				margin-bottom: 24px,
-				margin-left: math-sign($cadmin-grid-gutter-width * 0.5),
-				margin-right: math-sign($cadmin-grid-gutter-width * 0.5),
+				margin-bottom: 16px,
 				max-width: none,
 				menubar-collapse: (
 					border-color: transparent,
 					border-style: solid,
 					border-width: 1px,
 					display: none,
-					left: -1px,
-					position: absolute,
-					right: -1px,
+					position: relative,
 					top: 100%,
 					z-index:
 						$cadmin-zindex-menubar-vertical-expand-md-collapse-mobile,
@@ -50,6 +42,8 @@ $cadmin-menubar-vertical-expand-md: map-deep-merge(
 					padding-left: 8px,
 					padding-right: 8px,
 					c-inner: (
+						margin-left: -8px,
+						margin-right: -8px,
 						max-width: none,
 					),
 					lexicon-icon: (
@@ -87,6 +81,7 @@ $cadmin-menubar-vertical-transparent-md: map-deep-merge(
 				background-color: rgba($cadmin-gray-900, 0.04),
 				color: $cadmin-gray-900,
 				font-weight: $cadmin-font-weight-semi-bold,
+				letter-spacing: 0,
 				before: (
 					background: $cadmin-secondary-l0,
 					width: 3px,
@@ -133,6 +128,7 @@ $cadmin-menubar-vertical-transparent-md: map-deep-merge(
 				),
 			),
 			show: (
+				background-color: transparent,
 				color: $cadmin-gray-900,
 				font-weight: $cadmin-font-weight-semi-bold,
 				before: (
@@ -148,7 +144,6 @@ $cadmin-menubar-vertical-transparent-md: map-deep-merge(
 		),
 		media-breakpoint-down: (
 			sm: (
-				background-color: $cadmin-white,
 				nav-link: (
 					border-radius: clay-enable-rounded(0),
 					color: $cadmin-gray-900,
@@ -191,8 +186,7 @@ $cadmin-menubar-vertical-transparent-md: map-deep-merge(
 						clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
 				),
 				menubar-toggler: (
-					box-shadow: $cadmin-component-focus-box-shadow,
-					color: $cadmin-gray-900,
+					color: $cadmin-gray-600,
 					font-size: 14px,
 					font-weight: $cadmin-font-weight-semi-bold,
 					text-decoration: none,
@@ -281,22 +275,14 @@ $cadmin-menubar-vertical-expand-lg: map-deep-merge(
 		),
 		media-breakpoint-down: (
 			md: (
-				align-items: center,
-				display: flex,
-				flex-wrap: wrap,
-				justify-content: space-between,
-				margin-bottom: 24px,
-				margin-left: math-sign($cadmin-grid-gutter-width * 0.5),
-				margin-right: math-sign($cadmin-grid-gutter-width * 0.5),
+				margin-bottom: 16px,
 				max-width: none,
 				menubar-collapse: (
 					border-color: transparent,
 					border-style: solid,
 					border-width: 1px,
 					display: none,
-					left: -1px,
-					position: absolute,
-					right: -1px,
+					position: relative,
 					top: 100%,
 					z-index:
 						$cadmin-zindex-menubar-vertical-expand-md-collapse-mobile,
@@ -322,6 +308,8 @@ $cadmin-menubar-vertical-expand-lg: map-deep-merge(
 					padding-left: 8px,
 					padding-right: 8px,
 					c-inner: (
+						margin-left: -8px,
+						margin-right: -8px,
 						max-width: none,
 					),
 					lexicon-icon: (
@@ -404,6 +392,7 @@ $cadmin-menubar-vertical-transparent-lg: map-deep-merge(
 				),
 			),
 			show: (
+				background-color: transparent,
 				color: $cadmin-gray-900,
 				font-weight: $cadmin-font-weight-semi-bold,
 				before: (
@@ -419,7 +408,6 @@ $cadmin-menubar-vertical-transparent-lg: map-deep-merge(
 		),
 		media-breakpoint-down: (
 			md: (
-				background-color: $cadmin-white,
 				nav-link: (
 					border-radius: clay-enable-rounded(0),
 					color: $cadmin-gray-900,
@@ -461,7 +449,7 @@ $cadmin-menubar-vertical-transparent-lg: map-deep-merge(
 						clay-enable-shadows(0 1px 5px -1px rgba(0, 0, 0, 0.3)),
 				),
 				menubar-toggler: (
-					color: $cadmin-gray-900,
+					color: $cadmin-gray-600,
 					font-size: 14px,
 					font-weight: $cadmin-font-weight-semi-bold,
 					text-decoration: none,

--- a/packages/clay-css/src/scss/components/_grid.scss
+++ b/packages/clay-css/src/scss/components/_grid.scss
@@ -214,16 +214,6 @@
 
 	.container-form-lg {
 		@include clay-container($container-form-lg);
-
-		.menubar-vertical-expand-lg {
-			$container-form-lg-breakpoint-down: clay-breakpoint-prev(
-				map-get($container-form-lg, breakpoint-up)
-			);
-
-			@include media-breakpoint-down($container-form-lg-breakpoint-down) {
-				margin-top: -(map-get($container-form-lg, padding-top-mobile));
-			}
-		}
 	}
 
 	.container-view {

--- a/packages/clay-css/src/scss/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/variables/_menubar.scss
@@ -9,9 +9,7 @@ $menubar-vertical-expand-md: map-deep-merge(
 		),
 		media-breakpoint-down: (
 			sm: (
-				margin-bottom: 1.5rem,
-				margin-left: math-sign($grid-gutter-width * 0.5),
-				margin-right: math-sign($grid-gutter-width * 0.5),
+				margin-bottom: 1rem,
 				max-width: none,
 				menubar-collapse: (
 					border-color: transparent,
@@ -38,11 +36,13 @@ $menubar-vertical-expand-md: map-deep-merge(
 					border-color: transparent,
 					border-style: solid,
 					border-width: 0.0625rem,
-					display: flex,
+					display: inline-flex,
 					height: 2rem,
 					padding-left: 0.5rem,
 					padding-right: 0.5rem,
 					c-inner: (
+						margin-left: -0.5rem,
+						margin-right: -0.5rem,
 						max-width: none,
 					),
 					lexicon-icon: (
@@ -75,7 +75,6 @@ $menubar-vertical-transparent-md: map-deep-merge(
 		),
 		media-breakpoint-down: (
 			sm: (
-				background-color: $gray-100,
 				nav-link: (
 					border-radius: clay-enable-rounded(0),
 					color: $gray-900,
@@ -174,9 +173,7 @@ $menubar-vertical-expand-lg: map-deep-merge(
 		),
 		media-breakpoint-down: (
 			md: (
-				margin-bottom: 1.5rem,
-				margin-left: math-sign($grid-gutter-width * 0.5),
-				margin-right: math-sign($grid-gutter-width * 0.5),
+				margin-bottom: 1rem,
 				max-width: none,
 				menubar-collapse: (
 					border-color: transparent,
@@ -203,11 +200,13 @@ $menubar-vertical-expand-lg: map-deep-merge(
 					border-color: transparent,
 					border-style: solid,
 					border-width: 0.0625rem,
-					display: flex,
+					display: inline-flex,
 					height: 2rem,
 					padding-left: 0.5rem,
 					padding-right: 0.5rem,
 					c-inner: (
+						margin-left: -0.5rem,
+						margin-right: -0.5rem,
 						max-width: none,
 					),
 					lexicon-icon: (
@@ -240,7 +239,6 @@ $menubar-vertical-transparent-lg: map-deep-merge(
 		),
 		media-breakpoint-down: (
 			md: (
-				background-color: $gray-100,
 				nav-link: (
 					border-radius: clay-enable-rounded(0),
 					color: $gray-900,


### PR DESCRIPTION
… up Cadmin styles with Atlas

fixes #5521 

@ethib137 I ended up removing the negative margins based on @emiliano-cicero's screenshot. It looks like this:

![vertical-nav](https://github.com/liferay/clay/assets/788266/1e6de484-b771-41cd-a60e-5df1d1b5d795)
