### PR TITLE
feat(@clayui/date-picker): add Picker component to select year

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -56,10 +56,10 @@ module.exports = {
 			statements: 91,
 		},
 		'./packages/clay-core/src/picker/': {
-			branches: 80,
-			functions: 84,
-			lines: 90,
-			statements: 90,
+			branches: 59,
+			functions: 66,
+			lines: 77,
+			statements: 77,
 		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 56,
@@ -74,7 +74,7 @@ module.exports = {
 			statements: 85,
 		},
 		'./packages/clay-date-picker/src/': {
-			branches: 56,
+			branches: 55,
 			functions: 89,
 			lines: 81,
 			statements: 82,

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -519,7 +519,7 @@ export function Picker<T>({
 						className={classNames(
 							'dropdown-menu dropdown-menu-indicator-start dropdown-menu-select show',
 							{
-								'dropdown-menu-width-shrink':
+								'dropdown-menu-height-lg dropdown-menu-width-shrink':
 									UNSAFE_behavior === 'secondary',
 							}
 						)}

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -532,7 +532,7 @@ export function Picker<T>({
 								<Button
 									aria-hidden="true"
 									aria-label="Scroll to top"
-									className="dropdown-item text-4 text-center"
+									className="dropdown-item dropdown-item-scroll dropdown-item-scroll-up"
 									displayType="unstyled"
 									onClick={() => {
 										const list = collection.getItems();
@@ -573,7 +573,7 @@ export function Picker<T>({
 								<Button
 									aria-hidden="true"
 									aria-label="Scroll to bottom"
-									className="dropdown-item text-4 text-center"
+									className="dropdown-item dropdown-item-scroll dropdown-item-scroll-down"
 									displayType="unstyled"
 									onClick={() => {
 										const list = collection.getItems();

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -294,18 +294,11 @@ export function Picker<T>({
 				event.target.clientHeight -
 				THRESHOLD;
 
-			if (
-				scrollTop >= THRESHOLD &&
-				scrollTop <= scrollHeightMax &&
-				isArrowVisible !== 'both'
-			) {
+			if (scrollTop >= THRESHOLD && scrollTop <= scrollHeightMax) {
 				setIsArrowVisible('both');
-			} else if (scrollTop >= THRESHOLD && isArrowVisible !== 'top') {
+			} else if (scrollTop >= THRESHOLD) {
 				setIsArrowVisible('top');
-			} else if (
-				scrollTop <= scrollHeightMax &&
-				isArrowVisible !== 'bottom'
-			) {
+			} else if (scrollTop <= scrollHeightMax) {
 				setIsArrowVisible('bottom');
 			}
 		}

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -280,7 +280,7 @@ export function Picker<T>({
 		if (
 			!active ||
 			UNSAFE_behavior !== 'secondary' ||
-			collection.getItems().length <= 7
+			collection.getItems().length <= 12
 		) {
 			return;
 		}

--- a/packages/clay-css/src/scss/cadmin/components/_date-picker.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_date-picker.scss
@@ -28,6 +28,10 @@
 	select.form-control {
 		@include clay-select-variant($cadmin-date-picker-nav-select);
 	}
+
+	.form-control-select {
+		@include clay-select-variant($cadmin-date-picker-nav-select);
+	}
 }
 
 .date-picker-nav-item {

--- a/packages/clay-css/src/scss/components/_date-picker.scss
+++ b/packages/clay-css/src/scss/components/_date-picker.scss
@@ -26,6 +26,10 @@
 	select.form-control {
 		@include clay-select-variant($date-picker-nav-select);
 	}
+
+	.form-control-select {
+		@include clay-select-variant($date-picker-nav-select);
+	}
 }
 
 .date-picker-nav-item {

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -117,7 +117,13 @@
 
 			.dropdown-item {
 				@include clay-dropdown-item-variant(
-					map-deep-get($map, dropdown-item)
+					map-get($map, dropdown-item)
+				);
+			}
+
+			.dropdown-item-scroll {
+				@include clay-dropdown-item-variant(
+					map-get($map, dropdown-item-scroll)
 				);
 			}
 

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -127,6 +127,18 @@
 				);
 			}
 
+			.dropdown-item-scroll-down {
+				@include clay-dropdown-item-variant(
+					map-get($map, dropdown-item-scroll-down)
+				);
+			}
+
+			.dropdown-item-scroll-up {
+				@include clay-dropdown-item-variant(
+					map-get($map, dropdown-item-scroll-up)
+				);
+			}
+
 			.dropdown-divider {
 				@include clay-css(map-get($map, dropdown-divider));
 			}
@@ -189,6 +201,10 @@
 						)
 					);
 				}
+			}
+
+			.inline-scroller {
+				@include clay-css(map-get($map, inline-scroller));
 			}
 		}
 	}
@@ -724,6 +740,20 @@
 					&::after {
 						@include clay-css(map-get($disabled-active, after));
 					}
+				}
+			}
+
+			&.show {
+				$show: setter(map-get($map, show), ());
+
+				@include clay-css($show);
+
+				&::before {
+					@include clay-css(map-get($show, before));
+				}
+
+				&::after {
+					@include clay-css(map-get($show, after));
 				}
 			}
 

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -969,6 +969,55 @@ $dropdown-menu-palette: map-deep-merge(
 					padding-right: 1.5rem,
 				),
 			),
+			dropdown-item-scroll: (
+				font-size: 1rem,
+				height: 2rem,
+				padding: 0,
+				position: absolute,
+				text-align: center,
+				z-index: 1,
+				hover: (
+					background-color: $dropdown-link-hover-bg,
+					background-image: none,
+					color: $dropdown-link-hover-color,
+				),
+				focus: (
+					background-color: $dropdown-link-hover-bg,
+					background-image: none,
+					color: $dropdown-link-hover-color,
+				),
+				active: (
+					background-color: $dropdown-link-active-bg,
+					background-image: none,
+					color: $dropdown-link-active-color,
+				),
+				disabled: (
+					background-color: transparent,
+					background-image: none,
+					color: $dropdown-link-disabled-color,
+					cursor: $dropdown-item-disabled-cursor,
+				),
+			),
+			dropdown-item-scroll-up: (
+				background-image: (
+					linear-gradient(
+						to bottom,
+						rgba(255, 255, 255, 1) 84%,
+						rgba(255, 255, 255, 0) 100%
+					),
+				),
+				top: $dropdown-padding-y,
+			),
+			dropdown-item-scroll-down: (
+				background-image: (
+					linear-gradient(
+						to top,
+						rgba(255, 255, 255, 1) 84%,
+						rgba(255, 255, 255, 0) 100%
+					),
+				),
+				bottom: $dropdown-padding-y,
+			),
 			dropdown-divider: (
 				margin: 0.3125rem 0,
 			),

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -1034,6 +1034,11 @@ $dropdown-menu-palette: map-deep-merge(
 				),
 			),
 		),
+		'.dropdown-menu-select.dropdown-menu-height-lg': (
+			inline-scroller: (
+				max-height: 432px,
+			),
+		),
 	),
 	$dropdown-menu-palette
 );

--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -23,6 +23,7 @@
 	],
 	"dependencies": {
 		"@clayui/button": "^3.92.0",
+		"@clayui/core": "^3.97.1",
 		"@clayui/drop-down": "^3.97.1",
 		"@clayui/form": "^3.96.0",
 		"@clayui/icon": "^3.56.0",

--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -4,7 +4,9 @@
  */
 
 import Button from '@clayui/button';
+import {Option, Picker} from '@clayui/core';
 import Icon from '@clayui/icon';
+import {Keys} from '@clayui/shared';
 import React from 'react';
 
 import {setMonth} from './Helpers';
@@ -39,8 +41,6 @@ const ClayDatePickerDateNavigation = ({
 }: Props) => {
 	const monthSelectorRef = React.useRef<HTMLSelectElement | null>(null);
 
-	const yearSelectorRef = React.useRef<HTMLSelectElement | null>(null);
-
 	/**
 	 * Handles the change of the month from the available
 	 * years in the range
@@ -63,17 +63,6 @@ const ClayDatePickerDateNavigation = ({
 	 */
 	const handleNextMonthClicked = () => handleChangeMonth(1);
 
-	/**
-	 * Handles the change of the year and month of the header
-	 */
-	function handleFormChange() {
-		if (monthSelectorRef.current && yearSelectorRef.current) {
-			const year = Number(yearSelectorRef.current.value);
-			const month = Number(monthSelectorRef.current.value);
-			onMonthChange(new Date(year, month));
-		}
-	}
-
 	return (
 		<div className="date-picker-calendar-header">
 			<div className="date-picker-nav">
@@ -81,23 +70,57 @@ const ClayDatePickerDateNavigation = ({
 					<Select
 						disabled={disabled}
 						name="month"
-						onChange={() => handleFormChange()}
+						onChange={(event) =>
+							onMonthChange(
+								new Date(
+									currentMonth.getFullYear(),
+									Number(event.target.value)
+								)
+							)
+						}
 						options={months}
-						ref={monthSelectorRef}
 						testId="month-select"
 						value={currentMonth.getMonth()}
 					/>
 				</div>
 				<div className="date-picker-nav-item input-date-picker-year">
-					<Select
+					<Picker
+						UNSAFE_behavior="secondary"
+						className="form-control-sm"
 						disabled={disabled}
-						name="year"
-						onChange={() => handleFormChange()}
-						options={years}
-						ref={yearSelectorRef}
-						testId="year-select"
-						value={currentMonth.getFullYear()}
-					/>
+						items={years}
+						native
+						onKeyDown={(
+							event: React.KeyboardEvent<HTMLButtonElement>
+						) => {
+							if (
+								event.shiftKey &&
+								(event.key === Keys.Up ||
+									event.key === Keys.Down)
+							) {
+								event.key =
+									event.key === Keys.Up
+										? 'PageUp'
+										: 'PageDown';
+							}
+						}}
+						onSelectionChange={(key: React.Key) => {
+							if (!monthSelectorRef.current) {
+								return;
+							}
+
+							onMonthChange(
+								new Date(Number(key), currentMonth.getMonth())
+							);
+						}}
+						selectedKey={String(currentMonth.getFullYear())}
+					>
+						{(item) => (
+							<Option key={item.value}>
+								{String(item.label)}
+							</Option>
+						)}
+					</Picker>
 				</div>
 
 				<div className="date-picker-nav-controls date-picker-nav-item date-picker-nav-item-expand">

--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -85,6 +85,7 @@ const ClayDatePickerDateNavigation = ({
 					<Picker
 						UNSAFE_behavior="secondary"
 						className="form-control-sm"
+						data-testid="year-select"
 						disabled={disabled}
 						items={years}
 						native

--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -39,8 +39,6 @@ const ClayDatePickerDateNavigation = ({
 	spritemap,
 	years,
 }: Props) => {
-	const monthSelectorRef = React.useRef<HTMLSelectElement | null>(null);
-
 	/**
 	 * Handles the change of the month from the available
 	 * years in the range
@@ -104,15 +102,11 @@ const ClayDatePickerDateNavigation = ({
 										: 'PageDown';
 							}
 						}}
-						onSelectionChange={(key: React.Key) => {
-							if (!monthSelectorRef.current) {
-								return;
-							}
-
+						onSelectionChange={(key: React.Key) =>
 							onMonthChange(
 								new Date(Number(key), currentMonth.getMonth())
-							);
-						}}
+							)
+						}
 						selectedKey={String(currentMonth.getFullYear())}
 					>
 						{(item) => (

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -150,9 +150,8 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -863,7 +862,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-3"
+              aria-controls="clay-id-7"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose date"
@@ -898,7 +897,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-3"
+        id="clay-id-7"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -987,9 +986,8 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -1731,7 +1729,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-4"
+              aria-controls="clay-id-10"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose date"
@@ -1766,7 +1764,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-4"
+        id="clay-id-10"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -1855,9 +1853,8 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -2711,7 +2708,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-6"
+              aria-controls="clay-id-14"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose date"
@@ -2746,7 +2743,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-6"
+        id="clay-id-14"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -2835,9 +2832,8 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="1997"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -32,7 +32,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-5"
+              aria-controls="clay-id-13"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -66,7 +66,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-5"
+        id="clay-id-13"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -155,9 +155,8 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -866,7 +865,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-3"
+              aria-controls="clay-id-7"
               aria-expanded="false"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -900,7 +899,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
-        id="clay-id-3"
+        id="clay-id-7"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -989,9 +988,8 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -1703,7 +1701,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-2"
+              aria-controls="clay-id-4"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -1737,7 +1735,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-2"
+        id="clay-id-4"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -1826,9 +1824,8 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -2542,7 +2539,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-6"
+              aria-controls="clay-id-16"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -2576,7 +2573,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-6"
+        id="clay-id-16"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -2665,9 +2662,8 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2017"
@@ -3391,7 +3387,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-4"
+              aria-controls="clay-id-10"
               aria-expanded="false"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -3430,7 +3426,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
-        id="clay-id-4"
+        id="clay-id-10"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -3519,9 +3515,8 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -4356,9 +4351,8 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -32,7 +32,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-7"
+              aria-controls="clay-id-19"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -66,7 +66,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-7"
+        id="clay-id-19"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -155,9 +155,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -870,7 +869,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-3"
+              aria-controls="clay-id-7"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -904,7 +903,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-3"
+        id="clay-id-7"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -993,9 +992,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -1708,7 +1706,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-8"
+              aria-controls="clay-id-22"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -1742,7 +1740,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-8"
+        id="clay-id-22"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -1831,9 +1829,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -2546,7 +2543,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-2"
+              aria-controls="clay-id-4"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -2580,7 +2577,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-2"
+        id="clay-id-4"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -2669,9 +2666,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -3384,7 +3380,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-6"
+              aria-controls="clay-id-16"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -3418,7 +3414,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-6"
+        id="clay-id-16"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -3507,9 +3503,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -4222,7 +4217,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-4"
+              aria-controls="clay-id-10"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -4256,7 +4251,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-4"
+        id="clay-id-10"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -4345,9 +4340,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -5164,7 +5158,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-5"
+              aria-controls="clay-id-13"
               aria-expanded="true"
               aria-haspopup="dialog"
               aria-label="Choose your desired date"
@@ -5198,7 +5192,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         aria-modal="true"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        id="clay-id-5"
+        id="clay-id-13"
         role="dialog"
         style="left: -999px; top: -995px;"
       >
@@ -5287,9 +5281,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="2019"
@@ -6125,9 +6118,8 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
-                  class="form-control form-control-sm"
+                  class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
-                  name="year"
                 >
                   <option
                     value="1997"


### PR DESCRIPTION
Closes #5537

I still need to make some CSS adjustments to better deal with the arrows that should be floating @pat270 maybe you can help me with that here. Still need to understand what happens when clicking on the arrow options there is no description of the behavior of this in the documents cc @emiliano-cicero.

Instead of creating a DatePicker specific component I added an internal property that adds these new behaviors to the Picker component when enabled to avoid duplicating code or creating rules to try and share as resources are minimal, this seems like a better strategy to maintain the code long-term.

### ToDo

- [x] Add the arrow button behaviors
- [x] Adjust CSS of the arrow buttons