### PR TITLE
fix(@clayui/multi-select): maintains backwards compatibility with the `menuRenderer` API but without the new features

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -140,10 +140,10 @@ module.exports = {
 			statements: 85,
 		},
 		'./packages/clay-multi-select/src/': {
-			branches: 54,
-			functions: 60,
-			lines: 66,
-			statements: 66,
+			branches: 52,
+			functions: 57,
+			lines: 65,
+			statements: 65,
 		},
 		'./packages/clay-multi-step-nav/src/': {
 			branches: 87,

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -473,7 +473,7 @@ export const Autocomplete = React.forwardRef<
 					triggerRef={inputElementRef}
 				>
 					<div
-						className="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select show"
+						className="dropdown-menu dropdown-menu-select show"
 						ref={menuRef}
 						role="presentation"
 						style={{


### PR DESCRIPTION
Fixes #5565, #5566

The idea is to try to keep the same behavior as before the Menu when the `menuRenderer` property is declared otherwise the new behavior is adopted. I've also added a warning when using the API to encourage teams to move to the new composition-based API that simplifies its use.

As I commented in the issue of this problem, unfortunately we were unable to maintain the same accessibility features for the `menuRenderer` because we were unable to have visibility of the list items through the React implementation and because it allows the developer to render anything in the list, we were unable to infer the which is a item on menu, so we can't do navigation with virtual focus for example or add shortcut keys.

In the DXP cases I'm updating the vast majority that use this API to the composition-based one, some cases like commerce which is a more complex implementation I will leave it to the team to take care of it because it requires more tests and more care.