### PR TITLE
feat(@clayui/multi-select): adds the possibility to ignore the item's default behavior

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -142,8 +142,8 @@ module.exports = {
 		'./packages/clay-multi-select/src/': {
 			branches: 52,
 			functions: 57,
-			lines: 65,
-			statements: 65,
+			lines: 62,
+			statements: 63,
 		},
 		'./packages/clay-multi-step-nav/src/': {
 			branches: 87,

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -278,11 +278,11 @@ export const Autocomplete = React.forwardRef<
 						children.props.onClick(event);
 					}
 
-					setActive(false);
-
 					if (event.defaultPrevented) {
 						return;
 					}
+
+					setActive(false);
 
 					currentItemSelected.current = itemValue;
 					setValue(itemValue);

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -58,6 +58,11 @@ export interface IProps<T>
 		>,
 		Omit<Partial<ICollectionProps<T, unknown>>, 'virtualize' | 'items'> {
 	/**
+	 * Flag to indicate if menu is showing or not.
+	 */
+	active?: boolean;
+
+	/**
 	 * Whether MultiSelect allows an input value not corresponding to an item
 	 * to be added.
 	 */
@@ -78,6 +83,11 @@ export interface IProps<T>
 	 * Aria label for the Close button of the labels.
 	 */
 	closeButtonAriaLabel?: string;
+
+	/**
+	 * The initial value of the active state (uncontrolled).
+	 */
+	defaultActive?: boolean;
 
 	/**
 	 * Property to set the default value (uncontrolled).
@@ -164,6 +174,11 @@ export interface IProps<T>
 	messages?: Messages;
 
 	/**
+	 * Callback for when the active state changes (controlled).
+	 */
+	onActiveChange?: InternalDispatch<boolean>;
+
+	/**
 	 * Callback for when the clear all button is clicked
 	 */
 	onClearAllButtonClick?: () => void;
@@ -214,11 +229,13 @@ export interface IProps<T>
 const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 	(
 		{
+			active: externalActive,
 			allowsCustomLabel = true,
 			alignmentByViewport,
 			children,
 			clearAllTitle = 'Clear All',
 			closeButtonAriaLabel = 'Remove {0}',
+			defaultActive,
 			defaultItems = [],
 			defaultValue = '',
 			disabled,
@@ -244,6 +261,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 				loading: 'Loading...',
 				notFound: 'No results found',
 			},
+			onActiveChange,
 			onChange,
 			onClearAllButtonClick,
 			onItemsChange,
@@ -281,8 +299,14 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 			value: externalValue ?? inputValue,
 		});
 
-		// Backward compatibility with the `menuRenderer` API.
-		const [active, setActive] = useState(false);
+		const [active, setActive] = useControlledState({
+			defaultName: 'defaultActive',
+			defaultValue: defaultActive,
+			handleName: 'onActiveChange',
+			name: 'active',
+			onChange: onActiveChange,
+			value: externalActive,
+		});
 
 		const inputElementRef =
 			(ref as React.RefObject<HTMLInputElement>) || inputRef;
@@ -325,7 +349,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 				>
 					<Autocomplete
 						{...otherProps}
-						active={MenuRenderer ? false : undefined}
+						active={MenuRenderer ? false : active}
 						allowsCustomLabel={allowsCustomLabel}
 						ariaDescriptionId={ariaDescriptionId}
 						as={Labels}
@@ -340,7 +364,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 						locator={locator}
 						menuTrigger="focus"
 						messages={messages}
-						onActiveChange={MenuRenderer ? () => {} : undefined}
+						onActiveChange={MenuRenderer ? () => {} : setActive}
 						onChange={setValue}
 						onFocus={
 							MenuRenderer && sourceItems
@@ -374,6 +398,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 
 										event.preventDefault();
 
+										setActive(false);
 										setItems([...items, item]);
 										setValue('');
 									},
@@ -386,6 +411,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 									onClick={(event) => {
 										event.preventDefault();
 
+										setActive(false);
 										setItems([...items, item]);
 										setValue('');
 									}}

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -27,11 +27,6 @@ import type {Item, LastChangeLiveRegion, Locator} from './types';
 
 type Size = null | 'sm';
 
-type Messages = {
-	loading: string;
-	notFound: string;
-};
-
 interface IMenuRendererProps {
 	/**
 	 * Value of input
@@ -124,6 +119,7 @@ export interface IProps<T>
 	/**
 	 * Defines the description of hotkeys for the component, use this
 	 * to handle internationalization.
+	 * @deprecated since v3.96.1 - use `messages` instead.
 	 */
 	hotkeysDescription?: string;
 
@@ -157,6 +153,7 @@ export interface IProps<T>
 	/**
 	 * The off-screen live region informs screen reader users the result of
 	 * removing or adding a label.
+	 * @deprecated since v3.96.1 - use `messages` instead.
 	 */
 	liveRegion?: {
 		added: string;
@@ -171,7 +168,19 @@ export interface IProps<T>
 	/**
 	 * Messages for autocomplete.
 	 */
-	messages?: Messages;
+	messages?: {
+		loading: string;
+		notFound: string;
+
+		// Defines the description of hotkeys for the component, use this
+		// to handle internationalization.
+		hotkeys: string;
+
+		// The off-screen live region informs screen reader users the result of
+		// removing or adding a label.
+		labelAdded: string;
+		labelRemoved: string;
+	};
 
 	/**
 	 * Callback for when the active state changes (controlled).
@@ -240,16 +249,13 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 			defaultValue = '',
 			disabled,
 			disabledClearAll,
-			hotkeysDescription = 'Press backspace to delete the current row.',
+			hotkeysDescription,
 			inputName,
 			inputValue,
 			isLoading: _i,
 			isValid = true,
 			items: externalItems,
-			liveRegion = {
-				added: 'Label {0} added to the list',
-				removed: 'Label {0} removed to the list',
-			},
+			liveRegion,
 			locator = {
 				id: 'key',
 				label: 'label',
@@ -258,6 +264,9 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 			loadingState,
 			menuRenderer: MenuRenderer,
 			messages = {
+				hotkeys: 'Press backspace to delete the current row.',
+				labelAdded: 'Label {0} added to the list',
+				labelRemoved: 'Label {0} removed to the list',
 				loading: 'Loading...',
 				notFound: 'No results found',
 			},
@@ -476,13 +485,21 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 						)}
 
 					<div className="sr-only">
-						<span id={ariaDescriptionId}>{hotkeysDescription}</span>
+						<span id={ariaDescriptionId}>
+							{hotkeysDescription ?? messages.hotkeys}
+						</span>
 						<span aria-live="polite" aria-relevant="text">
 							{lastChangesRef.current
 								? sub(
-										liveRegion[
-											lastChangesRef.current.action
-										],
+										liveRegion
+											? liveRegion[
+													lastChangesRef.current
+														.action
+											  ]
+											: lastChangesRef.current.action ===
+											  'added'
+											? messages.labelAdded
+											: messages.labelRemoved,
 										[lastChangesRef.current.label]
 								  )
 								: null}

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -360,8 +360,18 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 					>
 						{(item: Item) => {
 							if (children && typeof children === 'function') {
-								return React.cloneElement(children(item), {
+								const child = children(item);
+
+								return React.cloneElement(child, {
 									onClick: (event) => {
+										if (child.props.onClick) {
+											child.props.onClick(event);
+										}
+
+										if (event.defaultPrevented) {
+											return;
+										}
+
 										event.preventDefault();
 
 										setItems([...items, item]);

--- a/packages/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/packages/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -83,9 +83,7 @@ Default.args = {
 };
 
 export const ComparingItems = () => {
-	const [items, setItems] = useState<
-		React.ComponentProps<typeof ClayMultiSelect>['items']
-	>([
+	const [items, setItems] = useState([
 		{
 			label: 'one',
 			value: '1',


### PR DESCRIPTION
Related #5562

Basically this implements some improvements and fixes as I mentioned in issue #5562, adds the behavior of being able to ignore the default behavior of the component when clicking on the `Item` and explicitly adds the types to control the `active` state of the menu.

A small change was to deprecate the `liveRegion` and `hotkeysDescription` APIs to use the `messages` API which has the same goal to add the same API which has the functionality to handle translate. In the future, an idea is to group all this on the `messages` API in all components with the same behavior and we will consume this by ClayProvider so that all components can share and easier to integrate with the DXP internationalization system so that the developers don't have to worry about adding this.