### PR TITLE
fix(@clayui/autocomplete): fixes error when not resetting visual focus when menu is closed by custom logic

### DIFF
--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -331,6 +331,15 @@ export const Autocomplete = React.forwardRef<
 		visible: active,
 	});
 
+	// Resets `activeDescendant` when the menu is closed, this avoids a bug when
+	// the `active` state is controlled and closes the menu with different
+	// statements than what is expected internally.
+	useEffect(() => {
+		if (!active && activeDescendant) {
+			setActiveDescendant('');
+		}
+	}, [active]);
+
 	const onPress = useCallback(() => {
 		if (menuRef.current && activeDescendant) {
 			const item = document.getElementById(String(activeDescendant));
@@ -464,10 +473,7 @@ export const Autocomplete = React.forwardRef<
 					isKeyboardDismiss
 					isOpen
 					menuRef={menuRef}
-					onClose={() => {
-						setActiveDescendant('');
-						setActive(false);
-					}}
+					onClose={() => setActive(false)}
 					portalRef={menuRef}
 					suppress={[menuRef, inputElementRef]}
 					triggerRef={inputElementRef}


### PR DESCRIPTION
Fixes #5580

Basically the explanation of this problem is in the issue to understand the context of this correction but here instead of resetting the visual focus only when our component `<Overlay />` notifies that the menu was closed now we use the state of `active` to do this that when its state changes to `false` it is safer because the overlay events can be interrupted due to the ordering of the DOM events.