### PR TITLE
fix(@clayui/multi-select): fixes error when having to click twice to select the option

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -143,7 +143,7 @@ module.exports = {
 			branches: 52,
 			functions: 57,
 			lines: 62,
-			statements: 63,
+			statements: 62,
 		},
 		'./packages/clay-multi-step-nav/src/': {
 			branches: 87,

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -261,39 +261,44 @@ export const Autocomplete = React.forwardRef<
 		children,
 		filter: isItemsUncontrolled ? filterFn : undefined,
 		filterKey: 'value',
-		itemContainer: ({children, keyValue}: ItemProps<any>) => {
-			const itemValue =
-				children.props.textValue ??
-				children.props.value ??
-				children.props.children;
+		itemContainer: useCallback(
+			({children, keyValue}: ItemProps<any>) => {
+				const itemValue =
+					children.props.textValue ??
+					children.props.value ??
+					children.props.children;
 
-			return React.cloneElement(children, {
-				keyValue,
-				match: value,
-				onClick: (
-					event: React.MouseEvent<
-						HTMLSpanElement | HTMLButtonElement | HTMLAnchorElement
-					>
-				) => {
-					if (children.props.onClick) {
-						children.props.onClick(event);
-					}
+				return React.cloneElement(children, {
+					keyValue,
+					match: value,
+					onClick: (
+						event: React.MouseEvent<
+							| HTMLSpanElement
+							| HTMLButtonElement
+							| HTMLAnchorElement
+						>
+					) => {
+						if (children.props.onClick) {
+							children.props.onClick(event);
+						}
 
-					if (event.defaultPrevented) {
-						return;
-					}
+						if (event.defaultPrevented) {
+							return;
+						}
 
-					setActive(false);
+						setActive(false);
 
-					currentItemSelected.current = itemValue;
-					setValue(itemValue);
+						currentItemSelected.current = itemValue;
+						setValue(itemValue);
 
-					shouldIgnoreOpenMenuOnFocus.current = true;
-					inputElementRef.current?.focus();
-				},
-				roleItem: 'option',
-			}) as React.ReactElement;
-		},
+						shouldIgnoreOpenMenuOnFocus.current = true;
+						inputElementRef.current?.focus();
+					},
+					roleItem: 'option',
+				}) as React.ReactElement;
+			},
+			[value]
+		),
 		items: filteredItems,
 		notFound: (
 			<DropDown.Item
@@ -341,6 +346,8 @@ export const Autocomplete = React.forwardRef<
 			setActiveDescendant('');
 		}
 	}, [active]);
+
+	const onClose = useCallback(() => setActive(false), []);
 
 	const onPress = useCallback(() => {
 		if (menuRef.current && activeDescendant) {
@@ -481,7 +488,7 @@ export const Autocomplete = React.forwardRef<
 					isKeyboardDismiss
 					isOpen
 					menuRef={menuRef}
-					onClose={() => setActive(false)}
+					onClose={onClose}
 					portalRef={menuRef}
 					suppress={[menuRef, inputElementRef]}
 					triggerRef={inputElementRef}

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -30,7 +30,7 @@ exports[`MultiSelect incremental interactions renders a custom item 1`] = `
   <li
     data-index="1"
     role="presentation"
-    style="left: 0px; position: absolute; top: 0px; transform: translateY(0px); width: 100%;"
+    style="left: 0px; position: absolute; top: 0px; transform: translateY(37px); width: 100%;"
   >
     <button
       aria-selected="false"
@@ -183,6 +183,7 @@ exports[`MultiSelect incremental interactions renders as disabled 1`] = `
           <input
             aria-autocomplete="list"
             aria-controls="clay-id-6"
+            aria-expanded="false"
             autocomplete="off"
             autocorrect="off"
             class="form-control-inset"
@@ -344,6 +345,7 @@ exports[`MultiSelect incremental interactions renders with items 1`] = `
           <input
             aria-autocomplete="list"
             aria-controls="clay-id-2"
+            aria-expanded="false"
             autocomplete="off"
             autocorrect="off"
             class="form-control-inset"

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -244,7 +244,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 			children,
 			clearAllTitle = 'Clear All',
 			closeButtonAriaLabel = 'Remove {0}',
-			defaultActive,
+			defaultActive = false,
 			defaultItems = [],
 			defaultValue = '',
 			disabled,

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -377,11 +377,18 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 						onChange={setValue}
 						onFocus={
 							MenuRenderer && sourceItems
-								? () =>
+								? (
+										event: React.FocusEvent<HTMLInputElement>
+								  ) => {
+										if (otherProps.onFocus) {
+											otherProps.onFocus(event);
+										}
+
 										setActive(
 											!!value && sourceItems.length !== 0
-										)
-								: undefined
+										);
+								  }
+								: otherProps.onFocus
 						}
 						onFocusChange={setIsFocused}
 						onItemsChange={hasAsyncItems ? () => {} : undefined}


### PR DESCRIPTION
Fixes #5562

Well this PR fixes the problem of having to click twice to select an option, in fact what was happening was that when clicking on an option the `onBlur` method of the input was called and internally we listened to this event to update the state of focus of the input to update the focus visual state of the entire container, this causes a rerender in the component that re-renders the menu and with that causes a loss of reference to the nodes of each element in the list, which cancels the `onClick` call because the previous node no longer exists and has been removed from the DOM by a new node. So now we're stabilizing the item's component container references to avoid losing the node reference in the DOM every time a new rerender happens.

Also I fixes some small bugs I found, the `onFocus` method was not called if the developer defined it and a warning was thrown for the `active` state in the MultiSelect due to the uncontrolled to controlled state change.