### PR TITLE
fix(@clayui/autocomplete): fixes type inference for properties and generic type

### DIFF
--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -38,12 +38,7 @@ type ItemProps<T> = {
 	keyValue: React.Key;
 };
 
-export interface IProps<T>
-	extends Omit<
-			React.HTMLAttributes<HTMLInputElement>,
-			'onChange' | 'children'
-		>,
-		Omit<Partial<ICollectionProps<T, unknown>>, 'virtualize'> {
+export type IProps<T> = {
 	/**
 	 * Flag to indicate if menu is showing or not.
 	 */
@@ -62,12 +57,6 @@ export interface IProps<T>
 	 * @deprecated since v3.92.0 - it is no longer necessary..
 	 */
 	alignmentByViewport?: boolean;
-
-	/**
-	 * Autocomplete container reference.
-	 * @ignore
-	 */
-	containerElementRef: React.MutableRefObject<HTMLElement | null>;
 
 	/**
 	 * The initial value of the active state (uncontrolled).
@@ -91,9 +80,14 @@ export interface IProps<T>
 	filterKey?: string;
 
 	/**
+	 * Property to render content with dynamic data.
+	 */
+	items?: Array<T> | null;
+
+	/**
 	 * Property to set the initial value of `items` (uncontrolled).
 	 */
-	defaultItems?: Array<T>;
+	defaultItems?: Array<T> | null;
 
 	/**
 	 * Messages for autocomplete.
@@ -118,7 +112,7 @@ export interface IProps<T>
 	/**
 	 * Callback called when items change (controlled).
 	 */
-	onItemsChange?: InternalDispatch<Array<T>>;
+	onItemsChange?: InternalDispatch<Array<T> | null>;
 
 	/**
 	 * Callback is called when more items need to be loaded when the scroll
@@ -143,7 +137,8 @@ export interface IProps<T>
 	loadingState?: number;
 
 	[key: string]: any;
-}
+} & Omit<React.HTMLAttributes<HTMLInputElement>, 'onChange' | 'children'> &
+	Omit<Partial<ICollectionProps<T, unknown>>, 'virtualize' | 'items'>;
 
 const List = React.forwardRef<
 	HTMLUListElement,
@@ -165,10 +160,7 @@ const defaultMessages = {
 	notFound: 'No results found',
 };
 
-export const Autocomplete = React.forwardRef<
-	HTMLInputElement,
-	IProps<Record<string, any>>
->(function Autocomplete<T extends Record<string, any>>(
+function AutocompleteInner<T extends Record<string, any> | string | number>(
 	{
 		active: externalActive,
 		as: As = Input,
@@ -262,6 +254,10 @@ export const Autocomplete = React.forwardRef<
 
 		if (!isItemsUncontrolled) {
 			return items ?? [];
+		}
+
+		if (!items) {
+			return [];
 		}
 
 		return items?.filter((option) => {
@@ -615,4 +611,13 @@ export const Autocomplete = React.forwardRef<
 			)}
 		</>
 	);
-});
+}
+
+type ForwardRef = {
+	displayName: string;
+	<T>(props: IProps<T> & {ref?: React.Ref<HTMLInputElement>}): JSX.Element;
+};
+
+export const Autocomplete = React.forwardRef(AutocompleteInner) as ForwardRef;
+
+Autocomplete.displayName = 'Autocomplete';

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -264,9 +264,22 @@ export const Autocomplete = React.forwardRef<
 			return items ?? [];
 		}
 
-		return items?.filter((option) =>
-			filterFn(filterKey ? option[filterKey] : option)
-		);
+		return items?.filter((option) => {
+			if (!filterKey && typeof option === 'object') {
+				console.warn(
+					`<Autocomplete />: the component is trying to filter the list but it doesn't know which key to use for comparison, defines the key in 'filterKey' ('<Autocomplete filterKey="value" />'). option=`,
+					option
+				);
+
+				return true;
+			}
+
+			return filterFn(
+				filterKey && typeof option === 'object'
+					? option[filterKey]
+					: option
+			);
+		});
 	}, [debouncedLoadingChange, isItemsUncontrolled, items, filterFn]);
 
 	const virtualizer = useVirtual({

--- a/packages/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
@@ -9,6 +9,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 const messages = {
+	listCount: '{0} option available.',
+	listCountPlural: '{0} options available.',
 	loading: 'Loading...',
 	notFound: 'No results found',
 };

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -49,81 +49,91 @@ const hasItems = (children?: React.ReactNode) => {
 	}).filter(Boolean);
 };
 
-interface IProps<T> extends Omit<IAutocompleteProps<T>, 'containerElementRef'> {
+type IProps<T> = IAutocompleteProps<T> & {
 	/**
 	 * Div component to render. It can be a one component that will replace the markup.
 	 */
 	component?: React.ForwardRefExoticComponent<any>;
+};
+
+function ClayAutocompleteInner<T extends Record<string, any> | string | number>(
+	{
+		children,
+		className,
+		component: Component = AutocompleteMarkup,
+		...otherProps
+	}: IProps<T>,
+	ref: React.Ref<HTMLInputElement>
+) {
+	const containerElementRef = React.useRef<null | HTMLDivElement>(null);
+	const [loading, setLoading] = React.useState(false);
+
+	const isNewBehavior =
+		hasItems(children).length >= 1 || children instanceof Function;
+
+	const Container = isNewBehavior ? React.Fragment : FocusScope;
+
+	return (
+		<Container>
+			<Component
+				{...(isNewBehavior ? {} : otherProps)}
+				className={className}
+				ref={(r: any) => {
+					if (r) {
+						containerElementRef.current = r;
+
+						if (typeof ref === 'function') {
+							ref(r);
+						} else if (ref !== null) {
+							(ref as React.MutableRefObject<any>).current = r;
+						}
+					}
+				}}
+			>
+				{isNewBehavior ? (
+					<Autocomplete<T>
+						containerElementRef={containerElementRef}
+						{...otherProps}
+					>
+						{children}
+					</Autocomplete>
+				) : (
+					<LegacyContext.Provider
+						value={{
+							containerElementRef,
+							loading,
+							onLoadingChange: (loading: boolean) =>
+								setLoading(loading),
+						}}
+					>
+						{children}
+					</LegacyContext.Provider>
+				)}
+			</Component>
+		</Container>
+	);
 }
 
-const ClayAutocomplete = React.forwardRef<HTMLDivElement, IProps<any>>(
-	(
-		{
-			children,
-			className,
-			component: Component = AutocompleteMarkup,
-			...otherProps
-		}: IProps<any>,
-		ref
-	) => {
-		const containerElementRef = React.useRef<null | HTMLDivElement>(null);
-		const [loading, setLoading] = React.useState(false);
+type ForwardRef = {
+	DropDown: typeof DropDown;
+	Input: typeof Input;
+	Item: typeof Item;
+	LoadingIndicator: typeof LoadingIndicator;
+	displayName: string;
+	<T>(props: IProps<T> & {ref?: React.Ref<HTMLInputElement>}): JSX.Element;
+};
 
-		const isNewBehavior =
-			hasItems(children).length >= 1 || children instanceof Function;
+const ClayAutocomplete = React.forwardRef(
+	ClayAutocompleteInner
+) as unknown as ForwardRef;
 
-		const Container = isNewBehavior ? React.Fragment : FocusScope;
-
-		return (
-			<Container>
-				<Component
-					{...(isNewBehavior ? {} : otherProps)}
-					className={className}
-					ref={(r: any) => {
-						if (r) {
-							containerElementRef.current = r;
-
-							if (typeof ref === 'function') {
-								ref(r);
-							} else if (ref !== null) {
-								(ref as React.MutableRefObject<any>).current =
-									r;
-							}
-						}
-					}}
-				>
-					{isNewBehavior ? (
-						<Autocomplete
-							containerElementRef={containerElementRef}
-							{...otherProps}
-						>
-							{children}
-						</Autocomplete>
-					) : (
-						<LegacyContext.Provider
-							value={{
-								containerElementRef,
-								loading,
-								onLoadingChange: (loading: boolean) =>
-									setLoading(loading),
-							}}
-						>
-							{children}
-						</LegacyContext.Provider>
-					)}
-				</Component>
-			</Container>
-		);
-	}
-);
+ClayAutocomplete.DropDown = DropDown;
+ClayAutocomplete.Input = Input;
+ClayAutocomplete.Item = Item;
+ClayAutocomplete.LoadingIndicator = LoadingIndicator;
 
 ClayAutocomplete.displayName = 'ClayAutocomplete';
 
 export {Autocomplete, Item};
 
-export default Object.assign(ClayAutocomplete, {
-	DropDown,
-	Input,
-	Item,
-	LoadingIndicator,
-});
+export default ClayAutocomplete;

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -221,6 +221,12 @@ export const CustomItem = () => {
 	);
 };
 
+type RickandMorty = {
+	id: number;
+	name: string;
+	[key: string]: any;
+};
+
 export const AsyncFilter = () => {
 	const [value, setValue] = useState('');
 
@@ -248,7 +254,9 @@ export const AsyncFilter = () => {
 						<ClayAutocomplete
 							aria-labelledby="clay-autocomplete-label-1"
 							id="clay-autocomplete-1"
-							items={resource?.results ?? []}
+							items={
+								(resource?.results as Array<RickandMorty>) ?? []
+							}
 							loadingState={networkStatus}
 							messages={{
 								loading: 'Loading...',
@@ -308,7 +316,7 @@ export const AsyncFilterPaginated = () => {
 						<ClayAutocomplete
 							aria-labelledby="clay-autocomplete-label-1"
 							id="clay-autocomplete-1"
-							items={resource ?? []}
+							items={(resource as Array<RickandMorty>) ?? []}
 							loadingState={networkStatus}
 							messages={{
 								loading: 'Loading...',

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -54,6 +54,8 @@ export const Default = (args: any) => (
 						id="clay-autocomplete-1"
 						menuTrigger={args.menuTrigger}
 						messages={{
+							listCount: '{0} option available.',
+							listCountPlural: '{0} options available.',
 							loading: 'Loading...',
 							notFound: 'No results found',
 						}}
@@ -145,6 +147,8 @@ export const Dynamic = () => (
 						]}
 						id="clay-autocomplete-1"
 						messages={{
+							listCount: '{0} option available.',
+							listCountPlural: '{0} options available.',
 							loading: 'Loading...',
 							notFound: 'No results found',
 						}}
@@ -187,6 +191,8 @@ export const CustomItem = () => {
 							]}
 							id="clay-autocomplete-2"
 							messages={{
+								listCount: '{0} option available.',
+								listCountPlural: '{0} options available.',
 								loading: 'Loading...',
 								notFound: 'No results found',
 							}}
@@ -259,6 +265,8 @@ export const AsyncFilter = () => {
 							}
 							loadingState={networkStatus}
 							messages={{
+								listCount: '{0} option available.',
+								listCountPlural: '{0} options available.',
 								loading: 'Loading...',
 								notFound: 'No results found',
 							}}
@@ -319,6 +327,8 @@ export const AsyncFilterPaginated = () => {
 							items={(resource as Array<RickandMorty>) ?? []}
 							loadingState={networkStatus}
 							messages={{
+								listCount: '{0} option available.',
+								listCountPlural: '{0} options available.',
 								loading: 'Loading...',
 								notFound: 'No results found',
 							}}

--- a/packages/clay-core/src/collection/Collection.tsx
+++ b/packages/clay-core/src/collection/Collection.tsx
@@ -47,7 +47,7 @@ interface IProps
 }
 
 function VirtualDynamicCollection<
-	T extends Record<any, any>,
+	T extends Record<string, any> | string | number,
 	P = unknown,
 	K = unknown
 >({
@@ -103,7 +103,7 @@ function VirtualDynamicCollection<
 }
 
 function DynamicCollection<
-	T extends Record<any, any>,
+	T extends Record<string, any> | string | number,
 	P = unknown,
 	K = unknown
 >({
@@ -133,7 +133,7 @@ function DynamicCollection<
 }
 
 export function Collection<
-	T extends Record<any, any>,
+	T extends Record<string, any> | string | number,
 	P = unknown,
 	K = unknown
 >({

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -43,8 +43,12 @@ const CollectionContext = React.createContext({} as CollectionContextProps);
 
 const SECTION_NAMES = ['Group', 'Section'];
 
+function getItemId(value: Record<string, any> | string | number) {
+	return typeof value === 'object' ? value.id : value;
+}
+
 export function useCollection<
-	T extends Record<any, any>,
+	T extends Record<string, any> | string | number,
 	P = unknown,
 	K = unknown
 >({
@@ -194,16 +198,17 @@ export function useCollection<
 			if (items && children instanceof Function) {
 				for (let index = 0; index < items.length; index++) {
 					const item = items[index];
-					const publicItem = exclude
-						? excludeProps(item as T, exclude)
-						: (item as T);
+					const publicItem =
+						exclude && typeof item === 'object'
+							? excludeProps(item as Record<any, any>, exclude)
+							: (item as T);
 					const child = Array.isArray(publicApi)
 						? (children(publicItem, ...publicApi) as ChildElement)
 						: (children(publicItem) as ChildElement);
 
 					callNestedChild(child);
 
-					registerItem(child.key ?? (item as T).id, child, index);
+					registerItem(child.key ?? getItemId(item), child, index);
 				}
 			} else {
 				React.Children.forEach(children, (child, index) => {
@@ -227,9 +232,13 @@ export function useCollection<
 					return virtualizer.getVirtualItems().map((virtual) => {
 						const item = items[virtual.index];
 
-						const publicItem = exclude
-							? excludeProps(item, exclude)
-							: item;
+						const publicItem =
+							exclude && typeof item === 'object'
+								? excludeProps(
+										item as Record<any, any>,
+										exclude
+								  )
+								: item;
 						const child = Array.isArray(publicApi)
 							? (children(
 									publicItem,
@@ -261,7 +270,7 @@ export function useCollection<
 							child,
 							getKey(
 								virtual.index,
-								child.key ?? item.id,
+								child.key ?? getItemId(item),
 								parentKey
 							),
 							virtual.index,
@@ -272,16 +281,17 @@ export function useCollection<
 				}
 
 				return items.map((item, index) => {
-					const publicItem = exclude
-						? excludeProps(item, exclude)
-						: item;
+					const publicItem =
+						exclude && typeof item === 'object'
+							? excludeProps(item as Record<any, any>, exclude)
+							: item;
 					const child = Array.isArray(publicApi)
 						? (children(publicItem, ...publicApi) as ChildElement)
 						: (children(publicItem) as ChildElement);
 
 					return performItemRender(
 						child,
-						getKey(index, child.key ?? item.id, parentKey),
+						getKey(index, child.key ?? getItemId(item), parentKey),
 						index,
 						item
 					);

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -140,7 +140,7 @@ export type Props<T> = {
 	[key: string]: any;
 } & Omit<ICollectionProps<T, unknown>, 'virtualize'>;
 
-export function Picker<T>({
+export function Picker<T extends Record<string, any> | string | number>({
 	UNSAFE_behavior,
 	UNSAFE_menuClassName,
 	active: externalActive,

--- a/packages/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/packages/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -68,7 +68,7 @@ export const Default = (args: any) => {
 				inputName="myInput"
 				isValid={args.isValid}
 				items={items}
-				onItemsChange={(items) => setItems(items)}
+				onItemsChange={setItems}
 				size={args.size}
 			/>
 		</>
@@ -151,14 +151,8 @@ export const SourceItems = () => {
 	);
 };
 
-type CustomItem = {
-	email: string;
-	label: string;
-	value: string;
-};
-
 export const CustomMenu = () => {
-	const [items, setItems] = useState<Array<CustomItem>>([
+	const [items, setItems] = useState([
 		{
 			email: 'one@example.com',
 			label: 'One',
@@ -191,7 +185,7 @@ export const CustomMenu = () => {
 					},
 				]}
 			>
-				{(item: CustomItem) => (
+				{(item) => (
 					<ClayMultiSelect.Item
 						key={item.value}
 						textValue={item.label}
@@ -219,7 +213,9 @@ export const CustomMenu = () => {
 
 export const CustomFilter = () => {
 	const [value, setValue] = useState('');
-	const [items, setItems] = useState<any>([]);
+	const [items, setItems] = useState<Array<{label: string; value: string}>>(
+		[]
+	);
 
 	return (
 		<ClayMultiSelect
@@ -232,9 +228,15 @@ export const CustomFilter = () => {
 	);
 };
 
+type RickandMorty = {
+	id: number;
+	name: string;
+	[key: string]: any;
+};
+
 export const Async = () => {
 	const [value, setValue] = useState('');
-	const [items, setItems] = useState<any>([]);
+	const [items, setItems] = useState<Array<RickandMorty>>([]);
 
 	const [networkStatus, setNetworkStatus] = useState<NetworkStatus>(
 		NetworkStatus.Unused
@@ -253,10 +255,10 @@ export const Async = () => {
 			locator={{id: 'id', label: 'name', value: 'name'}}
 			onChange={setValue}
 			onItemsChange={setItems}
-			sourceItems={resource?.results ?? []}
+			sourceItems={(resource?.results as Array<RickandMorty>) ?? []}
 			value={value}
 		>
-			{(item: any) => (
+			{(item) => (
 				<ClayMultiSelect.Item key={item.id}>
 					{item.name}
 				</ClayMultiSelect.Item>


### PR DESCRIPTION
Fixes #5577

Generic types for the component along with `React.forwardRef` didn't work as expected so I had to do some different strategies to get the types to work correctly so the `<Autocomplete />` wasn't inferring the correct properties of the component that was fixed now. `<MultiSelect />` and `<Autocomplete />` now have type inference for controlled and uncontrolled state APIs just like other components, for example:

```jsx
<MultiSelect
  items={items}
  onItemsChange={setItems} // <- It works
/>
```

I'm still marking this PR as a draft because it doesn't correct the inference in case the controlled state is an anonymous function, the value is not being inferred, I still don't understand why this is happening, so I'll keep investigating.

```jsx
<MultiSelect
  items={items}
  onItemsChange={(items) => setItems(items)} // <- items is any
/>
```