### PR TITLE
fix(@clayui/multi-select): fix error of not showing menu if it has suggestions when menuRenderer is used

### DIFF
--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -342,7 +342,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 			if (MenuRenderer && sourceItems) {
 				setActive(!!value && sourceItems.length !== 0);
 			}
-		}, [value]);
+		}, [value, sourceItems]);
 
 		return (
 			<Container {...containerProps}>


### PR DESCRIPTION
Fixes #5588

If the data is not asynchronous the menu will always appear but the specific case of commerce is that the data is asynchronous so we don't validate again after the `sourceItems` has changed if the menu should only be shown when the `value` changes.