### PR TITLE
fix(@clayui/autocomplete): fix bug not announcing available options when autocomplete is open

### DIFF
--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -26,4 +26,6 @@ export {Nav} from './nav';
 
 // Internal dependencies not public but exposed to other Clay packages.
 export * as __NOT_PUBLIC_COLLECTION from './collection';
+export * as __NOT_PUBLIC_LIVE_ANNOUNCER from './live-announcer';
+export type {AnnouncerAPI} from './live-announcer';
 export type {ICollectionProps} from './collection';

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -169,6 +169,8 @@ export interface IProps<T>
 	 * Messages for autocomplete.
 	 */
 	messages?: {
+		listCount: string;
+		listCountPlural: string;
 		loading: string;
 		notFound: string;
 
@@ -267,6 +269,8 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps<unknown>>(
 				hotkeys: 'Press backspace to delete the current row.',
 				labelAdded: 'Label {0} added to the list',
 				labelRemoved: 'Label {0} removed to the list',
+				listCount: '{0} option available.',
+				listCountPlural: '{0} options available.',
 				loading: 'Loading...',
 				notFound: 'No results found',
 			},


### PR DESCRIPTION
Fixes #5590

This PR implements the announcement to the SR of the amount of options available in an Autocomplete, this reflects to the MultiSelect as well, this only happens when there is no item with focus with the exception of the Voice Over that does not announce. We also announce for any SR when the user is typing and the list changes.