### PR TITLE
fix(@clayui/form): adds the proper `role` to the switch component

### DIFF
--- a/packages/clay-form/src/Toggle.tsx
+++ b/packages/clay-form/src/Toggle.tsx
@@ -31,6 +31,7 @@ const ClayToggle = React.forwardRef<HTMLLabelElement, IToggleProps>(
 			label,
 			onChange,
 			onToggle,
+			role = 'switch',
 			spritemap,
 			symbol,
 			toggled,
@@ -71,6 +72,7 @@ const ClayToggle = React.forwardRef<HTMLLabelElement, IToggleProps>(
 								onToggle(!toggled);
 							}
 						}}
+						role={role}
 						type={type}
 						value={value}
 					/>

--- a/packages/clay-form/src/__tests__/__snapshots__/Toggle.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/Toggle.tsx.snap
@@ -11,6 +11,7 @@ exports[`Rendering default 1`] = `
       checked={false}
       className="toggle-switch-check"
       onChange={[Function]}
+      role="switch"
       type="checkbox"
     />
     <span
@@ -39,6 +40,7 @@ exports[`Rendering inside radiogroup 1`] = `
         checked={true}
         className="toggle-switch-check"
         onChange={[Function]}
+        role="switch"
         type="radio"
         value="foo"
       />
@@ -67,6 +69,7 @@ exports[`Rendering inside radiogroup 1`] = `
         checked={false}
         className="toggle-switch-check"
         onChange={[Function]}
+        role="switch"
         type="radio"
         value="bar"
       />
@@ -95,6 +98,7 @@ exports[`Rendering inside radiogroup 1`] = `
         checked={false}
         className="toggle-switch-check"
         onChange={[Function]}
+        role="switch"
         type="radio"
         value="baz"
       />
@@ -128,6 +132,7 @@ exports[`Rendering w/ disabled 1`] = `
       className="toggle-switch-check"
       disabled={true}
       onChange={[Function]}
+      role="switch"
       type="checkbox"
     />
     <span
@@ -153,6 +158,7 @@ exports[`Rendering w/ symbol 1`] = `
       checked={false}
       className="toggle-switch-check"
       onChange={[Function]}
+      role="switch"
       type="checkbox"
     />
     <span


### PR DESCRIPTION
Fixes #5586