### PR TITLE
chore: converts all example collections that have id with type `number` to `string`

### DIFF
--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -28,17 +28,17 @@ const ITEMS_DRIVE = [
 			{
 				children: [
 					{
-						children: [{id: 17, name: 'Research 1'}],
-						id: 3,
+						children: [{id: '17', name: 'Research 1'}],
+						id: '3',
 						name: 'Research',
 					},
 					{
-						children: [{id: 16, name: 'News 1'}],
-						id: 4,
+						children: [{id: '16', name: 'News 1'}],
+						id: '4',
 						name: 'News',
 					},
 				],
-				id: 2,
+				id: '2',
 				name: 'Blogs',
 			},
 			{
@@ -46,59 +46,59 @@ const ITEMS_DRIVE = [
 					{
 						children: [
 							{
-								id: 18,
+								id: '18',
 								name: 'Instructions.pdf',
 								status: 'success',
 								type: 'pdf',
 							},
 						],
-						id: 15,
+						id: '15',
 						name: 'PDF',
 					},
 					{
 						children: [
 							{
-								id: 6,
+								id: '6',
 								name: 'Treeview review.docx',
 								status: 'success',
 								type: 'document',
 							},
 							{
-								id: 7,
+								id: '7',
 								name: 'Heuristics Evaluation.docx',
 								status: 'success',
 								type: 'document',
 							},
 						],
 						disabled: true,
-						id: 8,
+						id: '8',
 						name: 'Word',
 					},
 				],
-				id: 5,
+				id: '5',
 				name: 'Documents and Media',
 			},
 		],
 		disabled: true,
-		id: 1,
+		id: '1',
 		name: 'Liferay Drive',
 		type: 'cloud',
 	},
 	{
 		children: [
-			{disabled: true, id: 10, name: 'Blogs'},
-			{id: 11, name: 'Documents and Media'},
+			{disabled: true, id: '10', name: 'Blogs'},
+			{id: '11', name: 'Documents and Media'},
 		],
-		id: 9,
+		id: '9',
 		name: 'Repositories',
 		type: 'repository',
 	},
 	{
 		children: [
-			{id: 13, name: 'PDF'},
-			{id: 14, name: 'Word'},
+			{id: '13', name: 'PDF'},
+			{id: '14', name: 'Word'},
 		],
-		id: 12,
+		id: '12',
 		name: 'Documents and Media',
 		status: 'warning',
 	},
@@ -162,7 +162,7 @@ let nodeId = 0;
 
 type Node = {
 	children: Array<Node>;
-	id: number;
+	id: string;
 	name: string;
 };
 
@@ -173,7 +173,7 @@ const createNode = (
 ) => {
 	const node: Node = {
 		children: [],
-		id: nodeId,
+		id: String(nodeId),
 		name: `node-${nodeId}`,
 	};
 
@@ -525,29 +525,29 @@ export const PageElements = () => {
 										{
 											children: [
 												{
-													id: 11,
+													id: '11',
 													name: 'element-text',
 													type: 'editable',
 												},
 											],
-											id: 12,
+											id: '12',
 											name: 'Heading',
 											type: 'fragment-text',
 										},
 										{
 											children: [
 												{
-													id: 10,
+													id: '10',
 													name: 'element-text',
 													type: 'editable',
 												},
 											],
-											id: 13,
+											id: '13',
 											name: 'Paragraph',
 											type: 'paragraph',
 										},
 									],
-									id: 5,
+									id: '5',
 									name: 'Module',
 								},
 								{
@@ -555,38 +555,38 @@ export const PageElements = () => {
 										{
 											children: [
 												{
-													id: 9,
+													id: '9',
 													name: 'image-squere',
 													type: 'editable',
 												},
 											],
-											id: 6,
+											id: '6',
 											name: 'Image',
 											type: 'fragment-image',
 										},
 									],
-									id: 4,
+									id: '4',
 									name: 'Module',
 								},
 							],
-							id: 3,
+							id: '3',
 							name: 'Grid',
 							type: 'row',
 						},
 					],
-					id: 2,
+					id: '2',
 					name: 'Container',
 					type: 'container',
 				},
 			],
-			id: 1,
+			id: '1',
 			name: 'Container',
 			type: 'container',
 		},
 	];
 
 	const [expandedKeys, setExpandedKeys] = useState<Set<React.Key>>(
-		new Set([1, 2, 3, 4, 5])
+		new Set(['1', '2', '3', '4', '5'])
 	);
 
 	return (
@@ -627,7 +627,7 @@ export const PageElements = () => {
 
 export const PreSelectedItems = (args: any) => {
 	const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
-		new Set([3, 15, 17, 18])
+		new Set(['3', '15', '17', '18'])
 	);
 
 	// Just to avoid TypeScript error with required props
@@ -1325,12 +1325,12 @@ export const DemoCategoriesSingle = () => {
 		<TreeView
 			defaultItems={[
 				{
-					id: 0,
+					id: '0',
 					name: 'Animals',
 					vocabulary: true,
 				},
 				{
-					id: 1,
+					id: '1',
 					name: 'Vegetables',
 					vocabulary: true,
 				},
@@ -1339,36 +1339,36 @@ export const DemoCategoriesSingle = () => {
 						{
 							children: [
 								{
-									id: 7,
+									id: '7',
 									name: 'Metals',
 								},
 								{
-									id: 8,
+									id: '8',
 									name: 'Semimetals',
 								},
 								{
-									id: 9,
+									id: '9',
 									name: 'Nonmetals',
 								},
 							],
-							id: 4,
+							id: '4',
 							name: 'Native Elements',
 						},
 						{
-							id: 5,
+							id: '5',
 							name: 'Sulfides',
 						},
 						{
-							id: 6,
+							id: '6',
 							name: 'Silicates',
 						},
 					],
-					id: 2,
+					id: '2',
 					name: 'Minerals',
 					vocabulary: true,
 				},
 				{
-					id: 3,
+					id: '3',
 					name: 'Plants',
 					vocabulary: true,
 				},
@@ -1458,30 +1458,30 @@ export const DemoCategoriesMultiple = () => {
 				{
 					children: [
 						{
-							id: 16,
+							id: '16',
 							name: 'Dog',
 						},
 						{
-							id: 17,
+							id: '17',
 							name: 'Cat',
 						},
 					],
-					id: 1,
+					id: '1',
 					name: 'Animals',
 					vocabulary: true,
 				},
 				{
 					children: [
 						{
-							id: 14,
+							id: '14',
 							name: 'Arrowroot',
 						},
 						{
-							id: 15,
+							id: '15',
 							name: 'Arugula',
 						},
 					],
-					id: 2,
+					id: '2',
 					name: 'Vegetables',
 					vocabulary: true,
 				},
@@ -1490,50 +1490,50 @@ export const DemoCategoriesMultiple = () => {
 						{
 							children: [
 								{
-									id: 8,
+									id: '8',
 									name: 'Metals',
 								},
 								{
-									id: 9,
+									id: '9',
 									name: 'Semimetals',
 								},
 								{
-									id: 10,
+									id: '10',
 									name: 'Nonmetals',
 								},
 							],
-							id: 5,
+							id: '5',
 							name: 'Native Elements',
 						},
 						{
-							id: 6,
+							id: '6',
 							name: 'Sulfides',
 						},
 						{
-							id: 7,
+							id: '7',
 							name: 'Silicates',
 						},
 					],
-					id: 3,
+					id: '3',
 					name: 'Minerals',
 					vocabulary: true,
 				},
 				{
 					children: [
 						{
-							id: 11,
+							id: '11',
 							name: 'Bamboo',
 						},
 						{
-							id: 12,
+							id: '12',
 							name: 'Cactus',
 						},
 						{
-							id: 13,
+							id: '13',
 							name: 'Eucalyptus',
 						},
 					],
-					id: 4,
+					id: '4',
 					name: 'Plants',
 					vocabulary: true,
 				},
@@ -1613,25 +1613,25 @@ export const DemoDocumentsMultiple = () => {
 			defaultItems={[
 				{
 					children: [
-						{id: 2, name: 'Basic Web Content'},
-						{id: 3, name: 'New'},
-						{id: 4, name: 'Article'},
+						{id: '2', name: 'Basic Web Content'},
+						{id: '3', name: 'New'},
+						{id: '4', name: 'Article'},
 					],
-					id: 1,
+					id: '1',
 					name: 'Web Content Article',
 					type: 'article',
 				},
 				{
 					children: [
-						{id: 5, name: 'Basic Documents'},
+						{id: '5', name: 'Basic Documents'},
 						{name: 'External Video Shortcut'},
 					],
-					id: 6,
+					id: '6',
 					name: 'Documents',
 					type: 'documents',
 				},
 			]}
-			defaultSelectedKeys={new Set([1, 2, 3, 4, 5])}
+			defaultSelectedKeys={new Set(['1', '2', '3', '4', '5'])}
 			expandDoubleClick
 			selectionMode="multiple-recursive"
 			showExpanderOnHover={false}

--- a/packages/clay-core/stories/VerticalNav.stories.tsx
+++ b/packages/clay-core/stories/VerticalNav.stories.tsx
@@ -9,7 +9,7 @@ import React, {useState} from 'react';
 import {VerticalNav} from '../src';
 
 type Item = {
-	id: number;
+	id: string;
 	href?: string;
 	label: string;
 	active?: boolean;
@@ -18,11 +18,11 @@ type Item = {
 
 const items = [
 	{
-		id: 1,
+		id: '1',
 		items: [
 			{
 				href: '#',
-				id: 2,
+				id: '2',
 				label: 'Nested1',
 			},
 		],
@@ -30,25 +30,25 @@ const items = [
 	},
 	{
 		href: '#',
-		id: 3,
+		id: '3',
 		label: 'About',
 	},
 	{
 		href: '#',
-		id: 4,
+		id: '4',
 		label: 'Contact',
 	},
 	{
-		id: 5,
+		id: '5',
 		items: [
 			{
 				href: '#',
-				id: 6,
+				id: '6',
 				label: 'Five',
 			},
 			{
 				href: '#',
-				id: 7,
+				id: '7',
 				label: 'Six',
 			},
 		],
@@ -56,7 +56,7 @@ const items = [
 	},
 	{
 		href: '#',
-		id: 8,
+		id: '8',
 		label: 'Seven',
 	},
 ] as Array<Item>;
@@ -439,7 +439,7 @@ export default {
 };
 
 export const Default = () => (
-	<VerticalNav active={6} items={items}>
+	<VerticalNav active="6" items={items}>
 		{(item) => (
 			<VerticalNav.Item href={item.href} items={item.items} key={item.id}>
 				{item.label}

--- a/packages/clay-nav/docs/index.js
+++ b/packages/clay-nav/docs/index.js
@@ -47,14 +47,14 @@ const verticalNavigationImportsCode = `import {ClayVerticalNav} from '@clayui/na
 const VerticalNavigationCode = `const Component = () => {
 	return (
 		<ClayVerticalNav
-			active={6}
-			defaultExpandedKeys={new Set([5])}
+			active="6"
+			defaultExpandedKeys={new Set(['5'])}
 			items={[
 				{
-					id: 1,
+					id: '1',
 					items: [
 						{
-							id: 2,
+							id: '2',
 							href: '#nested1',
 							label: 'Nested1',
 						},
@@ -62,25 +62,25 @@ const VerticalNavigationCode = `const Component = () => {
 					label: 'Home',
 				},
 				{
-					id: 3,
+					id: '3',
 					href: '#2',
 					label: 'About',
 				},
 				{
-					id: 4,
+					id: '4',
 					href: '#3',
 					label: 'Contact',
 				},
 				{
-					id: 5,
+					id: '5',
 					items: [
 						{
-							id: 6,
+							id: '6',
 							href: '#5',
 							label: 'Five',
 						},
 						{
-							id: 7,
+							id: '7',
 							href: '#6',
 							label: 'Six',
 						},
@@ -88,7 +88,7 @@ const VerticalNavigationCode = `const Component = () => {
 					label: 'Projects',
 				},
 				{
-					id: 8,
+					id: '8',
 					href: '#7',
 					label: 'Seven',
 				},


### PR DESCRIPTION
Fixes #5595

To understand the context see [my comment](https://github.com/liferay/clay/issues/5595#issuecomment-1603341079) in the issue. Basically I'm changing all the examples we have that are related to Collection that has an `id` of type `number` to `string` to avoid problems.

One solution we could try is to internally convert the values of `active` and any property that is related to `key` with type `number` to `string` so that everything internally communicates with type `string` the problem is that if the developer controls the states he can have his state change from type `number` to `string` mainly if he saves some of this information on the server. I believe these cases are more rare normally the `id` are of type `string` instead of `number` when something is related to a list coming from the database the `id` can be uuid, uid or any other pattern that is not just of type `number`. So I think it's safe to go with that now and we'll look into the possibilities as soon as use cases come up where the `id`s are from the database and can't be changed.