### PR TITLE
fix(@clayui/tooltip): fix error not showing tooltip on nested elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"size-limit": [
 		{
 			"path": "all.js",
-			"limit": "140 kb",
+			"limit": "141 kb",
 			"ignore": [
 				"react",
 				"react-dom"


### PR DESCRIPTION
Fixes #5607

Now even if you have the `title` defined for nested elements the tooltip will be shown for the element that has the focus and also prevents the title of the parent element from being shown by the browser.