### PR TITLE
fix(@clayui/autocomplete): makes new `messages` properties optional

### DIFF
--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -93,8 +93,8 @@ export type IProps<T> = {
 	 * Messages for autocomplete.
 	 */
 	messages?: {
-		listCount: string;
-		listCountPlural: string;
+		listCount?: string;
+		listCountPlural?: string;
 		loading: string;
 		notFound: string;
 	};
@@ -395,8 +395,8 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 			announcerAPI.current.announce(
 				sub(
 					optionCount === 1
-						? messages!.listCount
-						: messages!.listCountPlural,
+						? messages!.listCount!
+						: messages!.listCountPlural!,
 					[optionCount]
 				)
 			);

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -169,8 +169,8 @@ export interface IProps<T>
 	 * Messages for autocomplete.
 	 */
 	messages?: {
-		listCount: string;
-		listCountPlural: string;
+		listCount?: string;
+		listCountPlural?: string;
 		loading: string;
 		notFound: string;
 


### PR DESCRIPTION
Fixes #5617