### PR TITLE
fix(@clayui/css): Utilities c-prefers-expanded-text shouldn't display…

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
@@ -857,6 +857,15 @@
 	visibility: hidden !important;
 }
 
+// C Prefers Expanded Text
+
+%c-prefers-expanded-text {
+	max-width: none !important;
+	overflow-wrap: break-word !important;
+	white-space: normal !important;
+	word-wrap: break-word !important;
+}
+
 @at-root {
 	// C Prefers Link Underline
 

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -834,7 +834,7 @@
 // C Prefers Expanded Text
 
 %c-prefers-expanded-text {
-	max-width: 100% !important;
+	max-width: none !important;
 	overflow-wrap: break-word !important;
 	white-space: normal !important;
 	word-wrap: break-word !important;


### PR DESCRIPTION
… text in a column

fixes #5620

@ethib137 `c-prefers-expanded-text` with tabs should look like:

![tabs](https://github.com/liferay/clay/assets/788266/493c12da-0d0b-40cb-9684-2238a07b3875)

The page editor tabs use the utility class `flex-nowrap`. It will overflow on the right, we need to remove it if we want the tabs to break to new line with long text.