### PR TITLE
fix(@clayui/multi-select): pass async properties to autocomplete

### DIFF
--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -40,6 +40,12 @@ type ItemProps<T> = {
 
 export type IProps<T> = {
 	/**
+	 * Internal property to change the loading indicator markup to shrink.
+	 * @ignore
+	 */
+	UNSAFE_loadingShrink?: boolean;
+
+	/**
 	 * Flag to indicate if menu is showing or not.
 	 */
 	active?: boolean;
@@ -162,6 +168,7 @@ const defaultMessages = {
 
 function AutocompleteInner<T extends Record<string, any> | string | number>(
 	{
+		UNSAFE_loadingShrink,
 		active: externalActive,
 		as: As = Input,
 		alignmentByViewport: _,
@@ -417,6 +424,10 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 		}
 	}, [activeDescendant]);
 
+	const LoadingGroupItem = UNSAFE_loadingShrink
+		? Input.GroupItem
+		: Input.GroupInsetItem;
+
 	return (
 		<>
 			<LiveAnnouncer ref={announcerAPI} />
@@ -597,17 +608,18 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 			)}
 
 			{isLoading && (
-				<Input.GroupInsetItem
-					after
+				<LoadingGroupItem
+					after={!UNSAFE_loadingShrink ? true : undefined}
 					aria-label={messages.loading}
 					aria-valuemax={100}
 					aria-valuemin={0}
 					role="progressbar"
+					shrink={UNSAFE_loadingShrink}
 				>
 					<span className="inline-item inline-item-middle">
 						<LoadingIndicator size="sm" />
 					</span>
-				</Input.GroupInsetItem>
+				</LoadingGroupItem>
 			)}
 		</>
 	);

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -374,6 +374,7 @@ function ClayMultiSelectInner<T extends Record<string, any> = Item>(
 					items={hasAsyncItems ? sourceItems : undefined}
 					labels={items}
 					lastChangesRef={lastChangesRef}
+					loadingState={loadingState}
 					locator={locator}
 					menuTrigger="focus"
 					messages={messages}
@@ -395,6 +396,7 @@ function ClayMultiSelectInner<T extends Record<string, any> = Item>(
 					onFocusChange={setIsFocused}
 					onItemsChange={hasAsyncItems ? () => {} : undefined}
 					onLabelsChange={setItems}
+					onLoadMore={onLoadMore}
 					placeholder={placeholder}
 					ref={inputElementRef}
 					spritemap={spritemap}

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -361,6 +361,7 @@ function ClayMultiSelectInner<T extends Record<string, any> = Item>(
 			>
 				<Autocomplete<T>
 					{...otherProps}
+					UNSAFE_loadingShrink
 					active={MenuRenderer ? false : active}
 					allowsCustomLabel={allowsCustomLabel}
 					ariaDescriptionId={ariaDescriptionId}


### PR DESCRIPTION
Fixes [LPS-189949](https://liferay.atlassian.net/browse/LPS-189949)

Basically the asynchronous or paged loading was not working correctly in MultiSelect because we forgot to pass the properties back to Autocomplete because we were using it to identify if the component was operating asynchronously or just dynamically.