### PR TITLE
fix(@clayui/css): Adds btn-beta-dark and badge-beta-dark and updates background colors

### DIFF
--- a/packages/clay-badge/docs/badge.mdx
+++ b/packages/clay-badge/docs/badge.mdx
@@ -5,13 +5,14 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/badges/'
 packageNpm: '@clayui/badge'
 ---
 
-import {Badge, BadgeBeta} from '$packages/clay-badge/docs/index';
+import {Badge, BadgeBeta, BadgeBetaDark} from '$packages/clay-badge/docs/index';
 
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
 -   [Display Types](#display-types)
 -   [Beta](#badge-beta)
+    -   [Dark](#badge-beta-dark)
 
 </div>
 </div>
@@ -30,3 +31,9 @@ We recommend that you review the use cases in the <a href="https://storybook.cla
 A component to indicate beta features in DXP. The `badge-beta` variant doesn’t have any interaction. It just informs the user. It uses a Badge component with custom visual states.
 
 <BadgeBeta />
+
+## Beta Dark(#badge-beta-dark)
+
+`badge-beta-dark` is a dark variant of `badge-beta` to be used with dark backgrounds.
+
+<BadgeBetaDark />

--- a/packages/clay-badge/docs/index.js
+++ b/packages/clay-badge/docs/index.js
@@ -76,8 +76,6 @@ export const Badge = () => {
 	return <Editor code={codeSnippets} scope={scope} />;
 };
 
-//
-
 const badgeBetaImportsCode = `import ClayBadge from '@clayui/badge';`;
 
 const BadgeBetaCode = `const Component = () => {
@@ -111,6 +109,47 @@ export const BadgeBeta = () => {
 			imports: badgeBetaJSPImportsCode,
 			name: 'JSP',
 			value: BadgeBetaJSPCode,
+		},
+	];
+
+	return <Editor code={codeSnippets} scope={scope} />;
+};
+
+const badgeBetaDarkImportsCode = `import ClayBadge from '@clayui/badge';`;
+
+const BadgeBetaDarkCode = `const Component = () => {
+    return (
+        <>
+        	<div className="bg-dark p-2">
+            	<ClayBadge displayType="beta-dark" label="Beta" />
+            </div>
+        </>
+    );
+}
+
+render(<Component />);`;
+
+const badgeBetaDarkJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
+
+const BadgeBetaDarkJSPCode = `<clay:badge
+    displayType="beta-dark"
+    label="Beta" 
+/>`;
+
+export const BadgeBetaDark = () => {
+	const scope = {ClayBadge};
+
+	const codeSnippets = [
+		{
+			imports: badgeBetaDarkImportsCode,
+			name: 'React',
+			value: BadgeBetaDarkCode,
+		},
+		{
+			disabled: true,
+			imports: badgeBetaDarkJSPImportsCode,
+			name: 'JSP',
+			value: BadgeBetaDarkJSPCode,
 		},
 	];
 

--- a/packages/clay-badge/src/index.tsx
+++ b/packages/clay-badge/src/index.tsx
@@ -13,7 +13,8 @@ type DisplayType =
 	| 'danger'
 	| 'success'
 	| 'warning'
-	| 'beta';
+	| 'beta'
+	| 'beta-dark';
 
 interface IProps extends React.HTMLAttributes<HTMLSpanElement> {
 	/**

--- a/packages/clay-button/docs/button.mdx
+++ b/packages/clay-button/docs/button.mdx
@@ -7,6 +7,7 @@ packageNpm: '@clayui/button'
 
 import {
 	ButtonBeta,
+	ButtonBetaDark,
 	ButtonDisplayTypes,
 	ButtonGroup,
 	ButtonIcon,
@@ -19,6 +20,7 @@ import {
 -   [Group](#group)
 -   [Icon](#icon)
 -   [Beta](#btn-beta)
+    -   [Dark](#btn-beta-dark)
 
 </div>
 </div>
@@ -47,8 +49,14 @@ You can use the high-level component `ClayButtonWithIcon` to create a button wit
 
 <ButtonIcon />
 
-## Beta
+## Beta(#btn-beta)
 
 A component to indicate beta features in DXP. The Button variant should be used when the component can be placed close to a non-interactive UI element, such as a title or a section. Also, a default popover is shown if the user interacts with it.
 
 <ButtonBeta />
+
+### Beta Dark(#btn-beta-dark)
+
+`btn-beta-dark` is a dark variant of `btn-beta` to be used with dark backgrounds.
+
+<ButtonBetaDark />

--- a/packages/clay-button/docs/index.js
+++ b/packages/clay-button/docs/index.js
@@ -160,4 +160,42 @@ const ButtonBeta = () => {
 	return <Editor code={code} imports={buttonBetaImportsCode} scope={scope} />;
 };
 
-export {ButtonDisplayTypes, ButtonGroup, ButtonIcon, ButtonBeta};
+const buttonBetaDarkImportsCode = `import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon;'`;
+
+const ButtonBetaDarkCode = `const Component = () => {
+	return (
+		<>
+			<div className="bg-dark p-2">
+				<ClayButton className="rounded-circle" displayType="beta-dark" size="xs">
+					<span className="inline-item">
+						{'Beta'}
+					</span>
+
+					<span className="inline-item inline-item-after">
+						<ClayIcon spritemap={spritemap} symbol="info-panel-open" />
+					</span>
+				</ClayButton>
+			</div>
+		</>
+	);
+}
+
+render(<Component />);`;
+
+const ButtonBetaDark = () => {
+	const scope = {ClayButton, ClayButtonWithIcon, ClayIcon};
+	const code = ButtonBetaDarkCode;
+
+	return (
+		<Editor code={code} imports={buttonBetaDarkImportsCode} scope={scope} />
+	);
+};
+
+export {
+	ButtonDisplayTypes,
+	ButtonGroup,
+	ButtonIcon,
+	ButtonBeta,
+	ButtonBetaDark,
+};

--- a/packages/clay-button/src/Button.tsx
+++ b/packages/clay-button/src/Button.tsx
@@ -19,6 +19,7 @@ export type DisplayType =
 	| 'danger'
 	| 'info'
 	| 'beta'
+	| 'beta-dark'
 	| 'unstyled';
 
 export interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/packages/clay-css/src/scss/variables/_badges.scss
+++ b/packages/clay-css/src/scss/variables/_badges.scss
@@ -495,8 +495,13 @@ $badge-palette: map-deep-merge(
 		light: $badge-light,
 		dark: $badge-dark,
 		badge-beta: (
-			background-color: $light-l1,
+			background-color: rgba($info-d1, 0.04),
 			color: $info-d1,
+			text-transform: uppercase,
+		),
+		badge-beta-dark: (
+			background-color: rgba($info-l2, 0.04),
+			color: $info-l1,
 			text-transform: uppercase,
 		),
 	),

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -895,16 +895,30 @@ $btn-palette: map-deep-merge(
 		dark: $btn-dark,
 		link: $btn-link,
 		btn-beta: (
-			background-color: $light-l1,
+			background-color: rgba($info-d1, 0.04),
 			color: $info-d1,
 			text-transform: uppercase,
 			hover: (
-				background-color: $light,
+				background-color: rgba($info-d1, 0.06),
 				color: $info-d1,
 			),
 			focus: (
-				background-color: $light,
+				background-color: rgba($info-d1, 0.06),
 				color: $info-d1,
+			),
+		),
+		btn-beta-dark: (
+			background-color: rgba($info-l2, 0.04),
+			border-color: transparent,
+			color: $info-l1,
+			text-transform: uppercase,
+			hover: (
+				background-color: rgba($info-l2, 0.06),
+				color: $info-l1,
+			),
+			focus: (
+				background-color: rgba($info-l2, 0.06),
+				color: $info-l1,
 			),
 		),
 	),


### PR DESCRIPTION
fixes #5623

@matuzalemsteles I currently have the classes as `btn-beta-dark` and `badge-beta-dark`. I was considering using `.btn-beta.btn-dark` and `.badge-beta.badge-dark`.