### PR TITLE
fix(@clayui/core): fix error when validating focus without any element

### DIFF
--- a/packages/clay-core/src/aria/useFocusWithin.tsx
+++ b/packages/clay-core/src/aria/useFocusWithin.tsx
@@ -60,7 +60,7 @@ export function FocusWithinProvider<T extends HTMLElement>({
 
 		const hasItem = items.find((item) => focusId === getId(item));
 
-		if (!hasItem) {
+		if (!hasItem && items.length) {
 			setFocusId(getId(items[0]));
 		}
 	}, [children]);


### PR DESCRIPTION
Fixes [LPS-190444](https://liferay.atlassian.net/browse/LPS-190444) and [LPS-190440](https://liferay.atlassian.net/browse/LPS-190440)

It happened that we were trying to focus on the first one in the list when none existed, this happens when the component was disassembled but the lifecycle is still happening.