### PR TITLE
fix(@clayui/core): fix indices when moving item in TreeView

### DIFF
--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -16,7 +16,7 @@ import {ItemContextProvider, useItem} from './useItem';
 export type ChildrenFunction<T extends Record<string, any>> =
 	ChildrenFunctionBase<T, [Selection, Expand, LoadMore]>;
 
-export interface ICollectionProps<T> {
+export interface ICollectionProps<T extends Record<string, any>> {
 	children: React.ReactNode | ChildrenFunction<T>;
 
 	/**

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -18,7 +18,7 @@ import {TreeViewItem, TreeViewItemStack} from './TreeViewItem';
 import {Icons, MoveItemIndex, OnLoadMore, TreeViewContext} from './context';
 import {ITreeProps, useTree} from './useTree';
 
-interface ITreeViewProps<T>
+interface ITreeViewProps<T extends Record<string, any>>
 	extends Omit<
 			React.HTMLAttributes<HTMLUListElement>,
 			'children' | 'onSelect'
@@ -120,13 +120,15 @@ interface ITreeViewProps<T>
 
 const focusableElements = ['.treeview-link[tabindex]'];
 
-export function TreeView<T>(props: ITreeViewProps<T>): JSX.Element & {
+export function TreeView<T extends Record<string, any>>(
+	props: ITreeViewProps<T>
+): JSX.Element & {
 	Item: typeof TreeViewItem;
 	Group: typeof TreeViewGroup;
 	ItemStack: typeof TreeViewItemStack;
 };
 
-export function TreeView<T>({
+export function TreeView<T extends Record<string, any>>({
 	children,
 	className,
 	defaultExpandedKeys,

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -17,16 +17,19 @@ interface ITreeViewGroupProps<T extends Record<string, any>>
 	extends ICollectionProps<T>,
 		Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {}
 
-function List({
-	children,
-	...otherProps
-}: React.HTMLAttributes<HTMLUListElement>) {
+const List = React.forwardRef<
+	HTMLUListElement,
+	React.HTMLAttributes<HTMLUListElement>
+>(function ListInner(
+	{children, ...otherProps}: React.HTMLAttributes<HTMLUListElement>,
+	ref
+) {
 	return (
-		<ul {...otherProps} className="treeview-group" role="group">
+		<ul {...otherProps} className="treeview-group" ref={ref} role="group">
 			{children}
 		</ul>
 	);
-}
+});
 
 export function TreeViewGroup<T extends Record<string, any>>(
 	props: ITreeViewGroupProps<T>

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -13,7 +13,7 @@ import {Collection, ICollectionProps} from './Collection';
 import {useTreeViewContext} from './context';
 import {useItem} from './useItem';
 
-interface ITreeViewGroupProps<T>
+interface ITreeViewGroupProps<T extends Record<string, any>>
 	extends ICollectionProps<T>,
 		Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {}
 
@@ -28,7 +28,9 @@ function List({
 	);
 }
 
-export function TreeViewGroup<T>(props: ITreeViewGroupProps<T>): JSX.Element & {
+export function TreeViewGroup<T extends Record<string, any>>(
+	props: ITreeViewGroupProps<T>
+): JSX.Element & {
 	displayName: string;
 };
 

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -28,7 +28,8 @@ export type MoveItemIndex = {
 	previous: number;
 };
 
-export interface ITreeViewContext<T> extends ITreeState<T> {
+export interface ITreeViewContext<T extends Record<string, any>>
+	extends ITreeState<T> {
 	childrenRoot: React.MutableRefObject<ChildrenFunction<Object> | null>;
 	dragAndDrop?: boolean;
 	expandDoubleClick?: boolean;
@@ -50,7 +51,7 @@ export const TreeViewContext = React.createContext<ITreeViewContext<any>>(
 	{} as ITreeViewContext<any>
 );
 
-export function useTreeViewContext(): ITreeViewContext<unknown> {
+export function useTreeViewContext(): ITreeViewContext<Record<string, any>> {
 	return useContext(TreeViewContext);
 }
 
@@ -71,7 +72,7 @@ export type Expand = {
 
 export type LoadMore = {
 	get: (key: Key) => any;
-	loadMore: <T>(
+	loadMore: <T extends Record<string, any>>(
 		id: React.Key,
 		item: T,
 		willToggle?: boolean
@@ -90,7 +91,11 @@ export function useAPI(): [Selection, Expand, LoadMore] {
 	} = useTreeViewContext();
 
 	const loadMore = useCallback(
-		<T>(id: Key, item: T, willToggle: boolean = false) => {
+		<T extends Record<string, any>>(
+			id: Key,
+			item: T,
+			willToggle: boolean = false
+		) => {
 			if (!onLoadMore) {
 				return;
 			}

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -179,7 +179,7 @@ export function ItemContextProvider({children, value}: Props) {
 
 				const isMoved = onItemMove(
 					removeItemInternalProps((dragItem as Value)['item']),
-					tree.nodeByPath(indexes).parent,
+					tree.nodeByPath(indexes).parent!,
 					{
 						next: indexes[indexes.length - 1]!,
 						previous: (dragItem as Value)['item'].index,
@@ -260,7 +260,7 @@ export function ItemContextProvider({children, value}: Props) {
 					removeItemInternalProps(
 						(dragItem as unknown as Value)['item']
 					),
-					tree.nodeByPath(indexes).parent,
+					tree.nodeByPath(indexes).parent!,
 					{
 						next: indexes[indexes.length - 1]!,
 						previous: (dragItem as unknown as Value)['item'].index,

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -48,7 +48,7 @@ export interface IMultipleSelectionState {
 	toggleSelection: (key: Key, options?: SelectionToggleOptions) => void;
 }
 
-export interface IMultipleSelectionProps<T>
+export interface IMultipleSelectionProps<T extends Record<string, any>>
 	extends IMultipleSelection,
 		Pick<ITreeProps<T>, 'nestedKey'>,
 		Pick<ICollectionProps<T>, 'items'> {
@@ -107,7 +107,7 @@ export interface IMultipleSelectionProps<T>
  * the item has unrendered children and using the tree to navigate but using
  * the item path to avoid traversing the entire tree.
  */
-export function useMultipleSelection<T>(
+export function useMultipleSelection<T extends Record<string, any>>(
 	props: IMultipleSelectionProps<T>
 ): IMultipleSelectionState {
 	const selectionMode = props.selectionMode;

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -60,7 +60,7 @@ export interface IExpandable {
 	selectionHydrationMode?: 'render-first' | 'hydrate-first';
 }
 
-export interface ITreeProps<T>
+export interface ITreeProps<T extends Record<string, any>>
 	extends IExpandable,
 		IMultipleSelection,
 		Pick<ICollectionProps<T>, 'items' | 'defaultItems'> {
@@ -76,7 +76,8 @@ export interface ITreeProps<T>
 	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
 }
 
-export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {
+export interface ITreeState<T extends Record<string, any>>
+	extends Pick<ICollectionProps<T>, 'items'> {
 	close: (key: Key) => boolean;
 	cursors: React.MutableRefObject<Map<React.Key, unknown>>;
 	expandedKeys: Set<Key>;
@@ -90,7 +91,9 @@ export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {
 	toggle: (key: Key) => void;
 }
 
-export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
+export function useTree<T extends Record<string, any>>(
+	props: ITreeProps<T>
+): ITreeState<T> {
 	const [items, setItems] = useControlledState({
 		defaultName: 'defaultItems',
 		defaultValue: props.defaultItems ?? [],


### PR DESCRIPTION
Fixes #5506

I still need to fix some edge cases that are still moving to the wrong places in the tree, I should continue investigating tomorrow. I'm trying to find a simpler solution that can fix only the use cases we want but it's still hard to infer due to the different possibilities that exist.