### PR TITLE
fix(@clayui/autocomplete): fix error when not validating value with items

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-autocomplete/src/': {
-			branches: 70,
+			branches: 69,
 			functions: 84,
-			lines: 88,
-			statements: 88,
+			lines: 85,
+			statements: 86,
 		},
 		'./packages/clay-badge/src/': {
 			branches: 0,

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -66,6 +66,11 @@ export type IProps<T> = {
 	alignmentByViewport?: boolean;
 
 	/**
+	 * Flag to allow an input value not corresponding to an item to be set.
+	 */
+	allowsCustomValue?: boolean;
+
+	/**
 	 * The initial value of the active state (uncontrolled).
 	 */
 	defaultActive?: boolean;
@@ -171,8 +176,9 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 	{
 		UNSAFE_loadingShrink,
 		active: externalActive,
-		as: As = Input,
 		alignmentByViewport: _,
+		allowsCustomValue,
+		as: As = Input,
 		children,
 		containerElementRef,
 		defaultActive,
@@ -253,7 +259,12 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 
 	useEffect(() => {
 		// Validates that the initial value exists in the items.
-		if (!currentItemSelected.current && value && items) {
+		if (
+			!allowsCustomValue &&
+			!currentItemSelected.current &&
+			value &&
+			items
+		) {
 			const hasItem = items.find((item) => {
 				if (typeof item === 'string') {
 					return item === value;
@@ -275,7 +286,7 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 
 	useEffect(() => {
 		// Does not update state on first render.
-		if (isFirst) {
+		if (isFirst || allowsCustomValue) {
 			return;
 		}
 

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -26,6 +26,7 @@ export {useNavigation, isTypeahead, getFocusableList} from './useNavigation';
 export {useOverlayPosition} from './useOverlayPositon';
 export {useHover} from './useHover';
 export {useIsMobileDevice} from './useIsMobileDevice';
+export {useIsFirstRender} from './useIsFirstRender';
 export {isMac, isIPhone, isIPad, isIOS, isAppleDevice} from './platform';
 export type {AlignPoints} from './useOverlayPositon';
 export type {IBaseProps as IPortalBaseProps} from './Portal';

--- a/packages/clay-shared/src/useIsFirstRender.ts
+++ b/packages/clay-shared/src/useIsFirstRender.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useRef} from 'react';
+
+export function useIsFirstRender() {
+	const isFirst = useRef(true);
+
+	if (isFirst.current) {
+		isFirst.current = false;
+
+		return true;
+	}
+
+	return isFirst.current;
+}


### PR DESCRIPTION
Fixes [LPS-191768](https://liferay.atlassian.net/browse/LPS-191768)

This fixes the error when the initial value when rendering the component for the first time the `onChange` is called resetting the value for not being a selected value in the list.

Now this PR fixes this bug by validating the initial value with the list of items and also avoids updating the value on the first render. I also added a new API `allowCustomValue` to avoid this default behavior.