### PR TITLE
fix(@clayui/autocomplete): does not revalidate the value if it is reset by the controlled state

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-autocomplete/src/': {
-			branches: 69,
-			functions: 84,
+			branches: 68,
+			functions: 82,
 			lines: 85,
-			statements: 86,
+			statements: 85,
 		},
 		'./packages/clay-badge/src/': {
 			branches: 0,

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -163,6 +163,25 @@ const List = React.forwardRef<
 	);
 });
 
+function hasItem<T extends Record<string, any> | string | number>(
+	items: Array<T>,
+	value: string,
+	filterKey?: string
+) {
+	return items.find((item) => {
+		if (typeof item === 'string') {
+			return item === value;
+		} else if (typeof item === 'object') {
+			// filter key is not defined and we cannot infer the data type.
+			if (!filterKey) {
+				return false;
+			}
+
+			return item[filterKey] === value;
+		}
+	});
+}
+
 const ESCAPE_REGEXP = /[.*+?^${}()|[\]\\]/g;
 
 const defaultMessages = {
@@ -213,7 +232,7 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 		value: externalItems,
 	});
 
-	const [value = '', setValue] = useControlledState({
+	const [value = '', setValue, isUncontrolled] = useControlledState({
 		defaultName: 'defaultValue',
 		defaultValue,
 		handleName: 'onChange',
@@ -265,20 +284,7 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 			value &&
 			items
 		) {
-			const hasItem = items.find((item) => {
-				if (typeof item === 'string') {
-					return item === value;
-				} else if (typeof item === 'object') {
-					// filter key is not defined and we cannot infer the data type.
-					if (!filterKey) {
-						return false;
-					}
-
-					return item[filterKey] === value;
-				}
-			});
-
-			if (hasItem) {
+			if (hasItem(items, value, filterKey)) {
 				currentItemSelected.current = value;
 			}
 		}
@@ -292,6 +298,14 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 		}
 
 		if (active === false && currentItemSelected.current !== value) {
+			// The state is controlled so we have to revalidate if the typed value
+			// exists in the suggestion list.
+			if (!isUncontrolled && items && hasItem(items, value, filterKey)) {
+				currentItemSelected.current = value;
+
+				return;
+			}
+
 			setValue(currentItemSelected.current);
 		}
 	}, [active]);

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -285,8 +285,9 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 	}, []);
 
 	useEffect(() => {
-		// Does not update state on first render.
-		if (isFirst || allowsCustomValue) {
+		// Does not update state on first render, if the custom value is allowed
+		// or if the value is empty.
+		if (isFirst || allowsCustomValue || !value) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes [LPS-192047](https://liferay.atlassian.net/browse/LPS-192047)

This PR improves the behavior of matching the value with the suggestion list when the state is controlled, as most of the mechanism is based on the internal interactions of the component it caused problems when the developer has the state controlled and added new behaviors, for example reset the value.