### PR TITLE
feat(@clayui/navigation-bar): Adds fluidSize prop to customize container-fluid width

### DIFF
--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -32,6 +32,13 @@ export interface IProps
 		| React.ReactElement<React.ComponentProps<typeof Item>>;
 
 	/**
+	 * Set a maximum width on container-fluid.
+	 */
+	fluidSize?:
+		| React.ComponentProps<typeof ClayLayout.Container>['fluidSize']
+		| false;
+
+	/**
 	 * Determines the style of the Navigation Bar
 	 */
 	inverted?: boolean;
@@ -54,6 +61,7 @@ function ClayNavigationBar(props: IProps): JSX.Element & {
 function ClayNavigationBar({
 	children,
 	className,
+	fluidSize,
 	inverted = false,
 	itemAriaCurrent: ariaCurrent = true,
 	spritemap,
@@ -93,7 +101,7 @@ function ClayNavigationBar({
 			<NavigationBarContext.Provider
 				value={{ariaCurrent: ariaCurrent ? 'page' : null}}
 			>
-				<ClayLayout.ContainerFluid>
+				<ClayLayout.ContainerFluid size={fluidSize}>
 					<ClayButton
 						aria-expanded={expanded}
 						className={classNames(
@@ -139,7 +147,7 @@ function ClayNavigationBar({
 						timeout={prefersReducedMotion ? 0 : 250}
 					>
 						<div>
-							<ClayLayout.ContainerFluid>
+							<ClayLayout.ContainerFluid size={fluidSize}>
 								<ul className="navbar-nav">{children}</ul>
 							</ClayLayout.ContainerFluid>
 						</div>

--- a/packages/clay-navigation-bar/stories/NavigationBar.stories.tsx
+++ b/packages/clay-navigation-bar/stories/NavigationBar.stories.tsx
@@ -18,7 +18,11 @@ export const NavigationBar = (args: any) => {
 	const [triggerName, setTriggerName] = useState<string>(args.active);
 
 	return (
-		<ClayNavigationBar inverted={args.inverted} triggerLabel={triggerName}>
+		<ClayNavigationBar
+			fluidSize={args.fluidSize}
+			inverted={args.inverted}
+			triggerLabel={triggerName}
+		>
 			<ClayNavigationBar.Item active={args.active === 'Item 1'}>
 				<ClayLink href="#">Item 1</ClayLink>
 			</ClayNavigationBar.Item>
@@ -47,9 +51,14 @@ NavigationBar.argTypes = {
 		control: {type: 'select'},
 		options: ['Item 1', 'Item 2', 'Item 3', 'Item 4'],
 	},
+	fluidSize: {
+		control: {type: 'select'},
+		options: [undefined, false, 'sm', 'md', 'lg', 'xl'],
+	},
 };
 
 NavigationBar.args = {
 	active: 'Item 1',
+	fluidSize: 'xl',
 	inverted: false,
 };


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-192418

@matuzalemsteles I added the prop `fluidSize` to ClayNavigationBar. We currently allow `ClayLayout.ContainerFluid` to omit outputting the class `container-fluid-max-{size}` if the `size=false`. Should we add a new `fluidSize`, something like `fluid` or `fluid-layout`, in `ClayLayout.Container` to do that instead?