### PR TITLE
fix(@clayui/drop-down): adds throttle to handle contextual menu visibility

### DIFF
--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -9,11 +9,12 @@ import {
 	InternalDispatch,
 	Keys,
 	MouseSafeArea,
+	throttle,
 	useControlledState,
 	useNavigation,
 } from '@clayui/shared';
 import classNames from 'classnames';
-import React, {useContext, useRef, useState} from 'react';
+import React, {useCallback, useContext, useRef, useState} from 'react';
 import warning from 'warning';
 
 import Caption from './Caption';
@@ -305,6 +306,13 @@ const OFFSET_MAP = {
 	trtl: LEFT_OFFSET,
 };
 
+function offsetFn(points: any) {
+	return OFFSET_MAP[points.join('') as keyof typeof OFFSET_MAP] as [
+		number,
+		number
+	];
+}
+
 const Contextual = ({
 	items,
 	label,
@@ -338,6 +346,11 @@ const Contextual = ({
 		visible,
 	});
 
+	const setThrottleVisible = useCallback(
+		throttle((value: boolean) => setVisible(value), 100),
+		[]
+	);
+
 	return (
 		<ClayDropDown.Item
 			{...otherProps}
@@ -370,14 +383,14 @@ const Contextual = ({
 				if (!visible) {
 					keyboardRef.current = false;
 					timeoutHandleRef.current = setTimeout(
-						() => setVisible(true),
-						500
+						() => setThrottleVisible(true),
+						400
 					);
 				}
 			}}
 			onMouseLeave={() => {
 				keyboardRef.current = false;
-				setVisible(false);
+				setThrottleVisible(false);
 
 				clearTimeout(timeoutHandleRef.current);
 				timeoutHandleRef.current = null;
@@ -395,11 +408,7 @@ const Contextual = ({
 					alignmentPosition={8}
 					hasLeftSymbols={hasLeftSymbols}
 					hasRightSymbols={hasRightSymbols}
-					offsetFn={(points) =>
-						OFFSET_MAP[
-							points.join('') as keyof typeof OFFSET_MAP
-						] as [number, number]
-					}
+					offsetFn={offsetFn}
 					onActiveChange={setVisible}
 					onKeyDown={navigationProps.onKeyDown}
 					ref={menuElementRef}

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -28,6 +28,7 @@ export {useHover} from './useHover';
 export {useIsMobileDevice} from './useIsMobileDevice';
 export {useIsFirstRender} from './useIsFirstRender';
 export {isMac, isIPhone, isIPad, isIOS, isAppleDevice} from './platform';
+export {throttle} from './throttle';
 export type {AlignPoints} from './useOverlayPositon';
 export type {IBaseProps as IPortalBaseProps} from './Portal';
 export type {InternalDispatch} from './useControlledState';

--- a/packages/clay-shared/src/throttle.ts
+++ b/packages/clay-shared/src/throttle.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export function throttle<T>(callback: Function, limit: number) {
+	var waiting = false;
+
+	return (...args: Array<T>) => {
+		if (!waiting) {
+			callback(...args);
+			waiting = true;
+
+			setTimeout(() => {
+				waiting = false;
+			}, limit);
+		}
+	};
+}

--- a/packages/clay-shared/src/useMousePosition.ts
+++ b/packages/clay-shared/src/useMousePosition.ts
@@ -5,22 +5,9 @@
 
 import {useEffect, useState} from 'react';
 
+import {throttle} from './throttle';
+
 type MousePosition = [number, number];
-
-function throttle<T>(callback: Function, limit: number) {
-	var waiting = false;
-
-	return (...args: Array<T>) => {
-		if (!waiting) {
-			callback(...args);
-			waiting = true;
-
-			setTimeout(() => {
-				waiting = false;
-			}, limit);
-		}
-	};
-}
 
 /**
  * Hook to get the current mouse position


### PR DESCRIPTION
Fixes [LPS-184506](https://liferay.atlassian.net/browse/LPS-184506)

Well this finally fixes the error that happens with contextual menu in PageEditor, I had trouble finding the problem actually I didn't find the root of the problem but this problem only happens in PageEditor but not in other places of DXP, I did tests adding just a simple contextual menu in PageEditor and the problem still happens but adding in another page doesn't, so it seems that the environment or maybe multiple renderings or slowness causes this problem.

Basically the problem is that hovering over a contextual menu opens the menu after a few ms and closes when the mouse leaves the contextual menu this is default behavior and we just use the React.js events but for some reason in the PageEditor it triggers the `onMouseEnter` and then `onMouseLeave`. To try to solve this I added a small throttle when defining the visible state, I did a test release and this solves the problem because if the mouse stops over the item it keeps triggering `onMouseEnter` and `onMouseLeave` in a loop.