### PR TITLE
fix(@clayui/core): Implements the use of cursor to reference unique items to move items in the tree

### DIFF
--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -160,15 +160,13 @@ export function useCollection<
 			};
 
 			function registerItem(
-				childKey: React.Key,
+				key: React.Key,
 				child: ChildElement,
 				index: number
 			) {
 				if (performFilter(child)) {
 					return;
 				}
-
-				const key = getKey(index, childKey, parentKey);
 
 				if (child.type.displayName === 'Item') {
 					layout.current.set(key, {
@@ -208,7 +206,18 @@ export function useCollection<
 
 					callNestedChild(child);
 
-					registerItem(child.key ?? getItemId(item), child, index);
+					const key = getKey(
+						index,
+						child.key ?? getItemId(item),
+						parentKey
+					);
+
+					// TODO: We need support for items with just number and string types.
+					if (typeof item === 'object') {
+						item['_key'] = key;
+					}
+
+					registerItem(key, child, index);
 				}
 			} else {
 				React.Children.forEach(children, (child, index) => {
@@ -218,7 +227,11 @@ export function useCollection<
 
 					callNestedChild(child as ChildElement);
 
-					registerItem(child.key!, child as ChildElement, index);
+					registerItem(
+						getKey(index, child.key!, parentKey),
+						child as ChildElement,
+						index
+					);
 				});
 			}
 		},

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -16,7 +16,7 @@ import {ItemContextProvider, useItem} from './useItem';
 export type ChildrenFunction<T extends Record<string, any>> =
 	ChildrenFunctionBase<T, [Selection, Expand, LoadMore]>;
 
-export interface ICollectionProps<T> {
+export interface ICollectionProps<T extends Record<string, any>> {
 	children: React.ReactNode | ChildrenFunction<T>;
 
 	/**

--- a/packages/clay-core/src/tree-view/DragAndDrop.tsx
+++ b/packages/clay-core/src/tree-view/DragAndDrop.tsx
@@ -36,6 +36,7 @@ export type DragAndDropMessages = {
 
 export type Value = {
 	[propName: string]: any;
+	cursor: Array<React.Key>;
 	indexes: Array<number>;
 	itemRef: React.RefObject<HTMLDivElement>;
 	key: React.Key;
@@ -266,7 +267,7 @@ export function DragAndDropProvider<T>({
 			}
 		}
 
-		reorder(dragLayoutItem!.loc, indexes);
+		reorder(dragLayoutItem!.cursor, dropLayoutItem!.cursor, position!);
 		setState({
 			currentDrag: null,
 			currentTarget: null,

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -18,7 +18,7 @@ import {TreeViewItem, TreeViewItemStack} from './TreeViewItem';
 import {Icons, MoveItemIndex, OnLoadMore, TreeViewContext} from './context';
 import {ITreeProps, useTree} from './useTree';
 
-interface ITreeViewProps<T>
+interface ITreeViewProps<T extends Record<string, any>>
 	extends Omit<
 			React.HTMLAttributes<HTMLUListElement>,
 			'children' | 'onSelect'
@@ -120,13 +120,15 @@ interface ITreeViewProps<T>
 
 const focusableElements = ['.treeview-link[tabindex]'];
 
-export function TreeView<T>(props: ITreeViewProps<T>): JSX.Element & {
+export function TreeView<T extends Record<string, any>>(
+	props: ITreeViewProps<T>
+): JSX.Element & {
 	Item: typeof TreeViewItem;
 	Group: typeof TreeViewGroup;
 	ItemStack: typeof TreeViewItemStack;
 };
 
-export function TreeView<T>({
+export function TreeView<T extends Record<string, any>>({
 	children,
 	className,
 	defaultExpandedKeys,

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -17,16 +17,19 @@ interface ITreeViewGroupProps<T extends Record<string, any>>
 	extends ICollectionProps<T>,
 		Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {}
 
-function List({
-	children,
-	...otherProps
-}: React.HTMLAttributes<HTMLUListElement>) {
+const List = React.forwardRef<
+	HTMLUListElement,
+	React.HTMLAttributes<HTMLUListElement>
+>(function ListInner(
+	{children, ...otherProps}: React.HTMLAttributes<HTMLUListElement>,
+	ref
+) {
 	return (
-		<ul {...otherProps} className="treeview-group" role="group">
+		<ul {...otherProps} className="treeview-group" ref={ref} role="group">
 			{children}
 		</ul>
 	);
-}
+});
 
 export function TreeViewGroup<T extends Record<string, any>>(
 	props: ITreeViewGroupProps<T>

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -13,7 +13,7 @@ import {Collection, ICollectionProps} from './Collection';
 import {useTreeViewContext} from './context';
 import {useItem} from './useItem';
 
-interface ITreeViewGroupProps<T>
+interface ITreeViewGroupProps<T extends Record<string, any>>
 	extends ICollectionProps<T>,
 		Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {}
 
@@ -28,7 +28,9 @@ function List({
 	);
 }
 
-export function TreeViewGroup<T>(props: ITreeViewGroupProps<T>): JSX.Element & {
+export function TreeViewGroup<T extends Record<string, any>>(
+	props: ITreeViewGroupProps<T>
+): JSX.Element & {
 	displayName: string;
 };
 

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -28,7 +28,8 @@ export type MoveItemIndex = {
 	previous: number;
 };
 
-export interface ITreeViewContext<T> extends ITreeState<T> {
+export interface ITreeViewContext<T extends Record<string, any>>
+	extends ITreeState<T> {
 	childrenRoot: React.MutableRefObject<ChildrenFunction<Object> | null>;
 	dragAndDrop?: boolean;
 	expandDoubleClick?: boolean;
@@ -50,7 +51,7 @@ export const TreeViewContext = React.createContext<ITreeViewContext<any>>(
 	{} as ITreeViewContext<any>
 );
 
-export function useTreeViewContext(): ITreeViewContext<unknown> {
+export function useTreeViewContext(): ITreeViewContext<Record<string, any>> {
 	return useContext(TreeViewContext);
 }
 
@@ -71,7 +72,7 @@ export type Expand = {
 
 export type LoadMore = {
 	get: (key: Key) => any;
-	loadMore: <T>(
+	loadMore: <T extends Record<string, any>>(
 		id: React.Key,
 		item: T,
 		willToggle?: boolean
@@ -90,7 +91,11 @@ export function useAPI(): [Selection, Expand, LoadMore] {
 	} = useTreeViewContext();
 
 	const loadMore = useCallback(
-		<T>(id: Key, item: T, willToggle: boolean = false) => {
+		<T extends Record<string, any>>(
+			id: Key,
+			item: T,
+			willToggle: boolean = false
+		) => {
 			if (!onLoadMore) {
 				return;
 			}

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -179,7 +179,7 @@ export function ItemContextProvider({children, value}: Props) {
 
 				const isMoved = onItemMove(
 					removeItemInternalProps((dragItem as Value)['item']),
-					tree.nodeByPath(indexes).parent,
+					tree.nodeByPath(indexes).parent!,
 					{
 						next: indexes[indexes.length - 1]!,
 						previous: (dragItem as Value)['item'].index,
@@ -260,7 +260,7 @@ export function ItemContextProvider({children, value}: Props) {
 					removeItemInternalProps(
 						(dragItem as unknown as Value)['item']
 					),
-					tree.nodeByPath(indexes).parent,
+					tree.nodeByPath(indexes).parent!,
 					{
 						next: indexes[indexes.length - 1]!,
 						previous: (dragItem as unknown as Value)['item'].index,

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -48,7 +48,7 @@ export interface IMultipleSelectionState {
 	toggleSelection: (key: Key, options?: SelectionToggleOptions) => void;
 }
 
-export interface IMultipleSelectionProps<T>
+export interface IMultipleSelectionProps<T extends Record<string, any>>
 	extends IMultipleSelection,
 		Pick<ITreeProps<T>, 'nestedKey'>,
 		Pick<ICollectionProps<T>, 'items'> {
@@ -107,7 +107,7 @@ export interface IMultipleSelectionProps<T>
  * the item has unrendered children and using the tree to navigate but using
  * the item path to avoid traversing the entire tree.
  */
-export function useMultipleSelection<T>(
+export function useMultipleSelection<T extends Record<string, any>>(
 	props: IMultipleSelectionProps<T>
 ): IMultipleSelectionState {
 	const selectionMode = props.selectionMode;

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -16,6 +16,8 @@ import {
 import type {Key} from 'react';
 
 import type {ICollectionProps} from './Collection';
+import type {Position} from './DragAndDrop';
+import type {Cursor} from './useLayout';
 
 export interface IExpandable {
 	/**
@@ -85,7 +87,7 @@ export interface ITreeState<T extends Record<string, any>>
 	layout: Layout;
 	open: (key: Key) => boolean;
 	remove: (path: Array<number>) => void;
-	reorder: (from: Array<number>, path: Array<number>) => void;
+	reorder: (from: Cursor, path: Cursor, op: Position) => void;
 	replace: (path: Array<number>, item: T) => void;
 	selection: IMultipleSelectionState;
 	toggle: (key: Key) => void;
@@ -245,10 +247,10 @@ export function useTree<T extends Record<string, any>>(
 	);
 
 	const reorder = useCallback(
-		(from: Array<number>, path: Array<number>) => {
+		(from: Cursor, path: Cursor, direction: Position) => {
 			const tree = createImmutableTree(items, props.nestedKey!);
 
-			tree.produce({from, op: 'move', path});
+			tree.produce({direction, from, op: 'move', path});
 
 			setItems(tree.applyPatches());
 		},
@@ -380,8 +382,9 @@ function visit<T extends Array<Record<string, any>>>(
 // RFC 6902 (JSON Patch) 4.4
 type PatchMove = {
 	op: 'move';
-	from: Array<number>;
-	path: Array<number>;
+	from: Cursor;
+	path: Cursor;
+	direction: Position;
 };
 
 // Operation of `add` value to the document structure.
@@ -425,17 +428,56 @@ export function createImmutableTree<T extends Array<Record<string, any>>>(
 		return [...tree.slice(0, index), item, ...tree.slice(index + 1)] as T;
 	}
 
+	function nodeByCursor(cursor: Cursor) {
+		const queue = [...cursor];
+
+		const rootId = queue.shift() as React.Key;
+
+		let parent = null;
+		let id = rootId;
+		let index = immutableTree.findIndex((item) => item['_key'] === id);
+		let item = {...immutableTree[index]};
+
+		immutableTree = pointer(immutableTree, index, item);
+
+		while (queue.length) {
+			id = queue.shift() as React.Key;
+
+			if (Array.isArray(item[nestedKey]) && item[nestedKey].length) {
+				index = item[nestedKey].findIndex(
+					(item: any) => item['_key'] === id
+				);
+
+				// The Index may still not exist after it's fixed because the
+				// index is to move the item below the last item.
+				if (item[nestedKey][index]) {
+					parent = item;
+					item = {...item[nestedKey][index]};
+
+					parent[nestedKey] = pointer(parent[nestedKey], index, item);
+
+					continue;
+				}
+			}
+
+			if (!item[nestedKey]) {
+				item[nestedKey] = [];
+			}
+
+			parent = item;
+		}
+
+		return {
+			index,
+			item,
+			parent,
+		};
+	}
+
 	function nodeByPath(path: Array<number>) {
 		const queue = [...path];
 
-		let rootIndex: number = queue.shift() as number;
-
-		// In an operation of moving an item from the root, it affects the indexes
-		// by having to delete first and then add. This is the same behavior
-		// as below.
-		if (!immutableTree[rootIndex]) {
-			rootIndex -= 1;
-		}
+		const rootIndex = queue.shift() as number;
 
 		let item = {...immutableTree[rootIndex]};
 		let parent = null;
@@ -520,39 +562,37 @@ export function createImmutableTree<T extends Array<Record<string, any>>>(
 				// immediately followed by the "add" operation at the target
 				// location with the value that was removed.
 				case 'move': {
-					const {from, path} = patch;
+					const {direction, from, path} = patch;
 
-					const nodeToRemove = nodeByPath(from);
+					const nodeToRemove = nodeByCursor(from);
 
 					if (nodeToRemove.parent) {
 						nodeToRemove.parent[nestedKey] = nodeToRemove.parent[
 							nestedKey
 						].filter(
-							(_item: any, index: number) =>
-								index !== nodeToRemove.index
+							(item: any) =>
+								item['_key'] !== nodeToRemove.item['_key']
 						);
 					} else {
 						immutableTree = immutableTree.filter(
-							(_item: any, index: number) =>
-								index !== nodeToRemove.index
+							(item: any) =>
+								item['_key'] !== nodeToRemove.item['_key']
 						) as T;
 					}
 
-					const pathToAdd = nodeByPath(path);
+					const pathToAdd = nodeByCursor(path);
 
-					// It has the same parent the index can change
-					const isSameParent =
-						[...from].slice(0, -1).join('') ===
-						[...path].slice(0, -1).join('');
+					let index = pathToAdd.index;
 
-					let index = path[path.length - 1]!;
+					if (direction === 'bottom') {
+						index += 1;
+					} else if (direction === 'middle') {
+						index = 0;
+						pathToAdd.parent = pathToAdd.item;
 
-					// If moving an item within the same parent and the drop position of
-					// the item is greater than the origin it affects the position
-					// because the item is always removed first, we just fix the position
-					// by decreasing.
-					if (isSameParent && nodeToRemove.index < pathToAdd.index) {
-						index -= 1;
+						if (!pathToAdd.parent[nestedKey]) {
+							pathToAdd.parent[nestedKey] = [];
+						}
 					}
 
 					if (pathToAdd.parent) {

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -60,7 +60,7 @@ export interface IExpandable {
 	selectionHydrationMode?: 'render-first' | 'hydrate-first';
 }
 
-export interface ITreeProps<T>
+export interface ITreeProps<T extends Record<string, any>>
 	extends IExpandable,
 		IMultipleSelection,
 		Pick<ICollectionProps<T>, 'items' | 'defaultItems'> {
@@ -76,7 +76,8 @@ export interface ITreeProps<T>
 	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
 }
 
-export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {
+export interface ITreeState<T extends Record<string, any>>
+	extends Pick<ICollectionProps<T>, 'items'> {
 	close: (key: Key) => boolean;
 	cursors: React.MutableRefObject<Map<React.Key, unknown>>;
 	expandedKeys: Set<Key>;
@@ -90,7 +91,9 @@ export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {
 	toggle: (key: Key) => void;
 }
 
-export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
+export function useTree<T extends Record<string, any>>(
+	props: ITreeProps<T>
+): ITreeState<T> {
 	const [items, setItems] = useControlledState({
 		defaultName: 'defaultItems',
 		defaultValue: props.defaultItems ?? [],


### PR DESCRIPTION
Fixes #5506

I'm changing the strategy when moving the items through the tree, using indexes is very fragile because removing an item in the tree can break all the indexes of the items when adding, this is similar when you have pagination of data using offset in the database that it can break when an item in the database is removed for example.

Instead we can use cursor which is a reference to the id of the item, in this implementation the `nodeByCursor` can be a bit slow for a very big list but these are edge cases with thousands or millions.

Using the cursor avoids the edge cases of every behavior we were trying to cover due to using indexes, being a tree it increases the amount of use cases and makes the code more complex. For now only `reorder` is using the cursor but we may soon switch to all methods using it too and removing indexes.

### ToDo

- [ ] Tests