### PR TITLE
 feat(clayui.com): adds Algolia's new docsearch

### DIFF
--- a/clayui.com/.env.production
+++ b/clayui.com/.env.production
@@ -1,1 +1,0 @@
-GATSBY_CLAY_NIGHTLY=false

--- a/clayui.com/.gitignore
+++ b/clayui.com/.gitignore
@@ -62,3 +62,6 @@ public
 static/css/*.css
 static/css/*.css.map
 yarn-error.log
+
+.env
+.env.production

--- a/clayui.com/gatsby-config.js
+++ b/clayui.com/gatsby-config.js
@@ -6,6 +6,10 @@
 const clay = require('@clayui/css');
 const path = require('path');
 
+require('dotenv').config({
+	path: `.env.${process.env.NODE_ENV}`,
+});
+
 module.exports = {
 	mapping: {
 		'MarkdownRemark.frontmatter.author': 'AuthorYaml',

--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -42,6 +42,7 @@
 		"@clayui/time-picker": "^3.103.1",
 		"@clayui/tooltip": "^3.103.1",
 		"@clayui/upper-toolbar": "^3.103.1",
+		"@docsearch/react": "3",
 		"@mdx-js/mdx": "^1.6.16",
 		"@mdx-js/react": "^1.6.16",
 		"@reach/router": "1.3.4",

--- a/clayui.com/src/components/LayoutNav/Search.js
+++ b/clayui.com/src/components/LayoutNav/Search.js
@@ -12,7 +12,7 @@ export default (props) => {
 	useEffect(() => {
 		if (window.docsearch) {
 			window.docsearch({
-				apiKey: 'bc205a621e5176b8720081c2a3de450c',
+				apiKey: process.env.GATSBY_ALGOLIA_PUBLIC_KEY,
 				indexName: 'clay',
 				inputSelector: '#algolia-doc-search',
 			});

--- a/clayui.com/src/components/LayoutNav/Search.js
+++ b/clayui.com/src/components/LayoutNav/Search.js
@@ -3,86 +3,34 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {useEffect, useRef} from 'react';
+import {DocSearch} from '@docsearch/react';
+import React, {useEffect} from 'react';
+
+import '@docsearch/css';
 
 export default (props) => {
-	const autocompleteRef = useRef();
-	const inputRef = useRef();
-
 	useEffect(() => {
-		if (window.docsearch) {
-			window.docsearch({
-				apiKey: process.env.GATSBY_ALGOLIA_PUBLIC_KEY,
-				indexName: 'clay',
-				inputSelector: '#algolia-doc-search',
-			});
-		}
-	}, []);
-
-	useEffect(() => {
-		let platform = null;
-
 		const platformUserAgent = (
 			navigator?.userAgentData?.platform || navigator?.platform
 		).toLowerCase();
 
 		if (platformUserAgent.includes('mac')) {
-			platform = 'mac';
 			props.searchRef.current.setAttribute(
 				'aria-keyshortcuts',
 				'Control+Option+K'
 			);
-			autocompleteRef.current.setAttribute('data-platform', 'mac');
 		} else if (platformUserAgent.includes('linux')) {
-			platform = 'linux';
 			props.searchRef.current.setAttribute('aria-keyshortcuts', 'Alt+K');
-			autocompleteRef.current.setAttribute('data-platform', 'linux');
-		}
-
-		const handleKeyDown = (event) => {
-			const isLinuxKey = platform === 'linux' && event.altKey;
-			const isNotMacKey = platform === null && event.ctrlKey;
-
-			if (event.code === 'KeyK' && (isLinuxKey || isNotMacKey)) {
-				event.preventDefault();
-				inputRef.current.focus();
-			}
-		};
-
-		if (platform !== 'mac') {
-			document.addEventListener('keydown', handleKeyDown);
-
-			return () => {
-				document.removeEventListener('keydown', handleKeyDown);
-			};
 		}
 	}, []);
 
 	return (
-		<div className="platform" ref={autocompleteRef}>
-			<div className="page-autocomplete">
-				<div className="input-group">
-					<input
-						className="form-control"
-						id="algolia-doc-search"
-						name="q"
-						placeholder={props.placeholder}
-						ref={inputRef}
-						required
-						type="text"
-					/>
-
-					<span aria-hidden="true" className="input-group-addon">
-						<span className="c-kbd c-kbd-sm d-md-block d-none mr-2">
-							<kbd className="c-kbd">K</kbd>
-						</span>
-
-						<svg className="lexicon-icon">
-							<use xlinkHref="/images/icons/icons.svg#search" />
-						</svg>
-					</span>
-				</div>
-			</div>
+		<div className="page-autocomplete">
+			<DocSearch
+				apiKey={process.env.GATSBY_ALGOLIA_PUBLIC_KEY}
+				appId={process.env.GATSBY_ALGOLIA_APP_ID}
+				indexName={process.env.GATSBY_ALGOLIA_INDEX}
+			/>
 		</div>
 	);
 };

--- a/clayui.com/src/html.js
+++ b/clayui.com/src/html.js
@@ -34,10 +34,6 @@ export default (props) => {
 				/>
 
 				{props.headComponents}
-				<link
-					href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
-					rel="stylesheet"
-				/>
 				<script src="/js/jquery.min.js" />
 				<script src="/js/popper.js" />
 				<script src="/js/bootstrap.js" />
@@ -49,7 +45,6 @@ export default (props) => {
 				/>
 				{props.postBodyComponents}
 				<script src="/js/docs-site.js" />
-				<script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" />
 			</body>
 		</html>
 	);

--- a/clayui.com/src/styles/_docsearch.scss
+++ b/clayui.com/src/styles/_docsearch.scss
@@ -1,145 +1,21 @@
-.page-autocomplete {
-	max-width: 550px;
+:root {
+	--docsearch-muted-color: #6b6c7e !important;
+	--docsearch-text-color: #757575 !important;
+	--docsearch-searchbox-background: #ffffff !important;
+	--docsearch-searchbox-shadow: inset 0 0 0 2px #b3472d !important;
+	--docsearch-key-gradient: transparent !important;
+	--docsearch-key-shadow: transparent !important;
 }
 
-.page-autocomplete .algolia-autocomplete {
-	display: block !important;
-	flex: 1;
-	width: 100%;
-
-	.ds-dropdown-menu {
-		max-width: auto;
-		min-width: auto;
-	}
+.DocSearch-Button {
+	border: 1px solid #e7e7ed !important;
+	margin: 0 !important;
+	padding: 0 14px !important;
 }
 
-.page-autocomplete .algolia-autocomplete .ds-dropdown-menu {
-	width: 100%;
-	padding: 0.75rem 0 !important;
-	background-color: #fff;
-	background-clip: padding-box;
-	border: 1px solid rgba(0, 0, 0, 0.1);
-	box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.175);
-}
-
-.algolia-autocomplete .ds-dropdown-menu::before {
-	display: none !important;
-}
-
-.algolia-autocomplete .ds-dropdown-menu [class^='ds-dataset-'] {
+.DocSearch-Button-Key {
+	align-items: baseline !important;
+	border: 1px solid #e7e7ed !important;
 	padding: 0 !important;
-	overflow: visible !important;
-	background-color: transparent !important;
-	border: 0 !important;
-}
-
-.algolia-autocomplete .ds-dropdown-menu .ds-suggestions {
-	margin-top: 0 !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-suggestion {
-	padding: 0 !important;
-	overflow: visible !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-suggestion--category-header {
-	padding: 0.125rem 1rem !important;
-	margin-top: 0 !important;
-	font-size: 0.875rem !important;
-	font-weight: 500 !important;
-	color: $brand-dark !important;
-	border-bottom: 0 !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-suggestion--wrapper {
-	float: none !important;
-	padding-top: 0 !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column {
-	float: none !important;
-	width: auto !important;
-	padding: 0 !important;
-	text-align: left !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-suggestion--content {
-	float: none !important;
-	width: auto !important;
-	padding: 0 !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-suggestion--content::before {
-	display: none !important;
-}
-
-.algolia-autocomplete
-	.ds-suggestion:not(:first-child)
-	.algolia-docsearch-suggestion--category-header {
-	padding-top: 0.75rem !important;
-	margin-top: 0.75rem !important;
-	border-top: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-.algolia-autocomplete
-	.ds-suggestion
-	.algolia-docsearch-suggestion--subcategory-column {
-	display: none !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-suggestion--title {
-	display: block;
-	padding: 0.25rem 1rem !important;
-	margin-bottom: 0 !important;
-	font-size: 0.875rem !important;
-	font-weight: 400 !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-suggestion--text {
-	padding: 0 1rem 0.5rem !important;
-	margin-top: -0.25rem;
-	font-size: 0.875rem !important;
-	font-weight: 400;
-	line-height: 1.25 !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-footer {
-	float: none !important;
-	width: auto !important;
-	height: auto !important;
-	padding: 0.75rem 1rem 0;
-	font-size: 0.75rem !important;
-	line-height: 1 !important;
-	color: #767676 !important;
-	border-top: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-.algolia-autocomplete .algolia-docsearch-footer--logo {
-	display: inline !important;
-	overflow: visible !important;
-	color: inherit !important;
-	text-indent: 0 !important;
-	background: none !important;
-}
-
-.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
-	color: $brand-dark;
-	background-color: rgba(179, 71, 45, 0.12);
-}
-
-.algolia-autocomplete
-	.algolia-docsearch-suggestion--text
-	.algolia-docsearch-suggestion--highlight {
-	box-shadow: inset 0 -2px 0 0 rgba(179, 71, 45, 0.5) !important;
-}
-
-.algolia-autocomplete
-	.ds-suggestion.ds-cursor
-	.algolia-docsearch-suggestion--content {
-	background-color: rgba(179, 71, 45, 0.15) !important;
-}
-
-.algolia-docsearch-suggestion--content,
-.algolia-docsearch-suggestion--title {
-	display: block !important;
+	top: 0 !important;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,137 @@
 # yarn lockfile v1
 
 
+"@algolia/autocomplete-core@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz#1d56482a768c33aae0868c8533049e02e8961be7"
+  integrity sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==
+  dependencies:
+    "@algolia/autocomplete-plugin-algolia-insights" "1.9.3"
+    "@algolia/autocomplete-shared" "1.9.3"
+
+"@algolia/autocomplete-plugin-algolia-insights@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz#9b7f8641052c8ead6d66c1623d444cbe19dde587"
+  integrity sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==
+  dependencies:
+    "@algolia/autocomplete-shared" "1.9.3"
+
+"@algolia/autocomplete-preset-algolia@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz#64cca4a4304cfcad2cf730e83067e0c1b2f485da"
+  integrity sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==
+  dependencies:
+    "@algolia/autocomplete-shared" "1.9.3"
+
+"@algolia/autocomplete-shared@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz#2e22e830d36f0a9cf2c0ccd3c7f6d59435b77dfa"
+  integrity sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==
+
+"@algolia/cache-browser-local-storage@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.19.1.tgz#d29f42775ed4d117182897ac164519c593faf399"
+  integrity sha512-FYAZWcGsFTTaSAwj9Std8UML3Bu8dyWDncM7Ls8g+58UOe4XYdlgzXWbrIgjaguP63pCCbMoExKr61B+ztK3tw==
+  dependencies:
+    "@algolia/cache-common" "4.19.1"
+
+"@algolia/cache-common@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.19.1.tgz#faa5eeacaffd6023c2cf26e9866bdb06193f9b26"
+  integrity sha512-XGghi3l0qA38HiqdoUY+wvGyBsGvKZ6U3vTiMBT4hArhP3fOGLXpIINgMiiGjTe4FVlTa5a/7Zf2bwlIHfRqqg==
+
+"@algolia/cache-in-memory@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.19.1.tgz#afe4f0f21149800358379871089e0141fb72415b"
+  integrity sha512-+PDWL+XALGvIginigzu8oU6eWw+o76Z8zHbBovWYcrtWOEtinbl7a7UTt3x3lthv+wNuFr/YD1Gf+B+A9V8n5w==
+  dependencies:
+    "@algolia/cache-common" "4.19.1"
+
+"@algolia/client-account@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.19.1.tgz#1fa65881baab79ad35af6bcf44646a13b8d5edc9"
+  integrity sha512-Oy0ritA2k7AMxQ2JwNpfaEcgXEDgeyKu0V7E7xt/ZJRdXfEpZcwp9TOg4TJHC7Ia62gIeT2Y/ynzsxccPw92GA==
+  dependencies:
+    "@algolia/client-common" "4.19.1"
+    "@algolia/client-search" "4.19.1"
+    "@algolia/transporter" "4.19.1"
+
+"@algolia/client-analytics@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.19.1.tgz#e6ed79acd4de5a0284c9696bf4e1c25278ba34db"
+  integrity sha512-5QCq2zmgdZLIQhHqwl55ZvKVpLM3DNWjFI4T+bHr3rGu23ew2bLO4YtyxaZeChmDb85jUdPDouDlCumGfk6wOg==
+  dependencies:
+    "@algolia/client-common" "4.19.1"
+    "@algolia/client-search" "4.19.1"
+    "@algolia/requester-common" "4.19.1"
+    "@algolia/transporter" "4.19.1"
+
+"@algolia/client-common@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.19.1.tgz#40a8387316fa61d62ad1091beb3a8e227f008e75"
+  integrity sha512-3kAIVqTcPrjfS389KQvKzliC559x+BDRxtWamVJt8IVp7LGnjq+aVAXg4Xogkur1MUrScTZ59/AaUd5EdpyXgA==
+  dependencies:
+    "@algolia/requester-common" "4.19.1"
+    "@algolia/transporter" "4.19.1"
+
+"@algolia/client-personalization@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-4.19.1.tgz#fe362e0684dc74c3504c3641c5a7488c6ae02e07"
+  integrity sha512-8CWz4/H5FA+krm9HMw2HUQenizC/DxUtsI5oYC0Jxxyce1vsr8cb1aEiSJArQT6IzMynrERif1RVWLac1m36xw==
+  dependencies:
+    "@algolia/client-common" "4.19.1"
+    "@algolia/requester-common" "4.19.1"
+    "@algolia/transporter" "4.19.1"
+
+"@algolia/client-search@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.19.1.tgz#5e54601aa5f5cea790cec3f2cde4af9d6403871e"
+  integrity sha512-mBecfMFS4N+yK/p0ZbK53vrZbL6OtWMk8YmnOv1i0LXx4pelY8TFhqKoTit3NPVPwoSNN0vdSN9dTu1xr1XOVw==
+  dependencies:
+    "@algolia/client-common" "4.19.1"
+    "@algolia/requester-common" "4.19.1"
+    "@algolia/transporter" "4.19.1"
+
+"@algolia/logger-common@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.19.1.tgz#0e46a11510f3e94e1afc0ac780ae52e9597be78f"
+  integrity sha512-i6pLPZW/+/YXKis8gpmSiNk1lOmYCmRI6+x6d2Qk1OdfvX051nRVdalRbEcVTpSQX6FQAoyeaui0cUfLYW5Elw==
+
+"@algolia/logger-console@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.19.1.tgz#656a6f4ebb5de39af6ef7095c398d9ab3cceb87d"
+  integrity sha512-jj72k9GKb9W0c7TyC3cuZtTr0CngLBLmc8trzZlXdfvQiigpUdvTi1KoWIb2ZMcRBG7Tl8hSb81zEY3zI2RlXg==
+  dependencies:
+    "@algolia/logger-common" "4.19.1"
+
+"@algolia/requester-browser-xhr@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.19.1.tgz#7341ea2f980b8980a2976110142026721e452187"
+  integrity sha512-09K/+t7lptsweRTueHnSnmPqIxbHMowejAkn9XIcJMLdseS3zl8ObnS5GWea86mu3vy4+8H+ZBKkUN82Zsq/zg==
+  dependencies:
+    "@algolia/requester-common" "4.19.1"
+
+"@algolia/requester-common@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.19.1.tgz#f3396c77631b9d36e8d4d6f819a2c27f9ddbf7a1"
+  integrity sha512-BisRkcWVxrDzF1YPhAckmi2CFYK+jdMT60q10d7z3PX+w6fPPukxHRnZwooiTUrzFe50UBmLItGizWHP5bDzVQ==
+
+"@algolia/requester-node-http@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.19.1.tgz#ea210de9642628b3bdda1dd7fcd1fcb686da442e"
+  integrity sha512-6DK52DHviBHTG2BK/Vv2GIlEw7i+vxm7ypZW0Z7vybGCNDeWzADx+/TmxjkES2h15+FZOqVf/Ja677gePsVItA==
+  dependencies:
+    "@algolia/requester-common" "4.19.1"
+
+"@algolia/transporter@4.19.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.19.1.tgz#b5787299740c4bec9ba05502d98c14b5999860c8"
+  integrity sha512-nkpvPWbpuzxo1flEYqNIbGz7xhfhGOKGAZS7tzC+TELgEmi7z99qRyTfNSUlW7LZmB3ACdnqAo+9A9KFBENviQ==
+  dependencies:
+    "@algolia/cache-common" "4.19.1"
+    "@algolia/logger-common" "4.19.1"
+    "@algolia/requester-common" "4.19.1"
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -1232,6 +1363,21 @@
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
   integrity sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==
+
+"@docsearch/css@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.5.1.tgz#4adf9884735bbfea621c3716e80ea97baa419b73"
+  integrity sha512-2Pu9HDg/uP/IT10rbQ+4OrTQuxIWdKVUEdcw9/w7kZJv9NeHS6skJx1xuRiFyoGKwAzcHXnLp7csE99sj+O1YA==
+
+"@docsearch/react@3":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.5.1.tgz#35f4a75f948211d8bb6830d2147c575f96a85274"
+  integrity sha512-t5mEODdLzZq4PTFAm/dvqcvZFdPDMdfPE5rJS5SC8OUq9mPzxEy6b+9THIqNM9P0ocCb4UC5jqBrxKclnuIbzQ==
+  dependencies:
+    "@algolia/autocomplete-core" "1.9.3"
+    "@algolia/autocomplete-preset-algolia" "1.9.3"
+    "@docsearch/css" "3.5.1"
+    algoliasearch "^4.0.0"
 
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
@@ -5418,6 +5564,26 @@ ajv@^8.0.1, ajv@^8.6.3:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+algoliasearch@^4.0.0:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.19.1.tgz#18111fb422eaf841737adb92d5ab12133d244218"
+  integrity sha512-IJF5b93b2MgAzcE/tuzW0yOPnuUyRgGAtaPv5UUywXM8kzqfdwZTO4sPJBzoGz1eOy6H9uEchsJsBFTELZSu+g==
+  dependencies:
+    "@algolia/cache-browser-local-storage" "4.19.1"
+    "@algolia/cache-common" "4.19.1"
+    "@algolia/cache-in-memory" "4.19.1"
+    "@algolia/client-account" "4.19.1"
+    "@algolia/client-analytics" "4.19.1"
+    "@algolia/client-common" "4.19.1"
+    "@algolia/client-personalization" "4.19.1"
+    "@algolia/client-search" "4.19.1"
+    "@algolia/logger-common" "4.19.1"
+    "@algolia/logger-console" "4.19.1"
+    "@algolia/requester-browser-xhr" "4.19.1"
+    "@algolia/requester-common" "4.19.1"
+    "@algolia/requester-node-http" "4.19.1"
+    "@algolia/transporter" "4.19.1"
+
 alphanum-sort@^1.0.0, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -8179,9 +8345,9 @@ core-js-compat@^3.16.0, core-js-compat@^3.16.2, core-js-compat@^3.8.1:
     semver "7.0.0"
 
 core-js-pure@^3.16.0, core-js-pure@^3.8.1:
-  version "3.30.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.30.1.tgz#7d93dc89e7d47b8ef05d7e79f507b0e99ea77eec"
-  integrity sha512-nXBEVpmUnNRhz83cHd9JRQC52cTMcuXAmR56+9dSMpRdpeA4I1PX6yjmhd71Eyc/wXNsdBdUDIj1QTIeZpU5Tg==
+  version "3.32.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.32.0.tgz#5d79f85da7a4373e9a06494ccbef995a4c639f8b"
+  integrity sha512-qsev1H+dTNYpDUEURRuOXMvpdtAnNEvQWS/FMJ2Vb5AY8ZP4rAPQldkE27joykZPJTe0+IVgHZYh1P5Xu1/i1g==
 
 core-js@^2.4.0, core-js@^2.6.10, core-js@^2.6.5:
   version "2.6.12"
@@ -22508,9 +22674,9 @@ semver-regex@^1.0.0:
   integrity sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=
 
 "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Well, I got an email from the Security team to move this to the env despite being a public key. We are also using a very old version of Algolia and need to migrate soon to using [docsearch](https://docsearch.algolia.com/docs/migrating-from-legacy) which has a new scraper infrastructure.