### PR TITLE
fix(@clayui/breadcrumb): updates colors to active state with link and expand button

### DIFF
--- a/packages/clay-breadcrumb/docs/index.js
+++ b/packages/clay-breadcrumb/docs/index.js
@@ -13,11 +13,8 @@ const breadcrumbImportsCode = `import ClayBreadcrumb from '@clayui/breadcrumb';
 const BreadcrumbCode = `const Component = () => {
 	return (
 		<ClayBreadcrumb
-			ellipsisBuffer={1}
-			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			items={[
 				{
-					active: true,
 					href: '#1',
 					label: 'Home',
 				},
@@ -34,6 +31,7 @@ const BreadcrumbCode = `const Component = () => {
 					label: 'Projects',
 				},
 				{
+					active: true,
 					href: '#5',
 					label: 'Five',
 				}

--- a/packages/clay-breadcrumb/src/Item.tsx
+++ b/packages/clay-breadcrumb/src/Item.tsx
@@ -40,7 +40,7 @@ const Item = ({active, href, label, onClick, ...otherProps}: IItem) => (
 			aria-current={active ? 'page' : undefined}
 			className="breadcrumb-link"
 			data-testid={`testId${label}`}
-			href={href}
+			href={active ? '#' : href}
 			onClick={(event) => {
 				if (onClick) {
 					event.preventDefault();

--- a/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
@@ -9,7 +9,7 @@ exports[`ClayBreadcrumb calls callback when an item is clicked 1`] = `
     <button
       aria-expanded="false"
       aria-label="See full nested"
-      class="btn btn-monospaced btn-xs"
+      class="breadcrumb-item-expand btn btn-monospaced btn-xs"
       title="See full nested"
       type="button"
     >
@@ -59,7 +59,7 @@ exports[`ClayBreadcrumb renders 1`] = `
     <button
       aria-expanded="false"
       aria-label="See full nested"
-      class="btn btn-monospaced btn-xs"
+      class="breadcrumb-item-expand btn btn-monospaced btn-xs"
       title="See full nested"
       type="button"
     >
@@ -111,7 +111,7 @@ exports[`ClayBreadcrumb renders with properties passed by \`ellipsisProps\` 1`] 
     <button
       aria-expanded="false"
       aria-label="See full nested"
-      class="btn btn-monospaced btn-xs"
+      class="breadcrumb-item-expand btn btn-monospaced btn-xs"
       title="See full nested"
       type="button"
     >

--- a/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
@@ -9,7 +9,7 @@ exports[`ClayBreadcrumb calls callback when an item is clicked 1`] = `
     <button
       aria-expanded="false"
       aria-label="See full nested"
-      class="breadcrumb-item-expand btn btn-monospaced btn-xs"
+      class="breadcrumb-toggle btn btn-monospaced btn-xs"
       title="See full nested"
       type="button"
     >
@@ -59,7 +59,7 @@ exports[`ClayBreadcrumb renders 1`] = `
     <button
       aria-expanded="false"
       aria-label="See full nested"
-      class="breadcrumb-item-expand btn btn-monospaced btn-xs"
+      class="breadcrumb-toggle btn btn-monospaced btn-xs"
       title="See full nested"
       type="button"
     >
@@ -111,7 +111,7 @@ exports[`ClayBreadcrumb renders with properties passed by \`ellipsisProps\` 1`] 
     <button
       aria-expanded="false"
       aria-label="See full nested"
-      class="breadcrumb-item-expand btn btn-monospaced btn-xs"
+      class="breadcrumb-toggle btn btn-monospaced btn-xs"
       title="See full nested"
       type="button"
     >

--- a/packages/clay-breadcrumb/src/index.tsx
+++ b/packages/clay-breadcrumb/src/index.tsx
@@ -84,6 +84,7 @@ const ClayBreadcrumb = ({
 				<ClayButtonWithIcon
 					aria-expanded={collapsed}
 					aria-label={collapsed ? ariaLabels.close : ariaLabels.open}
+					className="breadcrumb-item-expand"
 					displayType={null}
 					onClick={() => setCollapsed(!collapsed)}
 					size="xs"

--- a/packages/clay-breadcrumb/src/index.tsx
+++ b/packages/clay-breadcrumb/src/index.tsx
@@ -84,7 +84,7 @@ const ClayBreadcrumb = ({
 				<ClayButtonWithIcon
 					aria-expanded={collapsed}
 					aria-label={collapsed ? ariaLabels.close : ariaLabels.open}
-					className="breadcrumb-item-expand"
+					className="breadcrumb-toggle"
 					displayType={null}
 					onClick={() => setCollapsed(!collapsed)}
 					size="xs"

--- a/packages/clay-css/src/scss/cadmin/components/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_breadcrumbs.scss
@@ -15,12 +15,20 @@
 	}
 }
 
+.breadcrumb-item-expand {
+	@include clay-link($cadmin-breadcrumb-item-expand);
+}
+
 .breadcrumb-item {
 	@include clay-css($cadmin-breadcrumb-item);
 
 	&.active,
 	.active {
 		@include clay-css(map-get($cadmin-breadcrumb-item, active));
+
+		.breadcrumb-link {
+			color: inherit;
+		}
 	}
 
 	> span {

--- a/packages/clay-css/src/scss/cadmin/components/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_breadcrumbs.scss
@@ -15,8 +15,8 @@
 	}
 }
 
-.breadcrumb-item-expand {
-	@include clay-link($cadmin-breadcrumb-item-expand);
+.breadcrumb-toggle {
+	@include clay-link($cadmin-breadcrumb-toggle);
 }
 
 .breadcrumb-item {

--- a/packages/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
@@ -145,3 +145,13 @@ $cadmin-breadcrumb-link: map-deep-merge(
 	),
 	$cadmin-breadcrumb-link
 );
+
+// Breadcrumb Item Expand
+
+$cadmin-breadcrumb-item-expand: () !default;
+$cadmin-breadcrumb-item-expand: map-merge(
+	(
+		color: $cadmin-breadcrumb-link-color,
+	),
+	$cadmin-breadcrumb-item-expand
+);

--- a/packages/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
@@ -148,10 +148,10 @@ $cadmin-breadcrumb-link: map-deep-merge(
 
 // Breadcrumb Item Expand
 
-$cadmin-breadcrumb-item-expand: () !default;
-$cadmin-breadcrumb-item-expand: map-merge(
+$cadmin-breadcrumb-toggle: () !default;
+$cadmin-breadcrumb-toggle: map-merge(
 	(
 		color: $cadmin-breadcrumb-link-color,
 	),
-	$cadmin-breadcrumb-item-expand
+	$cadmin-breadcrumb-toggle
 );

--- a/packages/clay-css/src/scss/components/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/components/_breadcrumbs.scss
@@ -6,8 +6,8 @@
 	@include clay-link($breadcrumb-link);
 }
 
-.breadcrumb-item-expand {
-	@include clay-link($breadcrumb-item-expand);
+.breadcrumb-toggle {
+	@include clay-link($breadcrumb-toggle);
 }
 
 .breadcrumb-item {

--- a/packages/clay-css/src/scss/components/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/components/_breadcrumbs.scss
@@ -6,12 +6,20 @@
 	@include clay-link($breadcrumb-link);
 }
 
+.breadcrumb-item-expand {
+	@include clay-link($breadcrumb-item-expand);
+}
+
 .breadcrumb-item {
 	@include clay-css($breadcrumb-item);
 
 	&.active,
 	.active {
 		@include clay-css(map-get($breadcrumb-item, active));
+
+		.breadcrumb-link {
+			color: inherit;
+		}
 	}
 
 	> span {

--- a/packages/clay-css/src/scss/variables/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/variables/_breadcrumbs.scss
@@ -138,3 +138,13 @@ $breadcrumb-link: map-deep-merge(
 	),
 	$breadcrumb-link
 );
+
+// Breadcrumb Item Expand
+
+$breadcrumb-item-expand: () !default;
+$breadcrumb-item-expand: map-merge(
+	(
+		color: $breadcrumb-link-color,
+	),
+	$breadcrumb-item-expand
+);

--- a/packages/clay-css/src/scss/variables/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/variables/_breadcrumbs.scss
@@ -141,10 +141,10 @@ $breadcrumb-link: map-deep-merge(
 
 // Breadcrumb Item Expand
 
-$breadcrumb-item-expand: () !default;
-$breadcrumb-item-expand: map-merge(
+$breadcrumb-toggle: () !default;
+$breadcrumb-toggle: map-merge(
 	(
 		color: $breadcrumb-link-color,
 	),
-	$breadcrumb-item-expand
+	$breadcrumb-toggle
 );


### PR DESCRIPTION
I'm updating link colors with active state and also updating expand button color. There are other small details, the item with the active state we are setting the `href` to `#` instead of the link to avoid page refresh.