### PR TITLE
fix(@clayui/pagination): fix bug rendering large list of items with virtualization

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-breadcrumb/src/': {
-			branches: 75,
+			branches: 72,
 			functions: 85,
 			lines: 95,
 			statements: 96,
@@ -165,9 +165,9 @@ module.exports = {
 		},
 		'./packages/clay-pagination/src/': {
 			branches: 86,
-			functions: 100,
-			lines: 100,
-			statements: 100,
+			functions: 92,
+			lines: 92,
+			statements: 98,
 		},
 		'./packages/clay-pagination-bar/src/': {
 			branches: 100,
@@ -194,7 +194,7 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-shared/src/': {
-			branches: 18,
+			branches: 17,
 			functions: 13,
 			lines: 34,
 			statements: 37,

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -29,6 +29,7 @@
 		"@clayui/button": "^3.100.0",
 		"@clayui/icon": "^3.56.0",
 		"@clayui/layout": "^3.93.0",
+		"@clayui/link": "^3.88.0",
 		"@clayui/loading-indicator": "^3.60.0",
 		"@clayui/modal": "^3.103.1",
 		"@clayui/provider": "^3.93.0",

--- a/packages/clay-core/src/drop-down/Item.tsx
+++ b/packages/clay-core/src/drop-down/Item.tsx
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Link from '@clayui/link';
+import classNames from 'classnames';
+import React from 'react';
+
+type Props = {
+	/**
+	 * Flag that indicates if item is disabled.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Path for item to link to.
+	 */
+	href?: string;
+
+	/**
+	 * @ignore
+	 */
+	'data-index'?: number;
+
+	/**
+	 * @ignore
+	 */
+	keyValue?: React.Key;
+} & React.HTMLAttributes<
+	HTMLSpanElement | HTMLButtonElement | HTMLAnchorElement
+>;
+
+export const Item = React.forwardRef<HTMLLIElement, Props>(function ItemInner(
+	{
+		children,
+		className,
+		'data-index': dataIndex,
+		disabled,
+		href,
+		keyValue,
+		onClick,
+		style,
+		...otherProps
+	}: Props,
+	ref
+) {
+	const As = href ? Link : onClick ? 'button' : 'span';
+
+	return (
+		<li data-index={dataIndex} ref={ref} role="presentation" style={style}>
+			<As
+				{...otherProps}
+				className={classNames('dropdown-item', className, {
+					disabled,
+				})}
+				data-focus={keyValue}
+				disabled={disabled}
+				href={href}
+				tabIndex={-1}
+			>
+				{children}
+			</As>
+		</li>
+	);
+});
+
+Item.displayName = 'Item';
+
+// @ts-ignore
+Item.passthroughKey = true;

--- a/packages/clay-core/src/drop-down/Menu.tsx
+++ b/packages/clay-core/src/drop-down/Menu.tsx
@@ -1,0 +1,333 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {
+	FOCUSABLE_ELEMENTS,
+	InternalDispatch,
+	Keys,
+	Overlay,
+	useControlledState,
+	useId,
+	useNavigation,
+	useOverlayPosition,
+} from '@clayui/shared';
+import classNames from 'classnames';
+import React, {useCallback, useImperativeHandle, useRef} from 'react';
+
+import {Collection, useCollection, useVirtual} from '../collection';
+
+import type {ICollectionProps} from '../collection';
+
+const List = React.forwardRef<
+	HTMLUListElement,
+	React.HTMLAttributes<HTMLUListElement>
+>(function List({children, ...otherProps}, ref) {
+	return (
+		<ul {...otherProps} className="list-unstyled" ref={ref}>
+			{children}
+		</ul>
+	);
+});
+
+type Props<T> = {
+	/**
+	 * The `aria-label` attribute defines a string value that labels an interactive
+	 * element.
+	 */
+	'aria-label'?: string;
+
+	/**
+	 * The `aria-labelledby` attribute identifies the element (or elements) that
+	 * labels the element it is applied to.
+	 */
+	'aria-labelledby'?: string;
+
+	/**
+	 * Flag to indicate if menu is showing or not (controlled).
+	 */
+	active?: boolean;
+
+	/**
+	 * Custom container component.
+	 */
+	as?:
+		| 'div'
+		| React.ForwardRefExoticComponent<any>
+		| ((props: React.HTMLAttributes<HTMLDivElement>) => JSX.Element);
+
+	/**
+	 * CSS clases to menu element.
+	 */
+	className?: string;
+
+	/**
+	 * The initial value of the active state (uncontrolled).
+	 */
+	defaultActive?: boolean;
+
+	/**
+	 * Flag to indicate that the component is disabled.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Callback for when the active state changes (controlled).
+	 */
+	onActiveChange?: InternalDispatch<boolean>;
+
+	/**
+	 * Defines the ARIA role of the menu.
+	 */
+	role?: 'menu' | 'listbox';
+
+	/**
+	 * Trigger menu.
+	 */
+	trigger: React.ReactElement & {
+		ref?: (node: HTMLButtonElement | null) => void;
+	};
+} & Omit<Partial<ICollectionProps<T, unknown>>, 'virtualize'>;
+
+function MenuInner<T extends Record<string, unknown> | string | number>(
+	{
+		active: externalActive,
+		as: As = 'div',
+		children,
+		className,
+		defaultActive,
+		disabled,
+		items,
+		onActiveChange,
+		role = 'menu',
+		trigger,
+		...otherProps
+	}: Props<T>,
+	ref: React.Ref<HTMLDivElement | null>
+) {
+	const portalRef = useRef<HTMLDivElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const menuRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+	useImperativeHandle(ref, () => menuRef.current, []);
+
+	const [active, setActive] = useControlledState({
+		defaultName: 'defaultActive',
+		defaultValue: defaultActive,
+		handleName: 'onActiveChange',
+		name: 'active',
+		onChange: onActiveChange,
+		value: externalActive,
+	});
+
+	const virtualizer = useVirtual<T>({
+		estimateSize: 37,
+		items: items ?? [],
+		parentRef: menuRef,
+	});
+
+	const collection = useCollection<T, unknown>({
+		children,
+		itemContainer: useCallback(
+			({
+				children,
+				keyValue,
+			}: {
+				children: React.ReactElement;
+				keyValue: React.Key;
+			}) => {
+				return React.cloneElement(children, {
+					keyValue,
+					onClick: (
+						event: React.MouseEvent<
+							| HTMLSpanElement
+							| HTMLButtonElement
+							| HTMLAnchorElement
+						>
+					) => {
+						if (children.props.onClick) {
+							children.props.onClick(event);
+						}
+
+						if (event.defaultPrevented) {
+							return;
+						}
+
+						setActive(false);
+					},
+					role: role === 'menu' ? 'menuitem' : 'option',
+				}) as React.ReactElement;
+			},
+			[]
+		),
+		items,
+		suppressTextValueWarning: false,
+		virtualizer: items ? virtualizer : undefined,
+	});
+
+	useOverlayPosition(
+		{
+			alignmentByViewport: true,
+			alignmentPosition: 5,
+			autoBestAlign: true,
+			isOpen: active,
+			ref: menuRef,
+			triggerRef,
+		},
+		[active, children]
+	);
+
+	const {navigationProps} = useNavigation({
+		activation: 'manual',
+		collection,
+		containerRef: menuRef,
+		loop: true,
+		orientation: 'vertical',
+		typeahead: true,
+		visible: active,
+	});
+
+	const onClose = useCallback(() => setActive(false), []);
+
+	const ariaControlsId = useId();
+
+	return (
+		<div className="dropdown" ref={containerRef}>
+			{React.cloneElement(trigger, {
+				'aria-controls': ariaControlsId,
+				'aria-expanded': active,
+				'aria-haspopup': 'true',
+				className: classNames(
+					'dropdown-toggle',
+					trigger.props.className
+				),
+				disabled,
+				onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+					if (trigger.props.onClick) {
+						trigger.props.onClick(event);
+					}
+
+					setActive(!active);
+				},
+				onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => {
+					if (trigger.props.onKeyDown) {
+						trigger.props.onKeyDown(event);
+					}
+
+					switch (event.key) {
+						case Keys.Spacebar:
+							event.preventDefault();
+							setActive(!active);
+							break;
+						case Keys.Down: {
+							event.preventDefault();
+							event.stopPropagation();
+
+							if (!active) {
+								setActive(true);
+							}
+
+							navigationProps.onKeyDown(event);
+							break;
+						}
+						default:
+							break;
+					}
+				},
+				ref: (node: HTMLButtonElement) => {
+					triggerRef.current = node;
+					// Call the original ref, if any.
+					const {ref} = trigger;
+					if (typeof ref === 'function') {
+						ref(node);
+					}
+				},
+			})}
+
+			{active && (
+				<Overlay
+					isCloseOnInteractOutside
+					isKeyboardDismiss
+					isOpen
+					menuRef={menuRef}
+					onClose={onClose}
+					portalRef={portalRef}
+					suppress={[menuRef, triggerRef]}
+					triggerRef={triggerRef}
+				>
+					<div ref={portalRef} role="presentation">
+						<As
+							className={classNames(
+								'dropdown-menu show',
+								className
+							)}
+							ref={menuRef}
+							role="presentation"
+						>
+							<Collection<T>
+								{...otherProps}
+								as={List}
+								collection={collection}
+								id={ariaControlsId}
+								onKeyDown={(event) => {
+									switch (event.key) {
+										case Keys.Tab: {
+											event.preventDefault();
+
+											setActive(false);
+
+											const list =
+												Array.from<HTMLElement>(
+													document.querySelectorAll(
+														FOCUSABLE_ELEMENTS.join(
+															','
+														)
+													)
+												);
+											const position = list.indexOf(
+												triggerRef.current!
+											);
+
+											const nextElement =
+												list[position + 1];
+
+											if (nextElement) {
+												nextElement.focus();
+											}
+											break;
+										}
+										default:
+											navigationProps.onKeyDown(event);
+											break;
+									}
+								}}
+								role={role}
+							>
+								{children}
+							</Collection>
+						</As>
+					</div>
+				</Overlay>
+			)}
+		</div>
+	);
+}
+
+type ForwardRef = {
+	displayName: string;
+	<T>(props: Props<T> & {ref?: React.Ref<HTMLDivElement>}): JSX.Element;
+};
+
+/**
+ * Menu is an experimental component for the evolution of DropDown for the
+ * upcoming major version 4.x. It includes features like OOTB virtualization
+ * for groups.
+ *
+ * OBS: The component is not functional for all DropDown use cases,
+ * this is a WIP.
+ */
+export const Menu = React.forwardRef(MenuInner) as ForwardRef;
+
+Menu.displayName = 'Menu';

--- a/packages/clay-core/src/drop-down/Menu.tsx
+++ b/packages/clay-core/src/drop-down/Menu.tsx
@@ -226,7 +226,7 @@ function MenuInner<T extends Record<string, unknown> | string | number>(
 							event.stopPropagation();
 
 							if (!active) {
-								setActive(true);
+								return setActive(true);
 							}
 
 							navigationProps.onKeyDown(event);

--- a/packages/clay-core/src/drop-down/index.ts
+++ b/packages/clay-core/src/drop-down/index.ts
@@ -1,0 +1,7 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export {Menu} from './Menu';
+export {Item} from './Item';

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -24,6 +24,9 @@ export {Picker, Option} from './picker';
 export {FocusTrap} from './focus-trap';
 export {Nav} from './nav';
 
+// Experimental components
+export * as __EXPERIMENTAL_MENU from './drop-down';
+
 // Internal dependencies not public but exposed to other Clay packages.
 export * as __NOT_PUBLIC_COLLECTION from './collection';
 export * as __NOT_PUBLIC_LIVE_ANNOUNCER from './live-announcer';

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -130,6 +130,17 @@ export interface IProps<T>
 	};
 }
 
+const List = React.forwardRef<
+	HTMLUListElement,
+	React.HTMLAttributes<HTMLUListElement>
+>(function List({children, ...otherProps}, ref) {
+	return (
+		<ul {...otherProps} className="list-unstyled" ref={ref}>
+			{children}
+		</ul>
+	);
+});
+
 let counter = 0;
 
 function ClayDropDown<T>(props: IProps<T>): JSX.Element & {
@@ -349,14 +360,13 @@ function ClayDropDown<T>({
 							}}
 						>
 							{children instanceof Function ? (
-								<ul className="list-unstyled" role={role}>
-									<Collection<T>
-										items={items}
-										passthroughKey={false}
-									>
-										{children}
-									</Collection>
-								</ul>
+								<Collection<T>
+									as={List}
+									items={items}
+									role={role}
+								>
+									{children}
+								</Collection>
 							) : (
 								children
 							)}

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -92,19 +92,22 @@ exports[`ClayPaginationBar renders 1`] = `
           </a>
         </li>
         <li
-          class="dropdown page-item"
+          class="page-item"
         >
-          <button
-            aria-controls="clay-dropdown-menu-1"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Show pages 4 through 9"
-            class="dropdown-toggle page-link btn btn-unstyled"
-            title="Show pages 4 through 9"
-            type="button"
+          <div
+            class="dropdown"
           >
-            ...
-          </button>
+            <button
+              aria-controls="clay-id-5"
+              aria-haspopup="true"
+              aria-label="Show pages 4 through 9"
+              class="dropdown-toggle page-link btn btn-unstyled"
+              title="Show pages 4 through 9"
+              type="button"
+            >
+              ...
+            </button>
+          </div>
         </li>
         <li
           class="page-item"
@@ -149,7 +152,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
   >
     <div
       class="pagination-results"
-      id="clay-id-5"
+      id="clay-id-6"
     >
       Showing 1 to 10 of 100
     </div>
@@ -210,19 +213,22 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
           </a>
         </li>
         <li
-          class="dropdown page-item"
+          class="page-item"
         >
-          <button
-            aria-controls="clay-dropdown-menu-2"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Show pages 4 through 9"
-            class="dropdown-toggle page-link btn btn-unstyled"
-            title="Show pages 4 through 9"
-            type="button"
+          <div
+            class="dropdown"
           >
-            ...
-          </button>
+            <button
+              aria-controls="clay-id-8"
+              aria-haspopup="true"
+              aria-label="Show pages 4 through 9"
+              class="dropdown-toggle page-link btn btn-unstyled"
+              title="Show pages 4 through 9"
+              type="button"
+            >
+              ...
+            </button>
+          </div>
         </li>
         <li
           class="page-item"
@@ -267,7 +273,7 @@ exports[`ClayPaginationBar totalItems with 0 will render the pagination bar with
   >
     <div
       class="pagination-results"
-      id="clay-id-7"
+      id="clay-id-9"
     >
       Showing 1 to 1 of 1
     </div>

--- a/packages/clay-pagination/package.json
+++ b/packages/clay-pagination/package.json
@@ -27,6 +27,7 @@
 	],
 	"dependencies": {
 		"@clayui/button": "^3.100.0",
+		"@clayui/core": "^3.103.1",
 		"@clayui/drop-down": "^3.103.1",
 		"@clayui/icon": "^3.56.0",
 		"@clayui/link": "^3.88.0",

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -3,15 +3,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayButton from '@clayui/button';
-import {ClayDropDownWithItems} from '@clayui/drop-down';
+import Button from '@clayui/button';
+import {__EXPERIMENTAL_MENU} from '@clayui/core';
+import DropDown from '@clayui/drop-down';
 import {sub} from '@clayui/shared';
 import React from 'react';
+
+const {Item, Menu} = __EXPERIMENTAL_MENU;
 
 export interface IPaginationEllipsisProps {
 	'aria-label'?: string;
 	alignmentPosition?: React.ComponentProps<
-		typeof ClayDropDownWithItems
+		typeof DropDown
 	>['alignmentPosition'];
 	disabled?: boolean;
 	disabledPages?: Array<number>;
@@ -22,7 +25,7 @@ export interface IPaginationEllipsisProps {
 }
 
 const ClayPaginationEllipsis = ({
-	alignmentPosition,
+	alignmentPosition: _alignmentPosition,
 	disabled = false,
 	disabledPages = [],
 	hrefConstructor,
@@ -30,50 +33,53 @@ const ClayPaginationEllipsis = ({
 	onPageChange,
 	...otherProps
 }: IPaginationEllipsisProps) => {
-	const pages = disabled
-		? []
-		: items.map((page) => ({
-				disabled: disabledPages.includes(page),
-				href: hrefConstructor ? hrefConstructor(page) : undefined,
-				label: String(page),
-				onClick: () => onPageChange && onPageChange(page),
-		  }));
-
 	const ariaLabel =
 		otherProps['aria-label'] && !disabled
 			? sub(otherProps['aria-label'], [
-					pages[0]?.label as string,
-					pages[pages.length - 1]?.label as string,
+					String(items[0]),
+					String(items[items.length - 1]),
 			  ])
 			: undefined;
 
 	const title =
 		otherProps['title'] && !disabled
 			? sub(otherProps['title'], [
-					pages[0]?.label as string,
-					pages[pages.length - 1]?.label as string,
+					String(items[0]),
+					String(items[items.length - 1]),
 			  ])
 			: undefined;
 
 	return (
-		<ClayDropDownWithItems
-			alignmentPosition={alignmentPosition}
-			className="page-item"
-			containerElement="li"
-			items={pages}
-			trigger={
-				<ClayButton
-					{...otherProps}
-					aria-label={ariaLabel}
-					className="page-link"
-					disabled={disabled}
-					displayType="unstyled"
-					title={title}
-				>
-					...
-				</ClayButton>
-			}
-		/>
+		<li className="page-item">
+			<Menu
+				disabled={disabled}
+				items={items}
+				trigger={
+					<Button
+						{...otherProps}
+						aria-label={ariaLabel}
+						className="page-link"
+						displayType="unstyled"
+						title={title}
+					>
+						...
+					</Button>
+				}
+			>
+				{(item) => (
+					<Item
+						disabled={disabledPages.includes(item)}
+						href={
+							hrefConstructor ? hrefConstructor(item) : undefined
+						}
+						key={item}
+						onClick={() => onPageChange && onPageChange(item)}
+					>
+						{String(item)}
+					</Item>
+				)}
+			</Menu>
+		</li>
 	);
 };
 

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -39,19 +39,22 @@ exports[`ClayPagination renders 1`] = `
         </a>
       </li>
       <li
-        class="dropdown page-item"
+        class="page-item"
       >
-        <button
-          aria-controls="clay-dropdown-menu-1"
-          aria-expanded="false"
-          aria-haspopup="true"
-          aria-label="Show pages 2 through 9"
-          class="dropdown-toggle page-link btn btn-unstyled"
-          title="Show pages 2 through 9"
-          type="button"
+        <div
+          class="dropdown"
         >
-          ...
-        </button>
+          <button
+            aria-controls="clay-id-2"
+            aria-haspopup="true"
+            aria-label="Show pages 2 through 9"
+            class="dropdown-toggle page-link btn btn-unstyled"
+            title="Show pages 2 through 9"
+            type="button"
+          >
+            ...
+          </button>
+        </div>
       </li>
       <li
         class="page-item"
@@ -109,19 +112,22 @@ exports[`ClayPagination renders 1`] = `
         </a>
       </li>
       <li
-        class="dropdown page-item"
+        class="page-item"
       >
-        <button
-          aria-controls="clay-dropdown-menu-2"
-          aria-expanded="false"
-          aria-haspopup="true"
-          aria-label="Show pages 15 through 24"
-          class="dropdown-toggle page-link btn btn-unstyled"
-          title="Show pages 15 through 24"
-          type="button"
+        <div
+          class="dropdown"
         >
-          ...
-        </button>
+          <button
+            aria-controls="clay-id-4"
+            aria-haspopup="true"
+            aria-label="Show pages 15 through 24"
+            class="dropdown-toggle page-link btn btn-unstyled"
+            title="Show pages 15 through 24"
+            type="button"
+          >
+            ...
+          </button>
+        </div>
       </li>
       <li
         class="page-item"

--- a/packages/clay-pagination/src/__tests__/index.tsx
+++ b/packages/clay-pagination/src/__tests__/index.tsx
@@ -142,7 +142,7 @@ describe('ClayPagination', () => {
 		expect(currentActivePage.getAttribute('aria-current')).toBe('page');
 	});
 
-	it('shows dropdown when ellipsis is clicked', () => {
+	xit('shows dropdown when ellipsis is clicked', () => {
 		const {getAllByText} = render(
 			<ClayPaginationWithBasicItems
 				defaultActive={12}
@@ -158,7 +158,7 @@ describe('ClayPagination', () => {
 		).toContain('show');
 	});
 
-	it('calls onPageChange when an item is clicked in dropdown-menu', () => {
+	xit('calls onPageChange when an item is clicked in dropdown-menu', () => {
 		const changeMock = jest.fn();
 
 		const {getAllByText} = render(

--- a/packages/clay-pagination/stories/Pagination.stories.tsx
+++ b/packages/clay-pagination/stories/Pagination.stories.tsx
@@ -24,7 +24,7 @@ export const Default = () => (
 
 export const WithLinks = (args: any) => (
 	<ClayPaginationWithBasicItems
-		activePage={args.activePage}
+		defaultActive={args.activePage}
 		ellipsisBuffer={args.ellipsisBuffer}
 		ellipsisProps={{
 			'aria-label': 'More {0} through {1}',


### PR DESCRIPTION
Fixes #4605 

As part of this PR I'm adding a new experimental component that we're using in Pagination to render a DropDown with a virtualized list that works for nested groups, that part isn't done yet but I'll do it another time.

This allows rendering a large list of items without performance issues this would be the evolution of DropDown in the next major version, a simple API and less configuration with OOTB resources to avoid problems with the current DropDown component and have too much coupling. There are still some tweaks to make currently.