### PR TITLE
feat(@clayui/css): Adds focus-within

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -226,8 +226,8 @@ module.exports = {
 		'./packages/clay-time-picker/src/': {
 			branches: 85,
 			functions: 95,
-			lines: 98,
-			statements: 98,
+			lines: 95,
+			statements: 95,
 		},
 		'./packages/clay-toolbar/src/': {
 			branches: 50,

--- a/packages/clay-color-picker/src/Editor.tsx
+++ b/packages/clay-color-picker/src/Editor.tsx
@@ -85,7 +85,7 @@ const RGBInput = ({name, onChange, value}: RGBInputProps) => {
 	return (
 		<ClayForm.Group>
 			<ClayInput.Group>
-				<ClayInput.GroupItem>
+				<ClayInput.GroupItem className="form-control-container">
 					<ClayInput
 						data-testid={`${name}Input`}
 						insetBefore
@@ -208,7 +208,7 @@ export function Editor({
 			<div className="clay-color-footer">
 				<ClayForm.Group>
 					<ClayInput.Group>
-						<ClayInput.GroupItem>
+						<ClayInput.GroupItem className="form-control-container">
 							<ClayInput
 								data-testid="customHexInput"
 								insetBefore

--- a/packages/clay-color-picker/src/Editor.tsx
+++ b/packages/clay-color-picker/src/Editor.tsx
@@ -85,7 +85,7 @@ const RGBInput = ({name, onChange, value}: RGBInputProps) => {
 	return (
 		<ClayForm.Group>
 			<ClayInput.Group>
-				<ClayInput.GroupItem className="form-control-container">
+				<ClayInput.GroupItem className="input-group-item-focusable">
 					<ClayInput
 						data-testid={`${name}Input`}
 						insetBefore
@@ -208,7 +208,7 @@ export function Editor({
 			<div className="clay-color-footer">
 				<ClayForm.Group>
 					<ClayInput.Group>
-						<ClayInput.GroupItem className="form-control-container">
+						<ClayInput.GroupItem className="input-group-item-focusable">
 							<ClayInput
 								data-testid="customHexInput"
 								insetBefore

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -39,7 +39,7 @@ exports[`Interactions color editor interactions ability to change color of click
           </div>
         </div>
         <div
-          class="input-group-item input-group-append"
+          class="input-group-item form-control-container input-group-append"
         >
           <input
             aria-label="Color selection is FFFFFF"
@@ -235,7 +235,7 @@ exports[`Interactions color editor interactions ability to change color of click
                 class="input-group"
               >
                 <div
-                  class="input-group-item"
+                  class="input-group-item form-control-container"
                 >
                   <input
                     class="form-control input-group-inset input-group-inset-before"
@@ -260,7 +260,7 @@ exports[`Interactions color editor interactions ability to change color of click
                 class="input-group"
               >
                 <div
-                  class="input-group-item"
+                  class="input-group-item form-control-container"
                 >
                   <input
                     class="form-control input-group-inset input-group-inset-before"
@@ -285,7 +285,7 @@ exports[`Interactions color editor interactions ability to change color of click
                 class="input-group"
               >
                 <div
-                  class="input-group-item"
+                  class="input-group-item form-control-container"
                 >
                   <input
                     class="form-control input-group-inset input-group-inset-before"
@@ -330,7 +330,7 @@ exports[`Interactions color editor interactions ability to change color of click
               class="input-group"
             >
               <div
-                class="input-group-item"
+                class="input-group-item form-control-container"
               >
                 <input
                   class="form-control input-group-inset input-group-inset-before"
@@ -391,7 +391,7 @@ exports[`Interactions opens custom color picker drop down when clicked 1`] = `
         </div>
       </div>
       <div
-        class="input-group-item input-group-append"
+        class="input-group-item form-control-container input-group-append"
       >
         <input
           aria-label="Color selection is 008000"
@@ -447,7 +447,7 @@ exports[`Rendering default 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item input-group-append"
+          class="input-group-item form-control-container input-group-append"
         >
           <input
             aria-label="Color selection is FFF"
@@ -825,7 +825,7 @@ exports[`Rendering disabled palette 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item input-group-append"
+          class="input-group-item form-control-container input-group-append"
         >
           <input
             aria-label="Color selection is FFF"
@@ -1204,7 +1204,7 @@ exports[`Rendering disabled state 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item input-group-append"
+          class="input-group-item form-control-container input-group-append"
         >
           <input
             aria-label="Color selection is FFF"
@@ -1582,7 +1582,7 @@ exports[`Rendering renders w/ var() 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item input-group-append"
+          class="input-group-item form-control-container input-group-append"
         >
           <input
             aria-label="Color selection is var(--blue)"
@@ -1968,7 +1968,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item input-group-append"
+          class="input-group-item form-control-container input-group-append"
         >
           <input
             aria-label="Color selection is FFF"
@@ -2346,7 +2346,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item input-group-append"
+          class="input-group-item form-control-container input-group-append"
         >
           <input
             aria-label="Color selection is red"
@@ -2732,7 +2732,7 @@ exports[`Rendering small color-picker 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item input-group-append"
+          class="input-group-item form-control-container input-group-append"
         >
           <input
             aria-label="Color selection is FFF"

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -39,7 +39,7 @@ exports[`Interactions color editor interactions ability to change color of click
           </div>
         </div>
         <div
-          class="input-group-item form-control-container input-group-append"
+          class="input-group-item input-group-item-focusable input-group-append"
         >
           <input
             aria-label="Color selection is FFFFFF"
@@ -235,7 +235,7 @@ exports[`Interactions color editor interactions ability to change color of click
                 class="input-group"
               >
                 <div
-                  class="input-group-item form-control-container"
+                  class="input-group-item input-group-item-focusable"
                 >
                   <input
                     class="form-control input-group-inset input-group-inset-before"
@@ -260,7 +260,7 @@ exports[`Interactions color editor interactions ability to change color of click
                 class="input-group"
               >
                 <div
-                  class="input-group-item form-control-container"
+                  class="input-group-item input-group-item-focusable"
                 >
                   <input
                     class="form-control input-group-inset input-group-inset-before"
@@ -285,7 +285,7 @@ exports[`Interactions color editor interactions ability to change color of click
                 class="input-group"
               >
                 <div
-                  class="input-group-item form-control-container"
+                  class="input-group-item input-group-item-focusable"
                 >
                   <input
                     class="form-control input-group-inset input-group-inset-before"
@@ -330,7 +330,7 @@ exports[`Interactions color editor interactions ability to change color of click
               class="input-group"
             >
               <div
-                class="input-group-item form-control-container"
+                class="input-group-item input-group-item-focusable"
               >
                 <input
                   class="form-control input-group-inset input-group-inset-before"
@@ -391,7 +391,7 @@ exports[`Interactions opens custom color picker drop down when clicked 1`] = `
         </div>
       </div>
       <div
-        class="input-group-item form-control-container input-group-append"
+        class="input-group-item input-group-item-focusable input-group-append"
       >
         <input
           aria-label="Color selection is 008000"
@@ -447,7 +447,7 @@ exports[`Rendering default 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item form-control-container input-group-append"
+          class="input-group-item input-group-item-focusable input-group-append"
         >
           <input
             aria-label="Color selection is FFF"
@@ -825,7 +825,7 @@ exports[`Rendering disabled palette 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item form-control-container input-group-append"
+          class="input-group-item input-group-item-focusable input-group-append"
         >
           <input
             aria-label="Color selection is FFF"
@@ -1204,7 +1204,7 @@ exports[`Rendering disabled state 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item form-control-container input-group-append"
+          class="input-group-item input-group-item-focusable input-group-append"
         >
           <input
             aria-label="Color selection is FFF"
@@ -1582,7 +1582,7 @@ exports[`Rendering renders w/ var() 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item form-control-container input-group-append"
+          class="input-group-item input-group-item-focusable input-group-append"
         >
           <input
             aria-label="Color selection is var(--blue)"
@@ -1968,7 +1968,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item form-control-container input-group-append"
+          class="input-group-item input-group-item-focusable input-group-append"
         >
           <input
             aria-label="Color selection is FFF"
@@ -2346,7 +2346,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item form-control-container input-group-append"
+          class="input-group-item input-group-item-focusable input-group-append"
         >
           <input
             aria-label="Color selection is red"
@@ -2732,7 +2732,7 @@ exports[`Rendering small color-picker 1`] = `
           </div>
         </div>
         <div
-          class="input-group-item form-control-container input-group-append"
+          class="input-group-item input-group-item-focusable input-group-append"
         >
           <input
             aria-label="Color selection is FFF"

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -447,7 +447,10 @@ const ClayColorPicker = ({
 					</ClayDropDown.Menu>
 
 					{showHex && (
-						<ClayInput.GroupItem append>
+						<ClayInput.GroupItem
+							className="form-control-container"
+							append
+						>
 							<ClayInput
 								{...otherProps}
 								aria-label={sub(ariaLabels.selectionIs, [

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -448,8 +448,8 @@ const ClayColorPicker = ({
 
 					{showHex && (
 						<ClayInput.GroupItem
-							className="form-control-container"
 							append
+							className="form-control-container"
 						>
 							<ClayInput
 								{...otherProps}

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -449,7 +449,7 @@ const ClayColorPicker = ({
 					{showHex && (
 						<ClayInput.GroupItem
 							append
-							className="form-control-container"
+							className="input-group-item-focusable"
 						>
 							<ClayInput
 								{...otherProps}

--- a/packages/clay-css/src/scss/cadmin/components/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_custom-forms.scss
@@ -1,6 +1,5 @@
 .form-file {
-	display: flex;
-	position: relative;
+	@include clay-form-control-variant($cadmin-form-file);
 }
 
 .form-file-input {

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -129,6 +129,20 @@ fieldset[disabled] label {
 	}
 }
 
+.form-control-container {
+	@include clay-form-control-variant($cadmin-form-control-container);
+
+	&.input-group-append {
+		border-top-left-radius: 0;
+		border-bottom-left-radius: 0;
+	}
+
+	&.input-group-prepend {
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+}
+
 // This adds disabled styles to div.form-control inside a disabled fielset.
 
 fieldset[disabled] .form-control {

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -129,20 +129,6 @@ fieldset[disabled] label {
 	}
 }
 
-.form-control-container {
-	@include clay-form-control-variant($cadmin-form-control-container);
-
-	&.input-group-append {
-		border-top-left-radius: 0;
-		border-bottom-left-radius: 0;
-	}
-
-	&.input-group-prepend {
-		border-top-right-radius: 0;
-		border-bottom-right-radius: 0;
-	}
-}
-
 // This adds disabled styles to div.form-control inside a disabled fielset.
 
 fieldset[disabled] .form-control {

--- a/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
@@ -82,6 +82,10 @@
 	@include clay-input-group-item-variant($cadmin-input-group-item-shrink);
 }
 
+.input-group-item-focusable {
+	@include clay-input-group-item-variant($cadmin-input-group-item-focusable);
+}
+
 // Input Group Text
 
 .input-group-text {

--- a/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
@@ -1,6 +1,25 @@
 $cadmin-custom-forms-transition: background-color 0.15s ease-in-out,
 	border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out !default;
 
+// Form File
+
+$cadmin-form-file: () !default;
+$cadmin-form-file: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($cadmin-input-border-radius),
+		display: flex,
+		position: relative,
+		transition: clay-enable-transitions($cadmin-input-transition),
+		focus-within: (
+			background-color: $cadmin-input-focus-bg,
+			box-shadow: $cadmin-input-focus-box-shadow,
+			outline: 0,
+			z-index: 1,
+		),
+	),
+	$cadmin-form-file
+);
+
 // Custom Control Indicator
 
 $cadmin-custom-control-indicator-size: 16px !default;

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -99,6 +99,12 @@ $cadmin-input: map-deep-merge(
 				color: $cadmin-input-placeholder-focus-color,
 			),
 		),
+		focus-within: (
+			background-color: $cadmin-input-focus-bg,
+			border-color: $cadmin-input-focus-border-color,
+			box-shadow: $cadmin-input-focus-box-shadow,
+			color: $cadmin-input-focus-color,
+		),
 		disabled: (
 			background-color: $cadmin-input-disabled-bg,
 			border-color: $cadmin-input-disabled-border-color,
@@ -111,6 +117,23 @@ $cadmin-input: map-deep-merge(
 		),
 	),
 	$cadmin-input
+);
+
+// .form-control-focus-within
+
+$cadmin-form-control-container: () !default;
+$cadmin-form-control-container: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($cadmin-input-border-radius),
+		transition: clay-enable-transitions($cadmin-input-transition),
+		focus-within: (
+			background-color: $cadmin-input-focus-bg,
+			box-shadow: $cadmin-input-focus-box-shadow,
+			outline: 0,
+			z-index: 1,
+		),
+	),
+	$cadmin-form-control-container
 );
 
 // Form Control Variants

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -119,23 +119,6 @@ $cadmin-input: map-deep-merge(
 	$cadmin-input
 );
 
-// .form-control-focus-within
-
-$cadmin-form-control-container: () !default;
-$cadmin-form-control-container: map-deep-merge(
-	(
-		border-radius: clay-enable-rounded($cadmin-input-border-radius),
-		transition: clay-enable-transitions($cadmin-input-transition),
-		focus-within: (
-			background-color: $cadmin-input-focus-bg,
-			box-shadow: $cadmin-input-focus-box-shadow,
-			outline: 0,
-			z-index: 1,
-		),
-	),
-	$cadmin-form-control-container
-);
-
 // Form Control Variants
 
 $cadmin-input-palette: () !default;
@@ -1545,6 +1528,23 @@ $cadmin-input-group-item-shrink: map-deep-merge(
 		width: auto,
 	),
 	$cadmin-input-group-item-shrink
+);
+
+// .input-group-item-focusable
+
+$cadmin-input-group-item-focusable: () !default;
+$cadmin-input-group-item-focusable: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($cadmin-input-border-radius),
+		transition: clay-enable-transitions($cadmin-input-transition),
+		focus-within: (
+			background-color: $cadmin-input-focus-bg,
+			box-shadow: $cadmin-input-focus-box-shadow,
+			outline: 0,
+			z-index: 1,
+		),
+	),
+	$cadmin-input-group-item-focusable
 );
 
 // Input Group Inset

--- a/packages/clay-css/src/scss/components/_custom-forms.scss
+++ b/packages/clay-css/src/scss/components/_custom-forms.scss
@@ -1,6 +1,5 @@
 .form-file {
-	display: flex;
-	position: relative;
+	@include clay-form-control-variant($form-file);
 }
 
 .form-file-input {

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -108,20 +108,6 @@ fieldset[disabled] label {
 	}
 }
 
-.form-control-container {
-	@include clay-form-control-variant($form-control-container);
-
-	&.input-group-append {
-		border-top-left-radius: 0;
-		border-bottom-left-radius: 0;
-	}
-
-	&.input-group-prepend {
-		border-top-right-radius: 0;
-		border-bottom-right-radius: 0;
-	}
-}
-
 // This adds disabled styles to div.form-control inside a disabled fielset.
 
 fieldset[disabled] .form-control {

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -108,6 +108,20 @@ fieldset[disabled] label {
 	}
 }
 
+.form-control-container {
+	@include clay-form-control-variant($form-control-container);
+
+	&.input-group-append {
+		border-top-left-radius: 0;
+		border-bottom-left-radius: 0;
+	}
+
+	&.input-group-prepend {
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+}
+
 // This adds disabled styles to div.form-control inside a disabled fielset.
 
 fieldset[disabled] .form-control {

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -134,6 +134,10 @@
 	@include clay-input-group-item-variant($input-group-item-shrink);
 }
 
+.input-group-item-focusable {
+	@include clay-input-group-item-variant($input-group-item-focusable);
+}
+
 // Input Group Text
 
 .input-group-text {

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -601,6 +601,10 @@
 				}
 			}
 
+			&:focus-within:has(input:focus) {
+				@include clay-form-control-variant(map-get($map, focus-within));
+			}
+
 			&:active {
 				@include clay-css(map-get($map, active));
 			}

--- a/packages/clay-css/src/scss/mixins/_input-groups.scss
+++ b/packages/clay-css/src/scss/mixins/_input-groups.scss
@@ -299,8 +299,12 @@
 			}
 
 			&.focus {
+				@include clay-input-group-item-variant(map-get($map, focus));
+			}
+
+			&:focus-within:has(input:focus) {
 				@include clay-input-group-item-variant(
-					map-deep-get($map, focus)
+					map-get($map, focus-within)
 				);
 			}
 

--- a/packages/clay-css/src/scss/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/variables/_custom-forms.scss
@@ -5,6 +5,25 @@
 $custom-forms-transition: background-color 0.15s ease-in-out,
 	border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out !default;
 
+// Form File
+
+$form-file: () !default;
+$form-file: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($input-border-radius),
+		display: flex,
+		position: relative,
+		transition: clay-enable-transitions($input-transition),
+		focus-within: (
+			background-color: $input-focus-bg,
+			box-shadow: $input-focus-box-shadow,
+			outline: 0,
+			z-index: 1,
+		),
+	),
+	$form-file
+);
+
 // Custom Control Indicator
 
 $custom-control-indicator-size: 1rem !default;

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -117,23 +117,6 @@ $input: map-deep-merge(
 	$input
 );
 
-// .form-control-focus-within
-
-$form-control-container: () !default;
-$form-control-container: map-deep-merge(
-	(
-		border-radius: clay-enable-rounded($input-border-radius),
-		transition: clay-enable-transitions($input-transition),
-		focus-within: (
-			background-color: $input-focus-bg,
-			box-shadow: $input-focus-box-shadow,
-			outline: 0,
-			z-index: 1,
-		),
-	),
-	$form-control-container
-);
-
 // Form Control Variants
 
 $input-palette: () !default;
@@ -1547,6 +1530,31 @@ $input-group-item-shrink: map-deep-merge(
 		width: auto,
 	),
 	$input-group-item-shrink
+);
+
+// .input-group-item-focusable
+
+$input-group-item-focusable: () !default;
+$input-group-item-focusable: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($input-border-radius),
+		transition: clay-enable-transitions($input-transition),
+		focus-within: (
+			background-color: $input-focus-bg,
+			box-shadow: $input-focus-box-shadow,
+			outline: 0,
+			z-index: 1,
+			input-group-append: (
+				border-top-left-radius: 0,
+				border-bottom-left-radius: 0,
+			),
+			input-group-prepend: (
+				border-top-right-radius: 0,
+				border-bottom-right-radius: 0,
+			),
+		),
+	),
+	$input-group-item-focusable
 );
 
 // Input Group Inset

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -97,6 +97,12 @@ $input: map-deep-merge(
 				color: $input-placeholder-focus-color,
 			),
 		),
+		focus-within: (
+			background-color: $input-focus-bg,
+			border-color: $input-focus-border-color,
+			box-shadow: $input-focus-box-shadow,
+			color: $input-focus-color,
+		),
 		disabled: (
 			background-color: $input-disabled-bg,
 			border-color: $input-disabled-border-color,
@@ -109,6 +115,23 @@ $input: map-deep-merge(
 		),
 	),
 	$input
+);
+
+// .form-control-focus-within
+
+$form-control-container: () !default;
+$form-control-container: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($input-border-radius),
+		transition: clay-enable-transitions($input-transition),
+		focus-within: (
+			background-color: $input-focus-bg,
+			box-shadow: $input-focus-box-shadow,
+			outline: 0,
+			z-index: 1,
+		),
+	),
+	$form-control-container
 );
 
 // Form Control Variants

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -10,7 +10,7 @@ exports[`BasicRendering renders by default 1`] = `
         class="input-group"
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -845,7 +845,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -1678,7 +1678,7 @@ exports[`BasicRendering renders date picker with native picker 1`] = `
         class="input-group"
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -1712,7 +1712,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -2691,7 +2691,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -10,7 +10,7 @@ exports[`BasicRendering renders by default 1`] = `
         class="input-group"
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -845,7 +845,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -1678,7 +1678,7 @@ exports[`BasicRendering renders date picker with native picker 1`] = `
         class="input-group"
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -1712,7 +1712,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -2691,7 +2691,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -14,7 +14,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -847,7 +847,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -1683,7 +1683,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -2521,7 +2521,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -3369,7 +3369,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -4210,7 +4210,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -14,7 +14,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -847,7 +847,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -1683,7 +1683,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -2521,7 +2521,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -3369,7 +3369,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -4210,7 +4210,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -14,7 +14,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -851,7 +851,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -1688,7 +1688,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -2525,7 +2525,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -3362,7 +3362,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -4199,7 +4199,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -5140,7 +5140,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"
@@ -5977,7 +5977,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
         style=""
       >
         <div
-          class="input-group-item form-control-container"
+          class="input-group-item input-group-item-focusable"
         >
           <input
             name="datePicker"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -14,7 +14,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -851,7 +851,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -1688,7 +1688,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -2525,7 +2525,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -3362,7 +3362,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -4199,7 +4199,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -5140,7 +5140,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"
@@ -5977,7 +5977,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
         style=""
       >
         <div
-          class="input-group-item"
+          class="input-group-item form-control-container"
         >
           <input
             name="datePicker"

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -637,7 +637,7 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			<FocusScope arrowKeysUpDown={false}>
 				<div className="date-picker">
 					<ClayInput.Group ref={triggerElementRef}>
-						<ClayInput.GroupItem>
+						<ClayInput.GroupItem className="form-control-container">
 							<InputDate
 								{...otherProps}
 								ariaLabel={ariaLabels.input}

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -637,7 +637,7 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			<FocusScope arrowKeysUpDown={false}>
 				<div className="date-picker">
 					<ClayInput.Group ref={triggerElementRef}>
-						<ClayInput.GroupItem className="form-control-container">
+						<ClayInput.GroupItem className="input-group-item-focusable">
 							<InputDate
 								{...otherProps}
 								ariaLabel={ariaLabels.input}

--- a/packages/clay-drop-down/src/Search.tsx
+++ b/packages/clay-drop-down/src/Search.tsx
@@ -89,7 +89,7 @@ const ClayDropDownSearch = ({
 		>
 			<div className="dropdown-section">
 				<ClayInput.Group small>
-					<ClayInput.GroupItem>
+					<ClayInput.GroupItem className="form-control-container">
 						<ClayInput
 							{...otherProps}
 							insetAfter

--- a/packages/clay-drop-down/src/Search.tsx
+++ b/packages/clay-drop-down/src/Search.tsx
@@ -89,7 +89,7 @@ const ClayDropDownSearch = ({
 		>
 			<div className="dropdown-section">
 				<ClayInput.Group small>
-					<ClayInput.GroupItem className="form-control-container">
+					<ClayInput.GroupItem className="input-group-item-focusable">
 						<ClayInput
 							{...otherProps}
 							insetAfter

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -380,7 +380,7 @@ exports[`ClayDropDown renders with search input 1`] = `
               class="input-group input-group-sm"
             >
               <div
-                class="input-group-item form-control-container"
+                class="input-group-item input-group-item-focusable"
               >
                 <input
                   class="form-control input-group-inset input-group-inset-after"

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -380,7 +380,7 @@ exports[`ClayDropDown renders with search input 1`] = `
               class="input-group input-group-sm"
             >
               <div
-                class="input-group-item"
+                class="input-group-item form-control-container"
               >
                 <input
                   class="form-control input-group-inset input-group-inset-after"

--- a/packages/clay-management-toolbar/stories/ManagementToolbar.stories.tsx
+++ b/packages/clay-management-toolbar/stories/ManagementToolbar.stories.tsx
@@ -101,7 +101,7 @@ export const Default = () => {
 
 				<ClayManagementToolbar.Search showMobile={searchMobile}>
 					<ClayInput.Group>
-						<ClayInput.GroupItem className="form-control-container">
+						<ClayInput.GroupItem className="input-group-item-focusable">
 							<ClayInput
 								aria-label="Search"
 								className="form-control input-group-inset input-group-inset-after"

--- a/packages/clay-management-toolbar/stories/ManagementToolbar.stories.tsx
+++ b/packages/clay-management-toolbar/stories/ManagementToolbar.stories.tsx
@@ -101,7 +101,7 @@ export const Default = () => {
 
 				<ClayManagementToolbar.Search showMobile={searchMobile}>
 					<ClayInput.Group>
-						<ClayInput.GroupItem>
+						<ClayInput.GroupItem className="form-control-container">
 							<ClayInput
 								aria-label="Search"
 								className="form-control input-group-inset input-group-inset-after"

--- a/packages/clay-time-picker/src/__tests__/index.tsx
+++ b/packages/clay-time-picker/src/__tests__/index.tsx
@@ -93,54 +93,6 @@ describe('IncrementalInteractions', () => {
 		expect(document.activeElement).toBe(hoursEl);
 	});
 
-	it('clicking on the hour input of the time picker should add the focus', () => {
-		const {getByTestId} = render(<TimePickerWithState />);
-
-		const hoursEl = getByTestId('hours');
-		const formControlEl = getByTestId('formControl');
-
-		fireEvent.focus(hoursEl, {});
-
-		expect(formControlEl.classList).toContain('focus');
-	});
-
-	it('clicking on the minutes input of the time picker should add the focus', () => {
-		const {getByTestId} = render(<TimePickerWithState />);
-
-		const minutesEl = getByTestId('minutes');
-		const formControlEl = getByTestId('formControl');
-
-		fireEvent.focus(minutesEl, {});
-
-		expect(formControlEl.classList).toContain('focus');
-	});
-
-	it('clicking on the amp/pm input of the time picker should add the focus', () => {
-		const {getByTestId} = render(<TimePickerWithState use12Hours />);
-
-		const ampmEl = getByTestId('ampm');
-		const formControlEl = getByTestId('formControl');
-
-		fireEvent.focus(ampmEl, {});
-
-		expect(formControlEl.classList).toContain('focus');
-	});
-
-	it('clicking outside the inputs of the time picker should remove the focus', () => {
-		const {getByTestId} = render(<TimePickerWithState />);
-
-		const hoursEl = getByTestId('hours');
-		const formControlEl = getByTestId('formControl');
-
-		fireEvent.focus(hoursEl, {});
-
-		expect(formControlEl.classList).toContain('focus');
-
-		fireEvent.click(document.body, {});
-
-		expect(formControlEl.classList).not.toContain('focus');
-	});
-
 	describe('with actions', () => {
 		it('shows the spin action when the mouse is inside the form', () => {
 			const {getByTestId} = render(<TimePickerWithState />);

--- a/packages/clay-time-picker/src/index.tsx
+++ b/packages/clay-time-picker/src/index.tsx
@@ -399,7 +399,6 @@ const ClayTimePicker = ({
 						<div
 							className={classNames('form-control', {
 								disabled,
-								focus: isFocused,
 							})}
 							data-testid="formControl"
 							onMouseEnter={() => {

--- a/packages/clay-time-picker/src/index.tsx
+++ b/packages/clay-time-picker/src/index.tsx
@@ -202,7 +202,6 @@ const ClayTimePicker = ({
 	const useConfig: Config = config[use12Hours ? 'use12Hours' : 'use24Hours'];
 
 	const [actionVisible, setActionVisible] = useState(false);
-	const [isFocused, setIsFocused] = useState(false);
 	const elementRef = useRef<null | HTMLDivElement>(null);
 
 	const defaultFocused = {
@@ -357,7 +356,6 @@ const ClayTimePicker = ({
 		) {
 			setActionVisible(false);
 			setCurrentInputFocused(defaultFocused);
-			setIsFocused(false);
 		}
 	};
 
@@ -367,7 +365,6 @@ const ClayTimePicker = ({
 			configName,
 			focused: true,
 		});
-		setIsFocused(true);
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195104

This adds `:focus-within` to our `form-control` elements. This offloads focus interactions to the browser on more complex elements like `input-group`s (e.g., search bar, time picker, rgb inputs in color picker).  We weren't managing the focus class on a lot of input groups and now we no longer need to.

~One thing I don't like is the name of the `form-control-container` class. I was hoping for something better, but can't think of anything. @matuzalemsteles @ethib137 do you think we should add an attribute to the `ClayInput.GroupItem` component to output this? I'm currently adding it via `className="form-control-container"`.~

Edit: Went with `input-group-item-focusable`. Thanks @ethib137 !