### PR TITLE
fix(@clayui/autocomplete): fix error when navigating via keyboard with the mouse over the item

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-autocomplete/src/': {
-			branches: 68,
+			branches: 67,
 			functions: 82,
 			lines: 85,
 			statements: 85,

--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -63,12 +63,15 @@ const NewItem = React.forwardRef<HTMLLIElement, IProps>(function NewItem(
 	const {activeDescendant, onActiveDescendant} = useAutocompleteState();
 	const {isFocusVisible} = useInteractionFocus();
 
+	const isFocus = isFocusVisible();
+
 	const hoverProps = useHover({
 		disabled,
-		onHover: useCallback(() => onActiveDescendant(keyValue!), [keyValue]),
+		onHover: useCallback(
+			() => !isFocus && onActiveDescendant(keyValue!),
+			[keyValue, isFocus]
+		),
 	});
-
-	const isFocus = isFocusVisible();
 
 	const currentValue = textValue ?? value ?? String(children);
 	const fuzzyMatch = fuzzy.match(match, currentValue, optionsFuzzy);


### PR DESCRIPTION
Fixes [LPS-194107](https://liferay.atlassian.net/browse/LPS-194107)

Well, I thought fixing this would be more complex but I ended up using some resources we have to prevent hovering over the item from updating the virtual focus when the scroll moves when navigating via keyboard. The strategy here was simpler than I thought at the beginning, so we just avoided updating the `activeDescendant` on hover over the item when the current interaction is being via keyboard, we got this information with the `isFocusVisible` hook that we have to identify this behavior.