### PR TITLE
feat(@clayui/css): Tables adds table-nested-rows

### DIFF
--- a/clayui.com/static/js/docs-site.js
+++ b/clayui.com/static/js/docs-site.js
@@ -25,6 +25,7 @@ if (!Element.prototype.closest) {
 		var t = event.target;
 
 		var a = t.tagName === 'a' || t.tagName === 'button' ? t : t.closest('a') || t.closest('button');
+		var column = t.closest('.autofit-col-toggle') || false;
 
 		if (a) {
 			if (a.getAttribute('href') === '#1') {
@@ -36,6 +37,14 @@ if (!Element.prototype.closest) {
 			if (dataToggle && dataToggle.startsWith('c-prefers')) {
 				document.querySelector('body').classList.toggle(a.getAttribute('data-toggle'));
 			}
+		}
+
+		if (column) {
+			var button = column.querySelector('.component-action');
+
+			button.classList.toggle('show');
+
+			document.querySelector(button.dataset.target).classList.toggle('show');
 		}
 	});
 })();

--- a/packages/clay-css/src/scss/cadmin/components/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_tables.scss
@@ -418,6 +418,20 @@ caption {
 	}
 }
 
+// .table-nested-rows
+
+.table-nested-rows {
+	@include clay-table-variant($cadmin-c-table-nested-rows);
+
+	.component-action.show .collapse-icon-closed {
+		display: none;
+	}
+
+	.component-action:not(.show) .collapse-icon-open {
+		display: none;
+	}
+}
+
 // Show Quick Action
 
 .show-quick-actions-on-hover {

--- a/packages/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -403,6 +403,14 @@ $cadmin-c-table: map-deep-merge(
 				padding-right: 0,
 			),
 		),
+		component-drag: (
+			font-size: 14px,
+			height: 16px,
+			width: 16px,
+			focus: (
+				box-shadow: $cadmin-component-focus-inset-box-shadow,
+			),
+		),
 		custom-control: (
 			margin-bottom: 0,
 		),
@@ -466,6 +474,43 @@ $cadmin-c-table-sm: map-deep-merge(
 		),
 	),
 	$cadmin-c-table-sm
+);
+
+// .table-nested-rows
+
+$cadmin-c-table-nested-rows: () !default;
+$cadmin-c-table-nested-rows: map-deep-merge(
+	(
+		table-column-start: (
+			padding-left: 20px,
+		),
+		table-column-end: (
+			padding-right: 20px,
+		),
+		autofit-col: (
+			padding-left: 2px,
+			padding-right: 2px,
+			min-width: 28px,
+		),
+		autofit-col-checkbox: (
+			padding-right: 10px,
+		),
+		autofit-col-icon: (
+			padding-right: 10px,
+		),
+		component-drag: (
+			left: 2px,
+			position: absolute,
+			top: 50%,
+			transform: translateY(-50%),
+		),
+		component-toggle: (
+			font-size: 14px,
+			height: 24px,
+			width: 24px,
+		),
+	),
+	$cadmin-c-table-nested-rows
 );
 
 // Table Dark Variant

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -454,6 +454,20 @@ caption {
 	}
 }
 
+// .table-nested-rows
+
+.table-nested-rows {
+	@include clay-table-variant($c-table-nested-rows);
+
+	.component-action.show .collapse-icon-closed {
+		display: none;
+	}
+
+	.component-action:not(.show) .collapse-icon-open {
+		display: none;
+	}
+}
+
 // Show Quick Action
 
 .show-quick-actions-on-hover {

--- a/packages/clay-css/src/scss/mixins/_tables.scss
+++ b/packages/clay-css/src/scss/mixins/_tables.scss
@@ -366,6 +366,30 @@
 				}
 			}
 
+			.autofit-col-checkbox {
+				@include clay-css(map-get($map, autofit-col-checkbox));
+			}
+
+			.autofit-col-icon {
+				@include clay-css(map-get($map, autofit-col-icon));
+			}
+
+			.autofit-col-toggle {
+				@include clay-css(map-get($map, autofit-col-toggle));
+			}
+
+			.component-action {
+				@include clay-link(map-get($map, component-action));
+			}
+
+			.component-drag {
+				@include clay-link(map-get($map, component-drag));
+			}
+
+			.component-toggle {
+				@include clay-link(map-get($map, component-toggle));
+			}
+
 			.custom-control,
 			.form-check {
 				@include clay-custom-control-variant(

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -358,6 +358,14 @@ $c-table: map-deep-merge(
 				padding-right: 0,
 			),
 		),
+		component-drag: (
+			font-size: 0.875rem,
+			height: 1rem,
+			width: 1rem,
+			focus: (
+				box-shadow: $component-focus-inset-box-shadow,
+			),
+		),
 		custom-control: (
 			margin-bottom: 0,
 		),
@@ -440,6 +448,43 @@ $c-table-sm: map-deep-merge(
 		),
 	),
 	$c-table-sm
+);
+
+// .table-nested-rows
+
+$c-table-nested-rows: () !default;
+$c-table-nested-rows: map-deep-merge(
+	(
+		table-column-start: (
+			padding-left: 1.25rem,
+		),
+		table-column-end: (
+			padding-right: 1.25rem,
+		),
+		autofit-col: (
+			padding-left: 0.125rem,
+			padding-right: 0.125rem,
+			min-width: 1.75rem,
+		),
+		autofit-col-checkbox: (
+			padding-right: 0.625rem,
+		),
+		autofit-col-icon: (
+			padding-right: 0.625rem,
+		),
+		component-drag: (
+			left: 2px,
+			position: absolute,
+			top: 50%,
+			transform: translateY(-50%),
+		),
+		component-toggle: (
+			font-size: 0.875rem,
+			height: 1.5rem,
+			width: 1.5rem,
+		),
+	),
+	$c-table-nested-rows
 );
 
 // Table Dark Variant

--- a/packages/clay-table/docs/markup-table.md
+++ b/packages/clay-table/docs/markup-table.md
@@ -13,6 +13,7 @@ mainTabURL: 'docs/components/table.html'
     -   [Bordered](#css-bordered)
     -   [Hoverable](#css-hoverable)
     -   [Small](#css-small)
+    -   [Nested Rows](#css-table-nested-rows)
 -   [Responsiveness](#css-responsiveness)
     -   [Always Responsive](#css-always-responsive)
     -   [Breakpoints](#css-breakpoints)
@@ -796,6 +797,255 @@ Add `.table-sm` to make tables more compact by cutting cell padding in half.
 	</tbody>
 </table>
 ```
+
+### Nested Rows(#css-table-nested-rows)
+
+Example markup for Nested Rows in Frontend Dataset.
+
+<div class="sheet-example">
+    <div class="table-responsive">
+        <table class="show-quick-actions-on-hover table table-list table-nested-rows table-striped" role="treegrid">
+            <caption>Caption: Table List with filler content</caption>
+            <thead>
+                <tr>
+                    <th scope="col">
+                        Label
+                    </th>
+                    <th scope="col">
+                        Scope
+                    </th>
+                    <th scope="col">
+                        System
+                    </th>
+                    <th scope="col">Modified Date</th>
+                    <th scope="col">
+                        Status
+                    </th>
+                    <th scope="col">
+                        <svg class="lexicon-icon lexicon-icon-caret-down" focusable="false" role="presentation">
+                            <use xlink:href="/images/icons/icons.svg#caret-down" />
+                        </svg>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr class="table-divider">
+                    <td colspan="6">Group 1</td>
+                </tr>
+                <tr aria-level="1" role="row">
+                    <td role="gridcell">
+                        <button class="component-action component-drag">
+                            <svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
+                                <use xlink:href="/images/icons/icons.svg#drag" />
+                            </svg>
+                        </button>
+                        <div class="autofit-row">
+                            <div class="autofit-col autofit-col-toggle"></div>
+                            <div class="autofit-col autofit-col-checkbox">
+                                <div class="custom-control custom-checkbox">
+                                    <label>
+                                        <input class="custom-control-input" type="checkbox">
+                                        <span class="custom-control-label"></span>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="autofit-col autofit-col-icon">
+                                <svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+                                    <use xlink:href="/images/icons/icons.svg#folder" />
+                                </svg>
+                            </div>
+                            <div class="autofit-col autofit-col-expand">
+                                <span class="table-title">Root Object</span>
+                            </div>
+                        </div>
+                    </td>
+                    <td role="gridcell">Company</td>
+                    <td role="gridcell">No</td>
+                    <td role="gridcell">June 12, 2023, 6:07:25PM</td>
+                    <td role="gridcell">
+                        <span class="label label-sm">Draft</span>
+                    </td>
+                    <td role="gridcell">
+                        <div class="quick-action-menu">
+                            <a class="component-action quick-action-item" href="#1" role="button">
+                                <svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+                                    <use xlink:href="/images/icons/icons.svg#trash" />
+                                </svg>
+                            </a>
+                            <a class="component-action quick-action-item" href="#1" role="button">
+                                <svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+                                    <use xlink:href="/images/icons/icons.svg#download" />
+                                </svg>
+                            </a>
+                            <a class="component-action quick-action-item" href="#1" role="button">
+                                <svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+                                    <use xlink:href="/images/icons/icons.svg#expand" />
+                                </svg>
+                            </a>
+                        </div>
+                        <div class="dropdown dropdown-action">
+                            <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                                <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+                                    <use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+                                </svg>
+                            </a>
+                            <ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+                                <li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
+                                <li><a class="dropdown-item" href="#1" role="button">Download</a></li>
+                                <li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
+                            </ul>
+                        </div>
+                    </td>
+                </tr>
+                <tr aria-level="1" class="table-active" role="row">
+                    <td role="gridcell">
+                        <button class="component-action component-drag">
+                            <svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
+                                <use xlink:href="/images/icons/icons.svg#drag" />
+                            </svg>
+                        </button>
+                        <div class="autofit-row">
+                            <div class="autofit-col autofit-col-toggle">
+                                <button class="component-action" data-target="#tableCollapse01" type="button">
+                                    <span class="collapse-icon-closed">
+                                        <svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+                                            <use xlink:href="/images/icons/icons.svg#angle-right" />
+                                        </svg>
+                                    </span>
+                                    <span class="collapse-icon-open">
+                                        <svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+                                            <use xlink:href="/images/icons/icons.svg#angle-down" />
+                                        </svg>
+                                    </span>
+                                </button>
+                            </div>
+                            <div class="autofit-col autofit-col-checkbox">
+                                <div class="custom-control custom-checkbox">
+                                    <label>
+                                        <input class="custom-control-input" type="checkbox">
+                                        <span class="custom-control-label"></span>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="autofit-col autofit-col-expand">
+                                <span class="table-title">Root Object - First Level</span>
+                            </div>
+                        </div>
+                    </td>
+                    <td role="gridcell">Company</td>
+                    <td role="gridcell">No</td>
+                    <td role="gridcell">June 12, 2023, 6:07:25PM</td>
+                    <td role="gridcell">
+                        <span class="label label-sm">Draft</span>
+                    </td>
+                    <td role="gridcell">
+                        <div class="quick-action-menu">
+                            <a class="component-action quick-action-item" href="#1" role="button">
+                                <svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+                                    <use xlink:href="/images/icons/icons.svg#trash" />
+                                </svg>
+                            </a>
+                            <a class="component-action quick-action-item" href="#1" role="button">
+                                <svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+                                    <use xlink:href="/images/icons/icons.svg#download" />
+                                </svg>
+                            </a>
+                            <a class="component-action quick-action-item" href="#1" role="button">
+                                <svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+                                    <use xlink:href="/images/icons/icons.svg#expand" />
+                                </svg>
+                            </a>
+                        </div>
+                        <div class="dropdown dropdown-action">
+                            <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                                <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+                                    <use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+                                </svg>
+                            </a>
+                            <ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+                                <li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
+                                <li><a class="dropdown-item" href="#1" role="button">Download</a></li>
+                                <li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
+                            </ul>
+                        </div>
+                    </td>
+                </tr>
+                <tr aria-level="2" class="collapse" id="tableCollapse01" role="row">
+                    <td role="gridcell">
+                        <button class="component-action component-drag">
+                            <svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
+                                <use xlink:href="/images/icons/icons.svg#drag" />
+                            </svg>
+                        </button>
+                        <div class="autofit-row">
+                            <div class="autofit-col autofit-col-toggle"></div>
+                            <div class="autofit-col autofit-col-toggle">
+                                <button class="component-action" data-target="#tableCollapse02" type="button">
+                                    <span class="collapse-icon-closed">
+                                        <svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+                                            <use xlink:href="/images/icons/icons.svg#angle-right" />
+                                        </svg>
+                                    </span>
+                                    <span class="collapse-icon-open">
+                                        <svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+                                            <use xlink:href="/images/icons/icons.svg#angle-down" />
+                                        </svg>
+                                    </span>
+                                </button>
+                            </div>
+                            <div class="autofit-col autofit-col-checkbox">
+                                <div class="custom-control custom-checkbox">
+                                    <label>
+                                        <input class="custom-control-input" type="checkbox">
+                                        <span class="custom-control-label"></span>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="autofit-col autofit-col-expand">
+                                <span class="table-title">Second Level Object</span>
+                            </div>
+                        </div>
+                    </td>
+                    <td role="gridcell">Company</td>
+                    <td role="gridcell">No</td>
+                    <td role="gridcell">June 13, 2023, 12:00PM</td>
+                    <td role="gridcell">--</td>
+                    <td role="gridcell">--</td>
+                </tr>
+                <tr aria-level="3" class="collapse" id="tableCollapse02" role="row">
+                    <td role="gridcell">
+                        <button class="component-action component-drag">
+                            <svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
+                                <use xlink:href="/images/icons/icons.svg#drag" />
+                            </svg>
+                        </button>
+                        <div class="autofit-row">
+                            <div class="autofit-col autofit-col-toggle"></div>
+                            <div class="autofit-col autofit-col-toggle"></div>
+                            <div class="autofit-col autofit-col-toggle"></div>
+                            <div class="autofit-col autofit-col-checkbox">
+                                <div class="custom-control custom-checkbox">
+                                    <label>
+                                        <input class="custom-control-input" type="checkbox">
+                                        <span class="custom-control-label"></span>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="autofit-col autofit-col-expand">
+                                <span class="table-title">Third Level Object</span>
+                            </div>
+                        </div>
+                    </td>
+                    <td role="gridcell">Company</td>
+                    <td role="gridcell">No</td>
+                    <td role="gridcell">June 13, 2023, 12:00PM</td>
+                    <td role="gridcell">--</td>
+                    <td role="gridcell">--</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
 
 ## Inline Edit Table(#css-inline-edit-table)
 


### PR DESCRIPTION
https://liferay.atlassian.net/wiki/spaces/PEDS/pages/2432237790/Nested+Rows+-+Front-end+DataSet

I'm sending this as draft so we can discuss this implementation. 

![table-nested](https://github.com/liferay/clay/assets/788266/c5c5dda1-9f3f-44b5-b47f-972def6c6fca)

I had to use nested tables because we need a container element to animate the collapse if needed. The example in https://www.w3.org/WAI/ARIA/apg/patterns/treegrid/examples/treegrid-1/#ex_label is clean and concise, but we can't collapse the rows like we do panels. The code for the nested table looks like:

```html
<tr role="presentation">
  <td colspan="6" role="presentation">
    <div class="collapse" id="tableCollapse01">
      <table role="presentation">
        <tbody role="presentation">
          <tr aria-level="2" role="row"></tr>
        </tbody>
      </table>
    </div>
  </td>
</tr>
```

Voice Over announces this like it's the next table row. The `role="presentation"` makes the screen reader ignore them. 

To create the proper spacing, I used an extra element as a spacer. The [indentation levels](https://liferay.atlassian.net/wiki/spaces/PEDS/pages/2432237790/Nested+Rows+-+Front-end+DataSet#Nesting-Indentation) seem quite complicated since it's based on elements contained inside the title column. We also can't foresee the combination of items that will be put in it. I included a code snippet below.

```html
<tr aria-level="2" role="row">
    <td role="gridcell" style="width: 324.38px">
        <button class="component-action component-drag"></button>
        <div class="autofit-row">
            <div class="autofit-col autofit-col-toggle"></div>
            <div class="autofit-col autofit-col-toggle">
                <button class="component-action" data-target="#tableCollapse02" type="button"></button>
            </div>
            <div class="autofit-col autofit-col-checkbox">
                <div class="custom-control custom-checkbox"></div>
            </div>
            <div class="autofit-col autofit-col-expand">
                <span class="table-title">Second Level Object</span>
            </div>
        </div>
    </td>
    <td role="gridcell" style="width: 119.74px">2</td>
    <td role="gridcell" style="width: 104.48px">3</td>
    <td role="gridcell" style="width: 233.09px">4</td>
    <td role="gridcell" style="width: 101.58px">5</td>
    <td role="gridcell" style="width: 78.73px">6</td>
</tr>
```

This is for "Second Level Object" in the screenshot. We need to output an extra `<div class="autofit-col autofit-col-toggle"></div>` to space it correctly. In "Third Level Object", we need to output:

```html
<div class="autofit-col autofit-col-toggle"></div>
<div class="autofit-col autofit-col-toggle"></div>
<div class="autofit-col autofit-col-checkbox"></div>
```
to account for the two toggles and the checkbox in each parent item. I really don't like outputting empty elements, but this seemed easier and more future proof than managing specific padding for every situation. I guess the other option might be to calculate it with JS and inline it. Let me know your opinions, Thanks!

/cc @ethib137 @matuzalemsteles @ilzamcmed 