### PR TITLE
feat(@clayui/core): adds the implementation of the new data-oriented composition for Table

### DIFF
--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -33,6 +33,7 @@
 		"@clayui/loading-indicator": "^3.60.0",
 		"@clayui/modal": "^3.104.0",
 		"@clayui/provider": "^3.93.0",
+		"@clayui/table": "^3.56.0",
 		"@clayui/shared": "^3.104.0",
 		"@tanstack/react-virtual": "3.0.0-beta.54",
 		"aria-hidden": "^1.2.2",

--- a/packages/clay-core/src/table/Body.tsx
+++ b/packages/clay-core/src/table/Body.tsx
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+import {ChildrenFunction, Collection} from '../collection';
+import {Scope, ScopeContext} from './ScopeContext';
+
+type Props<T> = {
+	/**
+	 * Children content to render a dynamic or static content.
+	 */
+	children: React.ReactNode | ChildrenFunction<T, unknown>;
+
+	/**
+	 * Property to render content with dynamic data.
+	 */
+	items?: Array<T>;
+} & React.TableHTMLAttributes<HTMLTableSectionElement>;
+
+function BodyInner<T extends Record<string, any>>(
+	{children, items, ...otherProps}: Props<T>,
+	ref: React.Ref<HTMLTableSectionElement>
+) {
+	return (
+		<tbody {...otherProps} ref={ref}>
+			<ScopeContext.Provider value={Scope.Body}>
+				<Collection items={items} passthroughKey={false}>
+					{children}
+				</Collection>
+			</ScopeContext.Provider>
+		</tbody>
+	);
+}
+
+type ForwardRef = {
+	displayName: string;
+	<T>(
+		props: Props<T> & {ref?: React.Ref<HTMLTableSectionElement>}
+	): JSX.Element;
+};
+
+export const Body = React.forwardRef(BodyInner) as ForwardRef;
+
+Body.displayName = 'TableBody';

--- a/packages/clay-core/src/table/Column.tsx
+++ b/packages/clay-core/src/table/Column.tsx
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+import {Scope, useScope} from './ScopeContext';
+
+type Props = {
+	/**
+	 * Aligns the text inside the Cell.
+	 */
+	align?: 'center' | 'left' | 'right';
+
+	/**
+	 * Children content to render content.
+	 */
+	children: React.ReactNode;
+
+	/**
+	 * Sometimes we are unable to remove specific table columns from the DOM
+	 * and need to hide it using CSS. This property can be added to the "new"
+	 * first or last cell to maintain table styles on the left and right side.
+	 */
+	delimiter?: 'start' | 'end';
+
+	/**
+	 * Fills out the remaining space inside a Cell.
+	 */
+	expanded?: boolean;
+
+	/**
+	 * Aligns horizontally contents inside the Cell.
+	 */
+	textAlign?: 'center' | 'end' | 'start';
+
+	/**
+	 * Truncates the text inside a Cell.
+	 */
+	truncate?: boolean;
+
+	/*
+	 * Break the text into lines when necessary.
+	 */
+	wrap?: boolean;
+} & React.ThHTMLAttributes<HTMLTableCellElement> &
+	React.TdHTMLAttributes<HTMLTableCellElement>;
+
+export const Column = React.forwardRef<HTMLTableCellElement, Props>(
+	function ColumnInner(
+		{
+			align,
+			children,
+			className,
+			delimiter,
+			expanded,
+			textAlign,
+			truncate,
+			wrap = true,
+			...otherProps
+		},
+		ref
+	) {
+		const scope = useScope();
+		const As = scope === Scope.Head ? 'th' : 'td';
+
+		return (
+			<As
+				{...otherProps}
+				className={classNames(className, {
+					'table-cell-expand': truncate || expanded,
+					[`table-cell-${delimiter}`]: delimiter,
+					[`table-column-text-${textAlign}`]: textAlign,
+					[`text-${align}`]: align,
+					'table-cell-ws-nowrap': !wrap,
+				})}
+				ref={ref}
+			>
+				{truncate ? (
+					<span className="text-truncate-inline">
+						<span className="text-truncate">{children}</span>
+					</span>
+				) : (
+					children
+				)}
+			</As>
+		);
+	}
+);
+
+Column.displayName = 'Item';

--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+import {ChildrenFunction, Collection} from '../collection';
+import {Scope, ScopeContext} from './ScopeContext';
+
+type Props<T> = {
+	/**
+	 * Children content to render a dynamic or static content.
+	 */
+	children: React.ReactNode | ChildrenFunction<T, unknown>;
+
+	/**
+	 * Property to render content with dynamic data.
+	 */
+	items?: Array<T>;
+} & React.TableHTMLAttributes<HTMLTableSectionElement>;
+
+function HeadInner<T extends Record<string, any>>(
+	{children, items, ...otherProps}: Props<T>,
+	ref: React.Ref<HTMLTableSectionElement>
+) {
+	return (
+		<thead {...otherProps} ref={ref}>
+			<ScopeContext.Provider value={Scope.Head}>
+				<tr>
+					<Collection items={items} passthroughKey={false}>
+						{children}
+					</Collection>
+				</tr>
+			</ScopeContext.Provider>
+		</thead>
+	);
+}
+
+type ForwardRef = {
+	displayName: string;
+	<T>(
+		props: Props<T> & {ref?: React.Ref<HTMLTableSectionElement>}
+	): JSX.Element;
+};
+
+export const Head = React.forwardRef(HeadInner) as ForwardRef;
+
+Head.displayName = 'TableHead';

--- a/packages/clay-core/src/table/Row.tsx
+++ b/packages/clay-core/src/table/Row.tsx
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+import {ChildrenFunction, Collection} from '../collection';
+
+type Props<T> = {
+	/**
+	 * Children content to render a dynamic or static content.
+	 */
+	children: React.ReactNode | ChildrenFunction<T, unknown>;
+
+	/**
+	 * This property can be added to the "new" first
+	 * or last ClayTable.Row to maintain table styles on the top and bottom sides.
+	 */
+	delimiter?: 'start' | 'end';
+
+	/**
+	 * Applies a divider style inside the row.
+	 */
+	divider?: boolean;
+
+	/**
+	 * Property to render content with dynamic data.
+	 */
+	items?: Array<T>;
+} & React.HTMLAttributes<HTMLTableRowElement>;
+
+function RowInner<T extends Record<string, any>>(
+	{children, className, delimiter, divider, items, ...otherProps}: Props<T>,
+	ref: React.Ref<HTMLTableRowElement>
+) {
+	return (
+		<tr
+			{...otherProps}
+			className={classNames(className, {
+				'table-divider': divider,
+				[`table-row-${delimiter}`]: delimiter,
+			})}
+			ref={ref}
+		>
+			<Collection items={items} passthroughKey={false}>
+				{children}
+			</Collection>
+		</tr>
+	);
+}
+
+type ForwardRef = {
+	displayName: string;
+	<T>(props: Props<T> & {ref?: React.Ref<HTMLTableRowElement>}): JSX.Element;
+};
+
+export const Row = React.forwardRef(RowInner) as ForwardRef;
+
+Row.displayName = 'TableRow';

--- a/packages/clay-core/src/table/ScopeContext.ts
+++ b/packages/clay-core/src/table/ScopeContext.ts
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React, {useContext} from 'react';
+
+export enum Scope {
+	Head = 'head',
+	Body = 'body',
+}
+
+export const ScopeContext = React.createContext<Scope>(Scope.Head);
+
+export function useScope() {
+	return useContext(ScopeContext);
+}

--- a/packages/clay-core/src/table/Table.tsx
+++ b/packages/clay-core/src/table/Table.tsx
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import RootTable from '@clayui/table';
+
+export const Table = RootTable;

--- a/packages/clay-core/src/table/index.ts
+++ b/packages/clay-core/src/table/index.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export * from './Body';
+export * from './Column';
+export * from './Head';
+export * from './Row';
+export * from './Table';

--- a/packages/clay-core/stories/Table.stories.tsx
+++ b/packages/clay-core/stories/Table.stories.tsx
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+import {Body, Column, Head, Row, Table} from '../src/table';
+
+export default {
+	title: 'Design System/Components/Table',
+};
+
+const columns = [
+	{
+		id: '1',
+		name: 'Name',
+	},
+	{
+		id: '2',
+		name: 'Type',
+	},
+];
+
+const rows = [
+	{id: 1, name: 'Games', type: 'File folder'},
+	{id: 2, name: 'Program Files', type: 'File folder'},
+];
+
+export const Dynamic = () => {
+	return (
+		<Table>
+			<Head items={columns}>
+				{(column) => <Column key={column.id}>{column.name}</Column>}
+			</Head>
+
+			<Body items={rows}>
+				{(row) => (
+					<Row>
+						<Column>{row.name}</Column>
+						<Column>{row.type}</Column>
+					</Row>
+				)}
+			</Body>
+		</Table>
+	);
+};
+
+const columns2 = [
+	{
+		id: 'name',
+		name: 'Name',
+	},
+	{
+		id: 'type',
+		name: 'Type',
+	},
+];
+
+const rows2 = [
+	{id: 1, name: 'Games', type: 'File folder'},
+	{id: 2, name: 'Program Files', type: 'File folder'},
+];
+
+export const DynamicCells = () => {
+	return (
+		<Table>
+			<Head items={columns2}>
+				{(column) => <Column key={column.id}>{column.name}</Column>}
+			</Head>
+
+			<Body items={rows2}>
+				{(row) => (
+					<Row items={columns2}>
+						{(column) => <Column>{row[column.id]}</Column>}
+					</Row>
+				)}
+			</Body>
+		</Table>
+	);
+};


### PR DESCRIPTION
Closes [LPS-192998](https://liferay.atlassian.net/browse/LPS-192998)

This PR implements new components for Table to make room for new OOTB features for developers, so we can continue improving the UX and making the component more useful and prevent developers from having to implement more features on top of that.

The idea here is to bring a data-oriented composition using the Collection pattern that we already use in other Clay components, this already brings the UX benefits that we have in other components and we can also implement the features such as list virtualization that we need to implement the [treegrid](https://liferay.atlassian.net/browse/LPS-193002) pattern and the [column resizer](https://liferay.atlassian.net/browse/LPS-193001).

Instead of implementing this on top of the Table currently, we are recreating the component parts in a new composition to avoid backward compatibility or mechanisms that have to identify when using the old or new composition to use the right component. So to use the new composition use the Table from `@clayui/core` and we leave the component in `@clayui/table` in deprecation mode.

This is the new UX and composition of the component, it is not yet public. I will make it public only after we implement all the new features, such as treegrid support and column resizer with OOTB accessibility.

```jsx
<Table>
  <Head items={columns}>
    {(column) => <Column key={column.id}>{column.name}</Column>}
  </Head>

  <Body items={rows}>
    {(row) => (
      <Row items={columns}>
        {(column) => <Column>{row[column.id]}</Column>}
      </Row>
    )}
  </Body>
</Table>
```

Just like in other components that use collection, the list can be static or dynamic, for example `<Row />` can be a static list when the column is not dynamic.

```jsx
<Table>
  <Head items={columns}>
    <Column key="name">Name</Column>
    <Column key="type">Type</Column>
  </Head>

  <Body items={rows}>
    {(row) => (
      <Row>
        <Column>{row.name}</Column>
        <Column>{row.type}</Column>
      </Row>
    )}
  </Body>
</Table>
```