### PR TITLE
feat(@clayui/core): adds new API to handle column sorting with accessibility support

### DIFF
--- a/packages/clay-core/src/collection/Collection.tsx
+++ b/packages/clay-core/src/collection/Collection.tsx
@@ -116,6 +116,7 @@ function DynamicCollection<
 	parentKey,
 	passthroughKey,
 	publicApi,
+	suppressTextValueWarning,
 }: ICollectionProps<T, P> & Props<P, K>) {
 	const state = useCollection({
 		children,
@@ -127,6 +128,7 @@ function DynamicCollection<
 		parentKey,
 		passthroughKey,
 		publicApi,
+		suppressTextValueWarning,
 	});
 
 	return <>{state.collection}</>;
@@ -152,6 +154,7 @@ export function Collection<
 	parentRef,
 	passthroughKey = true,
 	publicApi,
+	suppressTextValueWarning,
 	virtualize = false,
 	...otherProps
 }: Partial<ICollectionProps<T, P>> & Props<P, K> & Partial<IProps>) {
@@ -206,6 +209,7 @@ export function Collection<
 				parentRef={parentRef}
 				passthroughKey={passthroughKey}
 				publicApi={publicApi}
+				suppressTextValueWarning={suppressTextValueWarning}
 			>
 				{children}
 			</VirtualDynamicCollection>
@@ -221,6 +225,7 @@ export function Collection<
 				parentKey={parentKey}
 				passthroughKey={passthroughKey}
 				publicApi={publicApi}
+				suppressTextValueWarning={suppressTextValueWarning}
 			>
 				{children}
 			</DynamicCollection>

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -131,7 +131,22 @@ export function useCollection<
 			return React.cloneElement(child as React.ReactElement<any>, {
 				key,
 				...(passthroughKey || hasChildNeedPassthroughKey
-					? {index, keyValue: key}
+					? {
+							index,
+							keyValue: key,
+
+							// We only pass the textValue to the component when the collection
+							// indicates that it will be used for accessibility issues.
+							...(!suppressTextValueWarning
+								? {
+										textValue: getTextValue(
+											key,
+											child,
+											true
+										),
+								  }
+								: {}),
+					  }
 					: {}),
 				...(props ? props : {}),
 			});

--- a/packages/clay-core/src/table/Column.tsx
+++ b/packages/clay-core/src/table/Column.tsx
@@ -40,9 +40,9 @@ type Props = {
 	keyValue?: React.Key;
 
 	/**
-	 * Whether the column allows sorting. Only available in the header column.
+	 * Whether the column allows sortable. Only available in the header column.
 	 */
-	sorting?: boolean;
+	sortable?: boolean;
 
 	/**
 	 * Aligns horizontally contents inside the Cell.
@@ -75,7 +75,7 @@ export const Column = React.forwardRef<HTMLTableCellElement, Props>(
 			delimiter,
 			expanded,
 			keyValue,
-			sorting,
+			sortable,
 			textAlign,
 			textValue,
 			truncate,
@@ -86,18 +86,17 @@ export const Column = React.forwardRef<HTMLTableCellElement, Props>(
 	) {
 		const {onSortChange, sort, sortDescriptionId} = useTable();
 		const scope = useScope();
-		const As = scope === Scope.Head ? 'th' : 'td';
+		const isHead = scope === Scope.Head;
+		const As = isHead ? 'th' : 'td';
 
 		return (
 			<As
 				{...otherProps}
 				aria-describedby={
-					scope === Scope.Head && sorting
-						? sortDescriptionId
-						: undefined
+					isHead && sortable ? sortDescriptionId : undefined
 				}
 				aria-sort={
-					scope === Scope.Head && sorting
+					isHead && sortable
 						? sort && keyValue === sort.column
 							? sort.direction
 							: 'none'
@@ -109,16 +108,14 @@ export const Column = React.forwardRef<HTMLTableCellElement, Props>(
 					[`table-column-text-${textAlign}`]: textAlign,
 					[`text-${align}`]: align,
 					'table-cell-ws-nowrap': !wrap,
-					'table-head-title': scope === Scope.Head,
+					'table-head-title': isHead,
 				})}
 				ref={ref}
 			>
-				{scope === Scope.Head && sorting ? (
+				{isHead && sortable ? (
 					<a
 						aria-describedby={
-							scope === Scope.Head && sorting
-								? sortDescriptionId
-								: undefined
+							isHead && sortable ? sortDescriptionId : undefined
 						}
 						className="inline-item text-truncate-inline"
 						href="#"

--- a/packages/clay-core/src/table/Column.tsx
+++ b/packages/clay-core/src/table/Column.tsx
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import Icon from '@clayui/icon';
 import classNames from 'classnames';
 import React from 'react';
 
 import {Scope, useScope} from './ScopeContext';
+import {useTable} from './context';
 
 type Props = {
 	/**
@@ -32,6 +34,17 @@ type Props = {
 	expanded?: boolean;
 
 	/**
+	 * Internal property.
+	 * @ignore
+	 */
+	keyValue?: React.Key;
+
+	/**
+	 * Whether the column allows sorting. Only available in the header column.
+	 */
+	sorting?: boolean;
+
+	/**
 	 * Aligns horizontally contents inside the Cell.
 	 */
 	textAlign?: 'center' | 'end' | 'start';
@@ -45,6 +58,11 @@ type Props = {
 	 * Break the text into lines when necessary.
 	 */
 	wrap?: boolean;
+
+	/**
+	 * Sets a text value if the component's content is not plain text.
+	 */
+	textValue?: string;
 } & React.ThHTMLAttributes<HTMLTableCellElement> &
 	React.TdHTMLAttributes<HTMLTableCellElement>;
 
@@ -56,29 +74,86 @@ export const Column = React.forwardRef<HTMLTableCellElement, Props>(
 			className,
 			delimiter,
 			expanded,
+			keyValue,
+			sorting,
 			textAlign,
+			textValue,
 			truncate,
 			wrap = true,
 			...otherProps
 		},
 		ref
 	) {
+		const {onSortChange, sort, sortDescriptionId} = useTable();
 		const scope = useScope();
 		const As = scope === Scope.Head ? 'th' : 'td';
 
 		return (
 			<As
 				{...otherProps}
+				aria-describedby={
+					scope === Scope.Head && sorting
+						? sortDescriptionId
+						: undefined
+				}
+				aria-sort={
+					scope === Scope.Head && sorting
+						? sort && keyValue === sort.column
+							? sort.direction
+							: 'none'
+						: undefined
+				}
 				className={classNames(className, {
 					'table-cell-expand': truncate || expanded,
 					[`table-cell-${delimiter}`]: delimiter,
 					[`table-column-text-${textAlign}`]: textAlign,
 					[`text-${align}`]: align,
 					'table-cell-ws-nowrap': !wrap,
+					'table-head-title': scope === Scope.Head,
 				})}
 				ref={ref}
 			>
-				{truncate ? (
+				{scope === Scope.Head && sorting ? (
+					<a
+						aria-describedby={
+							scope === Scope.Head && sorting
+								? sortDescriptionId
+								: undefined
+						}
+						className="inline-item text-truncate-inline"
+						href="#"
+						onClick={(event) => {
+							event.preventDefault();
+							onSortChange(
+								{
+									column: keyValue!,
+									direction:
+										sort && keyValue === sort.column
+											? sort.direction === 'ascending'
+												? 'descending'
+												: 'ascending'
+											: 'ascending',
+								},
+								textValue!
+							);
+						}}
+						role="button"
+					>
+						<span className="text-truncate">{children}</span>
+
+						{sort && keyValue === sort.column && (
+							<span className="inline-item inline-item-after">
+								<Icon
+									symbol={
+										sort.direction === 'ascending'
+											? 'order-arrow-up'
+											: 'order-arrow-down'
+									}
+								/>
+							</span>
+						)}
+					</a>
+				) : truncate ? (
 					<span className="text-truncate-inline">
 						<span className="text-truncate">{children}</span>
 					</span>

--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -28,7 +28,7 @@ function HeadInner<T extends Record<string, any>>(
 		<thead {...otherProps} ref={ref}>
 			<ScopeContext.Provider value={Scope.Head}>
 				<tr>
-					<Collection items={items} passthroughKey={false}>
+					<Collection items={items} suppressTextValueWarning={false}>
 						{children}
 					</Collection>
 				</tr>

--- a/packages/clay-core/src/table/Table.tsx
+++ b/packages/clay-core/src/table/Table.tsx
@@ -3,6 +3,105 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {sub, useControlledState, useId} from '@clayui/shared';
 import RootTable from '@clayui/table';
+import React, {useCallback, useRef} from 'react';
+import {createPortal} from 'react-dom';
 
-export const Table = RootTable;
+import {LiveAnnouncer} from '../live-announcer';
+import {Sorting, TableContext} from './context';
+
+import type {AnnouncerAPI} from '../live-announcer';
+
+type Props = {
+	/**
+	 * Default state of sort (uncontrolled).
+	 */
+	defaultSort?: Sorting | null;
+
+	/**
+	 * Texts used for assertive messages to SRs.
+	 */
+	messages?: {
+		sortDescription: string;
+		sorting: string;
+	};
+
+	/**
+	 * Callback for when the sorting change (controlled).
+	 */
+	onSortChange?: (sorting: Sorting | null) => void;
+
+	/**
+	 * Current state of sort (controlled).
+	 */
+	sort?: Sorting | null;
+} & React.ComponentProps<typeof RootTable>;
+
+export const Table = React.forwardRef<HTMLDivElement, Props>(
+	function TableInner(
+		{
+			children,
+			defaultSort,
+			messages = {
+				sortDescription: 'sortable column',
+				sorting: 'sorted by column {0} in {1} order',
+			},
+			onSortChange,
+			sort: externalSort,
+			...otherProps
+		}: Props,
+		ref
+	) {
+		const [sort, setSorting] = useControlledState({
+			defaultName: 'defaultSort',
+			defaultValue: defaultSort,
+			handleName: 'onSortChange',
+			name: 'sort',
+			onChange: onSortChange,
+			value: externalSort,
+		});
+
+		const announcerAPI = useRef<AnnouncerAPI>(null);
+
+		const sortDescriptionId = useId();
+
+		return (
+			<RootTable {...otherProps} ref={ref}>
+				<LiveAnnouncer ref={announcerAPI} />
+
+				<TableContext.Provider
+					value={{
+						onSortChange: useCallback(
+							(sort, textValue) => {
+								announcerAPI.current!.announce(
+									sub(messages!.sorting, [
+										textValue,
+										sort!.direction,
+									])
+								);
+								setSorting(sort);
+							},
+							[setSorting]
+						),
+						sort,
+						sortDescriptionId,
+					}}
+				>
+					{children}
+				</TableContext.Provider>
+
+				{createPortal(
+					<div
+						aria-hidden="true"
+						id={sortDescriptionId}
+						style={{display: 'none'}}
+					>
+						{messages!.sortDescription}
+					</div>,
+					document.body
+				)}
+			</RootTable>
+		);
+	}
+);

--- a/packages/clay-core/src/table/context.tsx
+++ b/packages/clay-core/src/table/context.tsx
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: © 2023 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React, {useContext} from 'react';
+
+export type Sorting = {
+	column: React.Key;
+	direction: 'ascending' | 'descending';
+};
+
+type Context = {
+	onSortChange: (sorting: Sorting | null, textValue: string) => void;
+	sort: Sorting | null;
+	sortDescriptionId: string;
+};
+
+export const TableContext = React.createContext<Context>({} as Context);
+
+export function useTable() {
+	return useContext(TableContext);
+}

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -45,6 +45,12 @@ interface IProps<T> extends React.HTMLAttributes<HTMLLIElement> {
 	 * Internal property.
 	 * @ignore
 	 */
+	textValue?: string;
+
+	/**
+	 * Internal property.
+	 * @ignore
+	 */
 	index?: number;
 
 	/**
@@ -84,6 +90,7 @@ export function Item<T extends object>({
 	items,
 	keyValue,
 	onClick,
+	textValue: _textValue,
 	...otherProps
 }: IProps<T>) {
 	const {

--- a/packages/clay-core/stories/Table.stories.tsx
+++ b/packages/clay-core/stories/Table.stories.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React from 'react';
+import React, {useCallback, useState} from 'react';
 
 import {Body, Column, Head, Row, Table} from '../src/table';
 
@@ -73,6 +73,66 @@ export const DynamicCells = () => {
 				{(row) => (
 					<Row items={columns2}>
 						{(column) => <Column>{row[column.id]}</Column>}
+					</Row>
+				)}
+			</Body>
+		</Table>
+	);
+};
+
+type Sorting = {
+	column: React.Key;
+	direction: 'ascending' | 'descending';
+};
+
+export const Sorting = () => {
+	const [sort, setSort] = useState<Sorting | null>(null);
+	const [items, setItems] = useState([
+		{files: 22, id: 1, name: 'Games', type: 'File folder'},
+		{files: 7, id: 2, name: 'Program Files', type: 'File folder'},
+	]);
+
+	const onSortChange = useCallback((sort: Sorting | null) => {
+		if (sort) {
+			setItems((items) =>
+				items.sort((a, b) => {
+					let cmp = new Intl.Collator('en', {numeric: true}).compare(
+						a[sort.column],
+						b[sort.column]
+					);
+
+					if (sort.direction === 'descending') {
+						cmp *= -1;
+					}
+
+					return cmp;
+				})
+			);
+		}
+
+		setSort(sort);
+	}, []);
+
+	return (
+		<Table onSortChange={onSortChange} sort={sort}>
+			<Head>
+				<Column key="name" sorting>
+					Name
+				</Column>
+				<Column key="files" sorting>
+					Files
+				</Column>
+				<Column key="type" sorting>
+					Type
+				</Column>
+			</Head>
+
+			<Body items={items}>
+				{(row) => (
+					<Row>
+						<Column>{row['name']}</Column>
+						<Column>{row['files']}</Column>
+						<Column>{row['type']}</Column>
 					</Row>
 				)}
 			</Body>

--- a/packages/clay-core/stories/Table.stories.tsx
+++ b/packages/clay-core/stories/Table.stories.tsx
@@ -116,13 +116,13 @@ export const Sorting = () => {
 	return (
 		<Table onSortChange={onSortChange} sort={sort}>
 			<Head>
-				<Column key="name" sorting>
+				<Column key="name" sortable>
 					Name
 				</Column>
-				<Column key="files" sorting>
+				<Column key="files" sortable>
 					Files
 				</Column>
-				<Column key="type" sorting>
+				<Column key="type" sortable>
 					Type
 				</Column>
 			</Head>

--- a/packages/clay-data-provider/docs/data-provider.mdx
+++ b/packages/clay-data-provider/docs/data-provider.mdx
@@ -30,6 +30,7 @@ import {
     -   [Suspense and ErrorBoundary](#suspense-and-errorboundary)
     -   [Data Fetching](#data-fetching)
         -   [Fetch](#fetch)
+    -   [Sortable](#sortable)
 -   [Advanced](#advanced)
     -   [Avoiding thundering herd problem](#avoiding-thundering-herd-problem)
     -   [Caching data at root level](#caching-data-at-root-level)
@@ -204,6 +205,24 @@ const App = () => {
 	const {resource} = useResource({fetch, link: 'https://clay.dev'});
 	// ...
 };
+```
+
+### Sortable
+
+```javascript
+const {resource, sort, sortChange} = useResource({
+	fetch: (link, init, sort) => {
+		const url = new URL(link);
+
+		if (sort) {
+			url.searchParams.append('column', sort.column);
+			url.searchParams.append('direction', sort.direction);
+		}
+
+		return fetch(url, init);
+	},
+	link: 'https://clay.dev',
+});
 ```
 
 ## Advanced

--- a/packages/clay-data-provider/src/__tests__/index.tsx
+++ b/packages/clay-data-provider/src/__tests__/index.tsx
@@ -102,7 +102,8 @@ describe('ClayDataProvider', () => {
 
 		expect(fetch).toHaveBeenCalledWith(
 			'https://clay.data/',
-			expect.any(Object)
+			expect.any(Object),
+			undefined
 		);
 	});
 

--- a/packages/clay-data-provider/src/index.tsx
+++ b/packages/clay-data-provider/src/index.tsx
@@ -5,9 +5,7 @@
 
 import React from 'react';
 
-import {useResource} from './useResource';
-
-import type {NetworkStatus} from './useResource';
+import {FetchPolicy, NetworkStatus, Sorting, useResource} from './useResource';
 
 type ChildrenProps = {
 	data: any;
@@ -91,5 +89,5 @@ const ClayDataProvider = ({
 	);
 };
 
-export {useResource};
+export {useResource, FetchPolicy, NetworkStatus, Sorting};
 export default ClayDataProvider;


### PR DESCRIPTION
Closes [LPS-192999](https://liferay.atlassian.net/browse/LPS-192999) and [LPS-193000](https://liferay.atlassian.net/browse/LPS-193000)

This PR implements column sorting support for an OOTB table with accessibility support, this also adds the controlled and uncontrolled state pattern to the sort API. There are still some details to be done, such as adding sort support to the Data Provider for asynchronous sorting. DX also makes this very simple, see my example of sorting in the storybook.

```jsx
<Table onSortChange={onSortChange} sort={sort}>
  <Head>
    <Column key="name" sorting>Name</Column>
    <Column key="files" sorting>Files</Column>
    <Column key="type">Type</Column>
  </Head>

  <Body items={items}>
    {(row) => (
      <Row>
        <Column>{row.name}</Column>
        <Column>{row.files}</Column>
        <Column>{row.type}</Column>
      </Row>
    )}
  </Body>
</Table>
```
By default the component does not handle the sorting of table items, this has to be done by the developer, I'm thinking if we can add this OOTB when the `sort` state is uncontrolled so this could be useful for demo cases or for all data when live on the client side.

The component also deals with accessibility, in the header column we add the ARIA attributes of `aria-sort` and `aria-describedby` to inform that the column can be sorted and current state. We also announce the sort action to the SR, with the column name and direction. One detail is that I want to remove the link action and move it to th so that the focus is on the column instead of the header but for that we would have to deal with managing the focus of the columns which we will do this in the treegrid implementation, so in this At the moment I am making the link assertive for the SR with the description, `aria-sort` is only used in th in the column header so it would have no effect on the link.

An initial idea to add sorting support to the DataProvider, it is very difficult to make some OOTB resource for this when we are dealing with data because there is no standard for this, so it will still be necessary for the developer to describe his rules for fetch the data in the server.

```jsx
const {resource, sort, sortChange} = useResource({
  fetchPolicy: FetchPolicy.CacheFirst,
  link: 'https://example.com/api/',

  // sort.column = column key
  // sort.direction = 'ascending' | 'descending'
  async sort(items, sort) {
    // impl here
  }
});

<Table onSortChange={sortChange} sort={sort}>
  {...}
</Table>
```
