### PR TITLE
fix(@clayui/css): Checkbox and Radio text should be vertically aligned at the start when breaking to new line

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -221,7 +221,7 @@ $dropdown-section-active-custom-control-label: map-deep-merge(
 $dropdown-section-custom-control-label-text: () !default;
 $dropdown-section-custom-control-label-text: map-deep-merge(
 	(
-		padding-left: 0.75rem,
+		padding-left: 1.75rem,
 	),
 	$dropdown-section-custom-control-label-text
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
@@ -327,7 +327,8 @@ $cadmin-dropdown-section-custom-control-label: map-deep-merge(
 $cadmin-dropdown-section-custom-control-label-text: () !default;
 $cadmin-dropdown-section-custom-control-label-text: map-deep-merge(
 	(
-		padding-left: 16px,
+		display: block,
+		padding-left: 28px,
 	),
 	$cadmin-dropdown-section-custom-control-label-text
 );

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -437,6 +437,13 @@ $dropdown-section-custom-control-label: () !default;
 /// @deprecated as of v3.x use map $dropdown-section instead
 
 $dropdown-section-custom-control-label-text: () !default;
+$dropdown-section-custom-control-label-text: map-deep-merge(
+	(
+		display: block,
+		padding-left: 2rem,
+	),
+	$dropdown-section-custom-control-label-text
+);
 
 /// @deprecated as of v3.x use map $dropdown-section instead
 

--- a/packages/clay-drop-down/docs/index.js
+++ b/packages/clay-drop-down/docs/index.js
@@ -107,9 +107,14 @@ const dropDownWithItemsCode = `const Component = () => {
 					type: 'radio',
 					value: 'two',
 				},
+				{
+					label: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
+					type: 'radio',
+					value: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
+				},
 			],
 			label: 'radio',
-			name: 'radio',
+			name: 'dropdownWithItemsRadio',
 			onChange: (value) => alert('New Radio checked'),
 			type: 'radiogroup',
 		},
@@ -124,6 +129,12 @@ const dropDownWithItemsCode = `const Component = () => {
 				{
 					checked: true,
 					label: 'checkbox 1',
+					onChange: () => alert('checkbox changed'),
+					type: 'checkbox',
+				},
+				{
+					checked: true,
+					label: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
 					onChange: () => alert('checkbox changed'),
 					type: 'checkbox',
 				},

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -477,7 +477,6 @@ const Radio = ({value = '', ...otherProps}: IItem & IInternalItem) => {
 			<ClayRadio
 				{...otherProps}
 				checked={checked === value}
-				inline
 				name={name}
 				onChange={() => onChange(value as string)}
 				tabIndex={!tabFocus ? -1 : undefined}

--- a/packages/clay-drop-down/stories/DropDown.stories.tsx
+++ b/packages/clay-drop-down/stories/DropDown.stories.tsx
@@ -36,9 +36,14 @@ const ITEMS = [
 				type: 'radio' as const,
 				value: 'two',
 			},
+			{
+				label: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
+				type: 'radio' as const,
+				value: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
+			},
 		],
 		label: 'radio',
-		name: 'radio',
+		name: 'dropdownWithItemsRadio',
 		onChange: (value: string) => alert(`New Radio checked ${value}`),
 		type: 'radiogroup' as const,
 	},
@@ -53,6 +58,12 @@ const ITEMS = [
 			{
 				checked: true,
 				label: 'checkbox 1',
+				onChange: () => alert('checkbox changed'),
+				type: 'checkbox' as const,
+			},
+			{
+				checked: true,
+				label: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
 				onChange: () => alert('checkbox changed'),
 				type: 'checkbox' as const,
 			},
@@ -244,6 +255,14 @@ export const Checkbox = () => (
 				/>
 			</ClayDropDown.Section>
 		</ClayDropDown.ItemList>
+		<ClayDropDown.ItemList>
+			<ClayDropDown.Section>
+				<ClayCheckbox
+					label="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
+					onChange={() => {}}
+				/>
+			</ClayDropDown.Section>
+		</ClayDropDown.ItemList>
 	</ClayDropDown>
 );
 
@@ -286,10 +305,26 @@ export const Radio = () => (
 		<ClayDropDown.ItemList>
 			<ClayDropDown.Group header="Order">
 				<ClayDropDown.Section>
-					<ClayRadio checked label="Ascending" value="asc" />
+					<ClayRadio
+						checked
+						label="Ascending"
+						name="dropdownRadio01"
+						value="asc"
+					/>
 				</ClayDropDown.Section>
 				<ClayDropDown.Section>
-					<ClayRadio label="Descending" value="desc" />
+					<ClayRadio
+						label="Descending"
+						name="dropdownRadio01"
+						value="desc"
+					/>
+				</ClayDropDown.Section>
+				<ClayDropDown.Section>
+					<ClayRadio
+						label="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
+						name="dropdownRadio01"
+						value="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
+					/>
 				</ClayDropDown.Section>
 			</ClayDropDown.Group>
 		</ClayDropDown.ItemList>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195376

![dropdown-checkbox](https://github.com/liferay/clay/assets/788266/8dd8a701-92e6-46d3-a7e7-3111008e4298)
![dropdown-radio](https://github.com/liferay/clay/assets/788266/fde75f56-e3f3-4894-b12b-7031e41419b7)
