### PR TITLE
fix(@clayui/css): Checkbox and radio text should be vertically aligne…

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
@@ -26,7 +26,7 @@ $cadmin-custom-control-indicator-size: 16px !default;
 
 $cadmin-custom-control-indicator-bg: $cadmin-white !default;
 $cadmin-custom-control-indicator-bg-size: 50% 50% !default;
-$cadmin-custom-control-indicator-border-color: $cadmin-gray-400 !default;
+$cadmin-custom-control-indicator-border-color: $cadmin-gray-600 !default;
 $cadmin-custom-control-indicator-border-style: solid !default;
 $cadmin-custom-control-indicator-border-width: 1px !default; // 1px
 $cadmin-custom-control-indicator-box-shadow: none !default;
@@ -201,7 +201,11 @@ $cadmin-label-custom-control-label: map-deep-merge(
 $cadmin-custom-control-label-text: () !default;
 $cadmin-custom-control-label-text: map-deep-merge(
 	(
-		padding-left: $cadmin-custom-control-description-padding-left,
+		display: block,
+		padding-left:
+			calc(
+				#{$cadmin-custom-control-indicator-size} + #{$cadmin-custom-control-description-padding-left}
+			),
 	),
 	$cadmin-custom-control-label-text
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
@@ -327,7 +327,6 @@ $cadmin-dropdown-section-custom-control-label: map-deep-merge(
 $cadmin-dropdown-section-custom-control-label-text: () !default;
 $cadmin-dropdown-section-custom-control-label-text: map-deep-merge(
 	(
-		display: block,
 		padding-left: 28px,
 	),
 	$cadmin-dropdown-section-custom-control-label-text

--- a/packages/clay-css/src/scss/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/variables/_custom-forms.scss
@@ -227,7 +227,11 @@ $label-custom-control-label: map-deep-merge(
 $custom-control-label-text: () !default;
 $custom-control-label-text: map-deep-merge(
 	(
-		padding-left: $custom-control-description-padding-left,
+		display: block,
+		padding-left:
+			calc(
+				#{$custom-control-indicator-size} + #{$custom-control-description-padding-left}
+			),
 	),
 	$custom-control-label-text
 );

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -439,7 +439,6 @@ $dropdown-section-custom-control-label: () !default;
 $dropdown-section-custom-control-label-text: () !default;
 $dropdown-section-custom-control-label-text: map-deep-merge(
 	(
-		display: block,
 		padding-left: 2rem,
 	),
 	$dropdown-section-custom-control-label-text


### PR DESCRIPTION
…d when breaking to a new line

https://liferay.atlassian.net/browse/LPS-195376

These are regular checkbox and radio not in a dropdown-menu

![normal-checkbox](https://github.com/liferay/clay/assets/788266/dd69aed2-8ce7-43fe-b962-53f0ffb99a19)
