### PR TITLE
fix: remove 'src' dir from being packaged with npm

### DIFF
--- a/packages/clay-alert/package.json
+++ b/packages/clay-alert/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-alert/tsconfig.declarations.json
+++ b/packages/clay-alert/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-autocomplete/tsconfig.declarations.json
+++ b/packages/clay-autocomplete/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-badge/package.json
+++ b/packages/clay-badge/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-badge/tsconfig.declarations.json
+++ b/packages/clay-badge/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-breadcrumb/package.json
+++ b/packages/clay-breadcrumb/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-breadcrumb/tsconfig.declarations.json
+++ b/packages/clay-breadcrumb/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-button/package.json
+++ b/packages/clay-button/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-button/tsconfig.declarations.json
+++ b/packages/clay-button/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-card/tsconfig.declarations.json
+++ b/packages/clay-card/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-charts/tsconfig.declarations.json
+++ b/packages/clay-charts/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-color-picker/package.json
+++ b/packages/clay-color-picker/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-color-picker/tsconfig.declarations.json
+++ b/packages/clay-color-picker/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.ts",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-core/tsconfig.declarations.json
+++ b/packages/clay-core/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-data-provider/package.json
+++ b/packages/clay-data-provider/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-data-provider/tsconfig.declarations.json
+++ b/packages/clay-data-provider/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -8,8 +8,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-date-picker/tsconfig.declarations.json
+++ b/packages/clay-date-picker/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-drop-down/package.json
+++ b/packages/clay-drop-down/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-drop-down/tsconfig.declarations.json
+++ b/packages/clay-drop-down/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-empty-state/package.json
+++ b/packages/clay-empty-state/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-empty-state/tsconfig.declarations.json
+++ b/packages/clay-empty-state/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-form/package.json
+++ b/packages/clay-form/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-form/tsconfig.declarations.json
+++ b/packages/clay-form/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-icon/package.json
+++ b/packages/clay-icon/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-icon/tsconfig.declarations.json
+++ b/packages/clay-icon/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-label/package.json
+++ b/packages/clay-label/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-label/tsconfig.declarations.json
+++ b/packages/clay-label/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-layout/package.json
+++ b/packages/clay-layout/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-layout/tsconfig.declarations.json
+++ b/packages/clay-layout/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-link/package.json
+++ b/packages/clay-link/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-link/tsconfig.declarations.json
+++ b/packages/clay-link/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-list/package.json
+++ b/packages/clay-list/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-list/tsconfig.declarations.json
+++ b/packages/clay-list/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-loading-indicator/package.json
+++ b/packages/clay-loading-indicator/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-loading-indicator/tsconfig.declarations.json
+++ b/packages/clay-loading-indicator/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-localized-input/package.json
+++ b/packages/clay-localized-input/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-localized-input/tsconfig.declarations.json
+++ b/packages/clay-localized-input/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-management-toolbar/package.json
+++ b/packages/clay-management-toolbar/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-management-toolbar/tsconfig.declarations.json
+++ b/packages/clay-management-toolbar/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-modal/package.json
+++ b/packages/clay-modal/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-modal/tsconfig.declarations.json
+++ b/packages/clay-modal/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-multi-select/package.json
+++ b/packages/clay-multi-select/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-multi-select/tsconfig.declarations.json
+++ b/packages/clay-multi-select/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-multi-step-nav/package.json
+++ b/packages/clay-multi-step-nav/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-multi-step-nav/tsconfig.declarations.json
+++ b/packages/clay-multi-step-nav/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-nav/package.json
+++ b/packages/clay-nav/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-nav/tsconfig.declarations.json
+++ b/packages/clay-nav/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-navigation-bar/package.json
+++ b/packages/clay-navigation-bar/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-navigation-bar/tsconfig.declarations.json
+++ b/packages/clay-navigation-bar/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-pagination-bar/package.json
+++ b/packages/clay-pagination-bar/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-pagination-bar/tsconfig.declarations.json
+++ b/packages/clay-pagination-bar/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-pagination/package.json
+++ b/packages/clay-pagination/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-pagination/tsconfig.declarations.json
+++ b/packages/clay-pagination/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-panel/package.json
+++ b/packages/clay-panel/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-panel/tsconfig.declarations.json
+++ b/packages/clay-panel/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-popover/package.json
+++ b/packages/clay-popover/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-popover/tsconfig.declarations.json
+++ b/packages/clay-popover/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-progress-bar/package.json
+++ b/packages/clay-progress-bar/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-progress-bar/tsconfig.declarations.json
+++ b/packages/clay-progress-bar/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-provider/package.json
+++ b/packages/clay-provider/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.ts",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-provider/tsconfig.declarations.json
+++ b/packages/clay-provider/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-shared/package.json
+++ b/packages/clay-shared/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-shared/tsconfig.declarations.json
+++ b/packages/clay-shared/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-slider/package.json
+++ b/packages/clay-slider/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-slider/tsconfig.declarations.json
+++ b/packages/clay-slider/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-sticker/package.json
+++ b/packages/clay-sticker/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-sticker/tsconfig.declarations.json
+++ b/packages/clay-sticker/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-table/package.json
+++ b/packages/clay-table/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-table/tsconfig.declarations.json
+++ b/packages/clay-table/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-tabs/package.json
+++ b/packages/clay-tabs/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-tabs/tsconfig.declarations.json
+++ b/packages/clay-tabs/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-time-picker/package.json
+++ b/packages/clay-time-picker/package.json
@@ -8,8 +8,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-time-picker/tsconfig.declarations.json
+++ b/packages/clay-time-picker/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-toolbar/package.json
+++ b/packages/clay-toolbar/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-toolbar/tsconfig.declarations.json
+++ b/packages/clay-toolbar/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-tooltip/package.json
+++ b/packages/clay-tooltip/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-tooltip/tsconfig.declarations.json
+++ b/packages/clay-tooltip/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/clay-upper-toolbar/package.json
+++ b/packages/clay-upper-toolbar/package.json
@@ -12,8 +12,7 @@
 	"types": "lib/index.d.ts",
 	"ts:main": "src/index.tsx",
 	"files": [
-		"lib",
-		"src"
+		"lib"
 	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/packages/clay-upper-toolbar/tsconfig.declarations.json
+++ b/packages/clay-upper-toolbar/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/packages/generator-clay-component/app/templates/_tsconfig.declarations.json
+++ b/packages/generator-clay-component/app/templates/_tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"declarationDir": "./lib"
 	},
 	"extends": "../../tsconfig.declarations.json",

--- a/tsconfig.declarations.json
+++ b/tsconfig.declarations.json
@@ -5,7 +5,8 @@
 		"declaration": true,
 		"emitDeclarationOnly": true,
 		"noEmit": false,
-		"removeComments": false
+		"removeComments": false,
+		"paths": {}
 	},
 	"exclude": [
 		"node_modules",

--- a/tsconfig.global.json
+++ b/tsconfig.global.json
@@ -3,7 +3,10 @@
 	"compilerOptions": {
 		"noEmit": true,
 		"declaration": true,
-		"emitDeclarationOnly": false
+		"emitDeclarationOnly": false,
+		"paths": {
+			"@clayui/*": ["node_modules/@clayui/*/src"]
+		}
 	},
 	"include": ["./packages/clay-*/src/**/*", "*.tsx", "*.ts"]
 }


### PR DESCRIPTION
Right now we bundle all src files with our npm packages when we publish. This isn't necessary and also can cause issues with TS projects that use Clay because TS will resolve to the `src` file before it resolves to the `lib`'s `.js` + `.d.ts` files, which should be the primary entry point into the packages.

This should also help speed up build times in DXP and additionally reduce the amount of files we publish.