### PR TITLE
fix(@clayui/css): Checkbox and Radio with badge breaks to new line

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -196,6 +196,16 @@ $dropdown-divider: map-merge(
 
 // .dropdown-section
 
+/// @deprecated as of v3.x use map $dropdown-section instead
+
+$dropdown-section-custom-control: () !default;
+$dropdown-section-custom-control: map-deep-merge(
+	(
+		padding-left: 1.75rem,
+	),
+	$dropdown-section-custom-control
+);
+
 // @deprecated as of v3.x use map $dropdown-section instead
 
 $dropdown-section-custom-control-label: () !default;
@@ -219,12 +229,6 @@ $dropdown-section-active-custom-control-label: map-deep-merge(
 // @deprecated as of v3.x use map $dropdown-section instead
 
 $dropdown-section-custom-control-label-text: () !default;
-$dropdown-section-custom-control-label-text: map-deep-merge(
-	(
-		padding-left: 1.75rem,
-	),
-	$dropdown-section-custom-control-label-text
-);
 
 $dropdown-section: () !default;
 $dropdown-section: map-deep-merge(

--- a/packages/clay-css/src/scss/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/variables/_custom-forms.scss
@@ -173,11 +173,10 @@ $custom-control-label: map-deep-merge(
 				clay-enable-shadows($custom-control-indicator-box-shadow),
 			content: '',
 			display: block,
-			float: left,
 			font-size: $custom-control-indicator-size,
 			height: $custom-control-indicator-size,
 			left: 0,
-			position: relative,
+			position: absolute,
 			top: $custom-control-indicator-position-top,
 			transition: clay-enable-transitions($custom-forms-transition),
 			width: $custom-control-indicator-size,
@@ -225,16 +224,6 @@ $label-custom-control-label: map-deep-merge(
 // .custom-control-label-text
 
 $custom-control-label-text: () !default;
-$custom-control-label-text: map-deep-merge(
-	(
-		display: block,
-		padding-left:
-			calc(
-				#{$custom-control-indicator-size} + #{$custom-control-description-padding-left}
-			),
-	),
-	$custom-control-label-text
-);
 
 // .custom-control-label-text small, .custom-control-label-text .small
 
@@ -254,6 +243,10 @@ $custom-control: map-deep-merge(
 		margin-bottom: $custom-control-margin-bottom,
 		margin-top: $custom-control-margin-top,
 		min-height: $custom-control-min-height,
+		padding-left:
+			calc(
+				#{$custom-control-indicator-size} + #{$custom-control-description-padding-left}
+			),
 		position: relative,
 		text-align: left,
 		only-child: (

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -426,6 +426,7 @@ $dropdown-section-custom-control: () !default;
 $dropdown-section-custom-control: map-deep-merge(
 	(
 		margin-bottom: 0,
+		padding-left: 2rem,
 	),
 	$dropdown-section-custom-control
 );
@@ -437,12 +438,6 @@ $dropdown-section-custom-control-label: () !default;
 /// @deprecated as of v3.x use map $dropdown-section instead
 
 $dropdown-section-custom-control-label-text: () !default;
-$dropdown-section-custom-control-label-text: map-deep-merge(
-	(
-		padding-left: 2rem,
-	),
-	$dropdown-section-custom-control-label-text
-);
 
 /// @deprecated as of v3.x use map $dropdown-section instead
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195376

This fixes a regression from https://github.com/liferay/clay/pull/5681 where badge breaks to new line. 

![radio-with-badge](https://github.com/liferay/clay/assets/788266/23eacf56-6c8d-4cf4-8c92-c271db228f5c)
