### PR TITLE
feat(@clayui/form): Checkbox and Radio should use modifier class custom-control-outside if a label is present

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -196,16 +196,6 @@ $dropdown-divider: map-merge(
 
 // .dropdown-section
 
-/// @deprecated as of v3.x use map $dropdown-section instead
-
-$dropdown-section-custom-control: () !default;
-$dropdown-section-custom-control: map-deep-merge(
-	(
-		padding-left: 1.75rem,
-	),
-	$dropdown-section-custom-control
-);
-
 // @deprecated as of v3.x use map $dropdown-section instead
 
 $dropdown-section-custom-control-label: () !default;
@@ -229,6 +219,12 @@ $dropdown-section-active-custom-control-label: map-deep-merge(
 // @deprecated as of v3.x use map $dropdown-section instead
 
 $dropdown-section-custom-control-label-text: () !default;
+$dropdown-section-custom-control-label-text: map-deep-merge(
+	(
+		padding-left: 1.75rem,
+	),
+	$dropdown-section-custom-control-label-text
+);
 
 $dropdown-section: () !default;
 $dropdown-section: map-deep-merge(

--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -235,6 +235,11 @@ $dropdown-section: map-deep-merge(
 		active: (
 			custom-control-label: $dropdown-section-active-custom-control-label,
 		),
+		custom-control-outside: (
+			label: (
+				padding-left: 1.75rem,
+			),
+		),
 	),
 	$dropdown-section
 );

--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -221,7 +221,7 @@ $dropdown-section-active-custom-control-label: map-deep-merge(
 $dropdown-section-custom-control-label-text: () !default;
 $dropdown-section-custom-control-label-text: map-deep-merge(
 	(
-		padding-left: 1.75rem,
+		padding-left: 0.75rem,
 	),
 	$dropdown-section-custom-control-label-text
 );

--- a/packages/clay-css/src/scss/cadmin/components/_cards.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_cards.scss
@@ -319,7 +319,6 @@
 	.custom-control {
 		display: inline;
 		margin-right: 0;
-		padding-left: 0;
 		position: static;
 
 		> label {

--- a/packages/clay-css/src/scss/cadmin/components/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_custom-forms.scss
@@ -164,6 +164,10 @@ label.custom-control-label {
 	@include clay-custom-control-variant($cadmin-custom-radio);
 }
 
+.custom-control-outside {
+	@include clay-custom-control-variant($cadmin-custom-control-outside);
+}
+
 // Custom Control Inline
 
 .custom-control-inline {

--- a/packages/clay-css/src/scss/cadmin/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_dropdowns.scss
@@ -89,6 +89,12 @@
 		);
 	}
 
+	.custom-control-outside {
+		@include clay-custom-control-variant(
+			map-get($cadmin-dropdown-section, custom-control-outside)
+		);
+	}
+
 	&.active {
 		@include clay-css(
 			setter(map-get($cadmin-dropdown-section, active), ())

--- a/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
@@ -26,7 +26,7 @@ $cadmin-custom-control-indicator-size: 16px !default;
 
 $cadmin-custom-control-indicator-bg: $cadmin-white !default;
 $cadmin-custom-control-indicator-bg-size: 50% 50% !default;
-$cadmin-custom-control-indicator-border-color: $cadmin-gray-600 !default;
+$cadmin-custom-control-indicator-border-color: $cadmin-gray-400 !default;
 $cadmin-custom-control-indicator-border-style: solid !default;
 $cadmin-custom-control-indicator-border-width: 1px !default; // 1px
 $cadmin-custom-control-indicator-box-shadow: none !default;
@@ -201,11 +201,7 @@ $cadmin-label-custom-control-label: map-deep-merge(
 $cadmin-custom-control-label-text: () !default;
 $cadmin-custom-control-label-text: map-deep-merge(
 	(
-		display: block,
-		padding-left:
-			calc(
-				#{$cadmin-custom-control-indicator-size} + #{$cadmin-custom-control-description-padding-left}
-			),
+		padding-left: $cadmin-custom-control-description-padding-left,
 	),
 	$cadmin-custom-control-label-text
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
@@ -533,3 +533,27 @@ $cadmin-custom-radio: map-deep-merge(
 	),
 	$cadmin-custom-radio
 );
+
+$cadmin-custom-control-outside: () !default;
+$cadmin-custom-control-outside: map-deep-merge(
+	(
+		label: (
+			display: block,
+			padding-left:
+				calc(
+					#{$cadmin-custom-control-indicator-size} + #{$cadmin-custom-control-description-padding-left}
+				),
+		),
+		custom-control-input: (
+			custom-control-label: (
+				before: (
+					position: absolute,
+				),
+			),
+		),
+		custom-control-label-text: (
+			padding-left: 0,
+		),
+	),
+	$cadmin-custom-control-outside
+);

--- a/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
@@ -327,6 +327,7 @@ $cadmin-dropdown-section-custom-control-label: map-deep-merge(
 $cadmin-dropdown-section-custom-control-label-text: () !default;
 $cadmin-dropdown-section-custom-control-label-text: map-deep-merge(
 	(
+		display: block,
 		padding-left: 28px,
 	),
 	$cadmin-dropdown-section-custom-control-label-text

--- a/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
@@ -327,8 +327,7 @@ $cadmin-dropdown-section-custom-control-label: map-deep-merge(
 $cadmin-dropdown-section-custom-control-label-text: () !default;
 $cadmin-dropdown-section-custom-control-label-text: map-deep-merge(
 	(
-		display: block,
-		padding-left: 28px,
+		padding-left: 16px,
 	),
 	$cadmin-dropdown-section-custom-control-label-text
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
@@ -353,6 +353,11 @@ $cadmin-dropdown-section: map-deep-merge(
 		custom-control-label: $cadmin-dropdown-section-custom-control-label,
 		custom-control-label-text:
 			$cadmin-dropdown-section-custom-control-label-text,
+		custom-control-outside: (
+			label: (
+				padding-left: 28px,
+			),
+		),
 		active: (
 			custom-control-label:
 				$cadmin-dropdown-section-active-custom-control-label,

--- a/packages/clay-css/src/scss/components/_custom-forms.scss
+++ b/packages/clay-css/src/scss/components/_custom-forms.scss
@@ -168,6 +168,10 @@ label.custom-control-label {
 	@include clay-custom-control-variant($custom-radio);
 }
 
+.custom-control-outside {
+	@include clay-custom-control-variant($custom-control-outside);
+}
+
 // Custom Control Inline
 
 .custom-control-inline {

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -82,6 +82,12 @@
 		);
 	}
 
+	.custom-control-outside {
+		@include clay-custom-control-variant(
+			map-get($dropdown-section, custom-control-outside)
+		);
+	}
+
 	&.active {
 		@include clay-css(map-get($dropdown-section, active));
 

--- a/packages/clay-css/src/scss/variables/_cards.scss
+++ b/packages/clay-css/src/scss/variables/_cards.scss
@@ -406,7 +406,6 @@ $form-check-card: map-deep-merge(
 		custom-control: (
 			display: inline,
 			margin-right: 0,
-			padding-left: 0,
 			position: static,
 			label: (
 				font-weight: $font-weight-normal,

--- a/packages/clay-css/src/scss/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/variables/_custom-forms.scss
@@ -227,11 +227,7 @@ $label-custom-control-label: map-deep-merge(
 $custom-control-label-text: () !default;
 $custom-control-label-text: map-deep-merge(
 	(
-		display: block,
-		padding-left:
-			calc(
-				#{$custom-control-indicator-size} + #{$custom-control-description-padding-left}
-			),
+		padding-left: $custom-control-description-padding-left,
 	),
 	$custom-control-label-text
 );

--- a/packages/clay-css/src/scss/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/variables/_custom-forms.scss
@@ -141,7 +141,7 @@ $custom-control-description-line-height: $custom-control-min-height !default;
 
 /// @deprecated as of v2.19.0 use the Sass map `$custom-control-label-text` instead
 
-$custom-control-description-padding-left: 0.5rem !default; // 8px
+$custom-control-description-padding-left: 0.5rem !default;
 
 /// @deprecated as of v2.19.0 use the Sass map `$custom-control-label-disabled` instead
 
@@ -530,6 +530,30 @@ $custom-radio: map-deep-merge(
 		),
 	),
 	$custom-radio
+);
+
+$custom-control-outside: () !default;
+$custom-control-outside: map-deep-merge(
+	(
+		label: (
+			display: block,
+			padding-left:
+				calc(
+					#{$custom-control-indicator-size} + #{$custom-control-description-padding-left}
+				),
+		),
+		custom-control-input: (
+			custom-control-label: (
+				before: (
+					position: absolute,
+				),
+			),
+		),
+		custom-control-label-text: (
+			padding-left: 0,
+		),
+	),
+	$custom-control-outside
 );
 
 // Custom Switch

--- a/packages/clay-css/src/scss/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/variables/_custom-forms.scss
@@ -173,10 +173,11 @@ $custom-control-label: map-deep-merge(
 				clay-enable-shadows($custom-control-indicator-box-shadow),
 			content: '',
 			display: block,
+			float: left,
 			font-size: $custom-control-indicator-size,
 			height: $custom-control-indicator-size,
 			left: 0,
-			position: absolute,
+			position: relative,
 			top: $custom-control-indicator-position-top,
 			transition: clay-enable-transitions($custom-forms-transition),
 			width: $custom-control-indicator-size,
@@ -224,6 +225,16 @@ $label-custom-control-label: map-deep-merge(
 // .custom-control-label-text
 
 $custom-control-label-text: () !default;
+$custom-control-label-text: map-deep-merge(
+	(
+		display: block,
+		padding-left:
+			calc(
+				#{$custom-control-indicator-size} + #{$custom-control-description-padding-left}
+			),
+	),
+	$custom-control-label-text
+);
 
 // .custom-control-label-text small, .custom-control-label-text .small
 
@@ -243,10 +254,6 @@ $custom-control: map-deep-merge(
 		margin-bottom: $custom-control-margin-bottom,
 		margin-top: $custom-control-margin-top,
 		min-height: $custom-control-min-height,
-		padding-left:
-			calc(
-				#{$custom-control-indicator-size} + #{$custom-control-description-padding-left}
-			),
 		position: relative,
 		text-align: left,
 		only-child: (

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -426,7 +426,6 @@ $dropdown-section-custom-control: () !default;
 $dropdown-section-custom-control: map-deep-merge(
 	(
 		margin-bottom: 0,
-		padding-left: 2rem,
 	),
 	$dropdown-section-custom-control
 );
@@ -438,6 +437,12 @@ $dropdown-section-custom-control-label: () !default;
 /// @deprecated as of v3.x use map $dropdown-section instead
 
 $dropdown-section-custom-control-label-text: () !default;
+$dropdown-section-custom-control-label-text: map-deep-merge(
+	(
+		padding-left: 2rem,
+	),
+	$dropdown-section-custom-control-label-text
+);
 
 /// @deprecated as of v3.x use map $dropdown-section instead
 

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -437,13 +437,6 @@ $dropdown-section-custom-control-label: () !default;
 /// @deprecated as of v3.x use map $dropdown-section instead
 
 $dropdown-section-custom-control-label-text: () !default;
-$dropdown-section-custom-control-label-text: map-deep-merge(
-	(
-		display: block,
-		padding-left: 2rem,
-	),
-	$dropdown-section-custom-control-label-text
-);
 
 /// @deprecated as of v3.x use map $dropdown-section instead
 

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -439,6 +439,7 @@ $dropdown-section-custom-control-label: () !default;
 $dropdown-section-custom-control-label-text: () !default;
 $dropdown-section-custom-control-label-text: map-deep-merge(
 	(
+		display: block,
 		padding-left: 2rem,
 	),
 	$dropdown-section-custom-control-label-text

--- a/packages/clay-drop-down/docs/index.js
+++ b/packages/clay-drop-down/docs/index.js
@@ -107,14 +107,9 @@ const dropDownWithItemsCode = `const Component = () => {
 					type: 'radio',
 					value: 'two',
 				},
-				{
-					label: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
-					type: 'radio',
-					value: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
-				},
 			],
 			label: 'radio',
-			name: 'dropdownWithItemsRadio',
+			name: 'radio',
 			onChange: (value) => alert('New Radio checked'),
 			type: 'radiogroup',
 		},
@@ -129,12 +124,6 @@ const dropDownWithItemsCode = `const Component = () => {
 				{
 					checked: true,
 					label: 'checkbox 1',
-					onChange: () => alert('checkbox changed'),
-					type: 'checkbox',
-				},
-				{
-					checked: true,
-					label: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
 					onChange: () => alert('checkbox changed'),
 					type: 'checkbox',
 				},

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -477,6 +477,7 @@ const Radio = ({value = '', ...otherProps}: IItem & IInternalItem) => {
 			<ClayRadio
 				{...otherProps}
 				checked={checked === value}
+				inline
 				name={name}
 				onChange={() => onChange(value as string)}
 				tabIndex={!tabFocus ? -1 : undefined}

--- a/packages/clay-drop-down/stories/DropDown.stories.tsx
+++ b/packages/clay-drop-down/stories/DropDown.stories.tsx
@@ -36,14 +36,9 @@ const ITEMS = [
 				type: 'radio' as const,
 				value: 'two',
 			},
-			{
-				label: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
-				type: 'radio' as const,
-				value: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
-			},
 		],
 		label: 'radio',
-		name: 'dropdownWithItemsRadio',
+		name: 'radio',
 		onChange: (value: string) => alert(`New Radio checked ${value}`),
 		type: 'radiogroup' as const,
 	},
@@ -58,12 +53,6 @@ const ITEMS = [
 			{
 				checked: true,
 				label: 'checkbox 1',
-				onChange: () => alert('checkbox changed'),
-				type: 'checkbox' as const,
-			},
-			{
-				checked: true,
-				label: 'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual',
 				onChange: () => alert('checkbox changed'),
 				type: 'checkbox' as const,
 			},
@@ -255,14 +244,6 @@ export const Checkbox = () => (
 				/>
 			</ClayDropDown.Section>
 		</ClayDropDown.ItemList>
-		<ClayDropDown.ItemList>
-			<ClayDropDown.Section>
-				<ClayCheckbox
-					label="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
-					onChange={() => {}}
-				/>
-			</ClayDropDown.Section>
-		</ClayDropDown.ItemList>
 	</ClayDropDown>
 );
 
@@ -305,26 +286,10 @@ export const Radio = () => (
 		<ClayDropDown.ItemList>
 			<ClayDropDown.Group header="Order">
 				<ClayDropDown.Section>
-					<ClayRadio
-						checked
-						label="Ascending"
-						name="dropdownRadio01"
-						value="asc"
-					/>
+					<ClayRadio checked label="Ascending" value="asc" />
 				</ClayDropDown.Section>
 				<ClayDropDown.Section>
-					<ClayRadio
-						label="Descending"
-						name="dropdownRadio01"
-						value="desc"
-					/>
-				</ClayDropDown.Section>
-				<ClayDropDown.Section>
-					<ClayRadio
-						label="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
-						name="dropdownRadio01"
-						value="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
-					/>
+					<ClayRadio label="Descending" value="desc" />
 				</ClayDropDown.Section>
 			</ClayDropDown.Group>
 		</ClayDropDown.ItemList>

--- a/packages/clay-form/src/Checkbox.tsx
+++ b/packages/clay-form/src/Checkbox.tsx
@@ -69,6 +69,7 @@ const ClayCheckbox = React.forwardRef<HTMLInputElement, IProps>(
 					containerProps.className,
 					{
 						'custom-control-inline': inline,
+						'custom-control-outside': label,
 					}
 				)}
 			>

--- a/packages/clay-form/src/Radio.tsx
+++ b/packages/clay-form/src/Radio.tsx
@@ -50,6 +50,7 @@ const ClayRadio = React.forwardRef<HTMLInputElement, IRadioProps>(
 					containerProps.className,
 					{
 						'custom-control-inline': inline,
+						'custom-control-outside': label,
 					}
 				)}
 			>

--- a/packages/clay-form/src/__tests__/__snapshots__/Checkbox.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/Checkbox.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ClayCheckbox render as read only 1`] = `
 <div>
   <div
-    class="custom-control custom-checkbox"
+    class="custom-control custom-checkbox custom-control-outside"
   >
     <label>
       <input
@@ -48,7 +48,7 @@ exports[`ClayCheckbox renders 1`] = `
 exports[`ClayCheckbox renders as checked 1`] = `
 <div>
   <div
-    class="custom-control custom-checkbox"
+    class="custom-control custom-checkbox custom-control-outside"
   >
     <label>
       <input
@@ -73,7 +73,7 @@ exports[`ClayCheckbox renders as checked 1`] = `
 exports[`ClayCheckbox renders as checked and disabled 1`] = `
 <div>
   <div
-    class="custom-control custom-checkbox"
+    class="custom-control custom-checkbox custom-control-outside"
   >
     <label>
       <input
@@ -99,7 +99,7 @@ exports[`ClayCheckbox renders as checked and disabled 1`] = `
 exports[`ClayCheckbox renders as disabled 1`] = `
 <div>
   <div
-    class="custom-control custom-checkbox"
+    class="custom-control custom-checkbox custom-control-outside"
   >
     <label>
       <input
@@ -124,7 +124,7 @@ exports[`ClayCheckbox renders as disabled 1`] = `
 exports[`ClayCheckbox renders with a label 1`] = `
 <div>
   <div
-    class="custom-control custom-checkbox"
+    class="custom-control custom-checkbox custom-control-outside"
   >
     <label>
       <input
@@ -148,7 +148,7 @@ exports[`ClayCheckbox renders with a label 1`] = `
 exports[`ClayCheckbox renders with an indeterminate value 1`] = `
 <div>
   <div
-    class="custom-control custom-checkbox"
+    class="custom-control custom-checkbox custom-control-outside"
   >
     <label>
       <input
@@ -173,7 +173,7 @@ exports[`ClayCheckbox renders with an indeterminate value 1`] = `
 exports[`ClayCheckbox renders with an indeterminate value and disabled 1`] = `
 <div>
   <div
-    class="custom-control custom-checkbox"
+    class="custom-control custom-checkbox custom-control-outside"
   >
     <label>
       <input

--- a/packages/clay-form/src/__tests__/__snapshots__/RadioGroup.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/RadioGroup.tsx.snap
@@ -5,7 +5,7 @@ exports[`Rendering default 1`] = `
   className=""
 >
   <div
-    className="custom-control custom-radio"
+    className="custom-control custom-radio custom-control-outside"
   >
     <label>
       <input
@@ -28,7 +28,7 @@ exports[`Rendering default 1`] = `
     </label>
   </div>
   <div
-    className="custom-control custom-radio"
+    className="custom-control custom-radio custom-control-outside"
   >
     <label>
       <input
@@ -51,7 +51,7 @@ exports[`Rendering default 1`] = `
     </label>
   </div>
   <div
-    className="custom-control custom-radio"
+    className="custom-control custom-radio custom-control-outside"
   >
     <label>
       <input

--- a/packages/clay-form/stories/Checkbox.stories.tsx
+++ b/packages/clay-form/stories/Checkbox.stories.tsx
@@ -46,16 +46,28 @@ export const Accessibility = () => {
 
 export const CustomContent = () => {
 	const [value, setValue] = useState<boolean>(false);
+	const [value2, setValue2] = useState<boolean>(false);
 
 	return (
-		<ClayCheckbox
-			checked={value}
-			label="Badge"
-			onChange={() => setValue((val) => !val)}
-		>
-			<span className="badge badge-primary">
-				<span className="badge-item badge-item-expand">10</span>
-			</span>
-		</ClayCheckbox>
+		<div style={{width: '300px'}}>
+			<ClayCheckbox
+				checked={value}
+				label="Badge"
+				onChange={() => setValue((val) => !val)}
+			>
+				<span className="badge badge-primary ml-1">
+					<span className="badge-item badge-item-expand">10</span>
+				</span>
+			</ClayCheckbox>
+			<ClayCheckbox
+				checked={value2}
+				label="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
+				onChange={() => setValue2((val) => !val)}
+			>
+				<span className="badge badge-primary ml-1">
+					<span className="badge-item badge-item-expand">10</span>
+				</span>
+			</ClayCheckbox>
+		</div>
 	);
 };

--- a/packages/clay-form/stories/Radio.stories.tsx
+++ b/packages/clay-form/stories/Radio.stories.tsx
@@ -16,15 +16,21 @@ export const Default = (args: any) => {
 	const [value, setValue] = useState<string>('one');
 
 	return (
-		<ClayRadioGroup
-			inline={args.inline}
-			onSelectedValueChange={(val) => setValue(val as string)}
-			selectedValue={value}
-		>
-			<ClayRadio label="One" value="one" />
-			<ClayRadio label="Two" value="two" />
-			<ClayRadio label="Three" value="three" />
-		</ClayRadioGroup>
+		<div style={{width: '300px'}}>
+			<ClayRadioGroup
+				inline={args.inline}
+				onSelectedValueChange={(val) => setValue(val as string)}
+				selectedValue={value}
+			>
+				<ClayRadio label="One" value="one" />
+				<ClayRadio label="Two" value="two" />
+				<ClayRadio label="Three" value="three" />
+				<ClayRadio
+					label="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
+					value="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
+				/>
+			</ClayRadioGroup>
+		</div>
 	);
 };
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195376

@matuzalemsteles I added the modifier class `custom-control-outside`. It's output when there is a `label`. I wish there was a better way to do this globally.

Edit: I'll send a docs update in a separate pr.