### PR TITLE
fix(@clayui/css): Cadmin nav-tabs remove deprecated styles

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_navs.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navs.scss
@@ -316,7 +316,7 @@ $cadmin-nav-tabs-link-hover-border-color: transparent !default;
 
 $cadmin-nav-tabs-link-active-bg: $cadmin-white !default;
 $cadmin-nav-tabs-link-active-border-color: $cadmin-gray-400 $cadmin-gray-400
-	$cadmin-body-bg !default;
+	$cadmin-nav-tabs-link-active-bg !default;
 $cadmin-nav-tabs-link-active-color: $cadmin-gray-900 !default;
 
 $cadmin-nav-tabs-link-show-color: $cadmin-nav-tabs-link-active-color !default;
@@ -379,10 +379,7 @@ $cadmin-nav-tabs-link: map-deep-merge(
 $cadmin-nav-tabs: () !default;
 $cadmin-nav-tabs: map-deep-merge(
 	(
-		background-color: $cadmin-gray-100,
-		border-color: $cadmin-gray-400,
-		border-style: solid,
-		border-width: 1px 0,
+		border-bottom: 1px solid $cadmin-gray-400,
 		padding-left: 24px,
 		padding-right: 24px,
 		padding-top: 7px,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-196996

Cadmin Old Nav Tab
![cadmin-nav-tabs-old](https://github.com/liferay/clay/assets/788266/9e14022a-1a23-4637-a40e-34c014c5a055)

Cadmin New Nav Tab
![nav-tabs-new](https://github.com/liferay/clay/assets/788266/0eff5ab9-fee2-4394-8303-6736dac2536f)
