### PR TITLE
chore: remove the use of regenerator in the build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -26,8 +26,9 @@ module.exports = (api) => {
 		],
 		presets: [
 			[
-				'@babel/env',
+				'@babel/preset-env',
 				{
+					exclude: ['transform-regenerator'],
 					targets: [
 						'last 2 Chrome versions',
 						'last 1 Edge versions',


### PR DESCRIPTION
Well, we are deleting `transform-regenerator` so that we can use the [Generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) feature and consequently we can now also use [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) instead of continuing to use `then` for Promise, these are features that have been supported by the browser for a long time and is also included within our compatibility matrix.

- `async/await` - 95.9% https://caniuse.com/async-functions
- `function*` - 96.25% https://caniuse.com/es6-generators
- `yield*` - 95.15% https://caniuse.com/mdn-javascript_operators_yield_star
- `yield` - 95.15% https://caniuse.com/mdn-javascript_operators_yield