### PR TITLE
fix(@clayui/css): Cadmin dropdown-menu-indicator spacing is off by 4px

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
@@ -79,7 +79,7 @@ $cadmin-dropdown-item-padding-y: 8px !default;
 $cadmin-dropdown-item-disabled-cursor: $cadmin-disabled-cursor !default;
 
 $cadmin-dropdown-item-indicator-size: 16px !default;
-$cadmin-dropdown-item-indicator-spacer-x: 16px !default;
+$cadmin-dropdown-item-indicator-spacer-x: 12px !default;
 
 $cadmin-dropdown-link-color: $cadmin-gray-600 !default;
 $cadmin-dropdown-link-font-weight: $cadmin-font-weight-normal !default;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-196999