### PR TITLE
fix(@clayui/css): Cadmin alert-indicator-start spacing should be 8px …

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
@@ -578,25 +578,11 @@ $cadmin-alert-indicator-start: map-deep-merge(
 			),
 		),
 		alert-feedback: (
-			padding-left:
-				calc(
-					#{$cadmin-alert-indicator-font-size} + #{map-deep-get(
-							$cadmin-alert-autofit-row,
-							autofit-col,
-							padding-left
-						)}
-				),
+			padding-left: calc(#{$cadmin-alert-indicator-font-size} + 8px),
 		),
 		alert-indicator: (
 			line-height: 1,
-			margin-left:
-				calc(
-					-1em - #{map-deep-get(
-							$cadmin-alert-autofit-row,
-							autofit-col,
-							padding-left
-						)}
-				),
+			margin-left: calc(-1em - 8px),
 			margin-top: 2px,
 			position: absolute,
 			lead: (


### PR DESCRIPTION
…between icon and text

https://liferay.atlassian.net/browse/LPS-200551

https://clayui.com/docs/components/alert/markup.html#css-alert-indicator-start