### PR TITLE
fix(@clayui/core): fixes error when cleaning up the collection for explicitly nested collections

### DIFF
--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -414,9 +414,9 @@ export function useCollection<
 	// there are nested collections.
 	useEffect(
 		() => () => {
-			cleanUp();
-
 			if (forceUpdate) {
+				cleanUp();
+
 				forceUpdate(null);
 			}
 		},


### PR DESCRIPTION
Fixes [LPS-200526](https://liferay.atlassian.net/browse/LPS-200526)

The clean up should only be done in use cases where we have the collection implicitly declared as the VerticalNav component and the list is rendered in render time instead of just once in the root of the component like the Picker component.