### PR TITLE
feat(@clayui/css): Adds translucent buttons and badges

### DIFF
--- a/packages/clay-badge/docs/badge.mdx
+++ b/packages/clay-badge/docs/badge.mdx
@@ -5,14 +5,22 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/badges/'
 packageNpm: '@clayui/badge'
 ---
 
-import {Badge, BadgeBeta, BadgeBetaDark} from '$packages/clay-badge/docs/index';
+import {
+	Badge,
+	BadgeBeta,
+	BadgeBetaDark,
+	BadgeDark,
+	BadgeTranslucent,
+} from '$packages/clay-badge/docs/index';
 
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
 -   [Display Types](#display-types)
--   [Beta](#badge-beta)
-    -   [Dark](#badge-beta-dark)
+-   [Translucent](#badge-translucent)
+-   [Clay Dark](#badge-clay-dark)
+-   [Beta (Deprecated)](#badge-beta)
+    -   [Dark (Deprecated)](#badge-beta-dark)
 
 </div>
 </div>
@@ -26,13 +34,37 @@ For numbers greater than 999, use K to indicate Thousands (5K for 5.231) and M t
 
 We recommend that you review the use cases in the <a href="https://storybook.clayui.com/?path=/story/design-system-components-badge--default">Storybook</a>.
 
-## Beta(#badge-beta)
+## Translucent(#badge-translucent)
+
+The boolean attribute `translucent` renders a badge with an opaque background color optimized for light backgrounds.
+
+<BadgeTranslucent />
+
+## Dark(#badge-clay-dark)
+
+The boolean attribute `dark` renders a badge with an opaque background color optimized for dark backgrounds. It adds the class `clay-dark` to the badge. The class `clay-dark` can be added to the parent element to make badges contained inside render the dark variant. When adding `clay-dark` to the parent element, the `dark` attribute on the badge should be omitted.
+
+<BadgeDark />
+
+## Beta (Deprecated)(#badge-beta)
+
+<div class="clay-site-alert alert alert-warning">
+	The property <code>displayType="beta"</code> has been deprecated in favor of
+	semantic attributes <code>displayType="info"</code> and{' '}
+	<code>translucent</code>.
+</div>
 
 A component to indicate beta features in DXP. The `badge-beta` variant doesn’t have any interaction. It just informs the user. It uses a Badge component with custom visual states.
 
 <BadgeBeta />
 
-## Beta Dark(#badge-beta-dark)
+## Beta Dark (Deprecated)(#badge-beta-dark)
+
+<div class="clay-site-alert alert alert-warning">
+	The property <code>displayType="beta-dark"</code> has been deprecated in
+	favor of semantic attributes <code>dark</code>,{' '}
+	<code>displayType="info"</code> and <code>translucent</code>.
+</div>
 
 `badge-beta-dark` is a dark variant of `badge-beta` to be used with dark backgrounds.
 

--- a/packages/clay-badge/docs/index.js
+++ b/packages/clay-badge/docs/index.js
@@ -11,14 +11,14 @@ const badgeImportsCode = `import ClayBadge from '@clayui/badge';`;
 
 const BadgeCode = `const Component = () => {
 	return (
-        <>
-            <ClayBadge displayType="success" label="100" />
-            <ClayBadge displayType="primary" label="100" />
-            <ClayBadge displayType="secondary" label="100" />
-            <ClayBadge displayType="info" label="100" />
-            <ClayBadge displayType="warning" label="100" />
-            <ClayBadge displayType="danger" label="100" />
-        </>
+		<>
+			<ClayBadge displayType="success" label="100" />
+			<ClayBadge displayType="primary" label="100" />
+			<ClayBadge displayType="secondary" label="100" />
+			<ClayBadge displayType="info" label="100" />
+			<ClayBadge displayType="warning" label="100" />
+			<ClayBadge displayType="danger" label="100" />
+		</>
 	);
 }
 
@@ -27,33 +27,33 @@ render(<Component />);`;
 const badgeJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
 
 const BadgeJSPCode = `<clay:badge
-    displayType="success"
-    label="100" 
+	displayType="success"
+	label="100" 
 />
 
 <clay:badge
-    displayType="primary"
-    label="100" 
+	displayType="primary"
+	label="100" 
 />
 
 <clay:badge
-    displayType="secondary"
-    label="100" 
+	displayType="secondary"
+	label="100" 
 />
 
 <clay:badge
-    displayType="info"
-    label="100" 
+	displayType="info"
+	label="100" 
 />
 
 <clay:badge
-    displayType="warning"
-    label="100" 
+	displayType="warning"
+	label="100" 
 />
 
 <clay:badge
-    displayType="danger"
-    label="100" 
+	displayType="danger"
+	label="100" 
 />`;
 
 export const Badge = () => {
@@ -76,14 +76,106 @@ export const Badge = () => {
 	return <Editor code={codeSnippets} scope={scope} />;
 };
 
+const badgeTranslucentImportsCode = `import ClayBadge from '@clayui/badge';`;
+
+const BadgeTranslucentCode = `const Component = () => {
+	return (
+		<>
+			<ClayBadge displayType="primary" label="Primary" translucent />
+			<ClayBadge displayType="info" label="Info" translucent />
+			<ClayBadge displayType="success" label="Success" translucent />
+			<ClayBadge displayType="warning" label="Warning" translucent />
+			<ClayBadge displayType="danger" label="Danger" translucent />
+		</>
+	);
+}
+
+render(<Component />);`;
+
+const badgeTranslucentJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
+
+const BadgeTranslucentJSPCode = `<clay:badge
+	dark
+	displayType="info"
+	label="Info"
+	translucent
+/>`;
+
+export const BadgeTranslucent = () => {
+	const scope = {ClayBadge};
+
+	const codeSnippets = [
+		{
+			imports: badgeTranslucentImportsCode,
+			name: 'React',
+			value: BadgeTranslucentCode,
+		},
+		{
+			disabled: true,
+			imports: badgeTranslucentJSPImportsCode,
+			name: 'JSP',
+			value: BadgeTranslucentJSPCode,
+		},
+	];
+
+	return <Editor code={codeSnippets} scope={scope} />;
+};
+
+const badgeDarkImportsCode = `import ClayBadge from '@clayui/badge';`;
+
+const BadgeDarkCode = `const Component = () => {
+	return (
+		<>
+			<div className="clay-dark bg-dark p-2">
+				<ClayBadge displayType="primary" label="Primary" translucent />
+				<ClayBadge displayType="info" label="Info" translucent />
+				<ClayBadge displayType="success" label="Success" translucent />
+				<ClayBadge displayType="warning" label="Warning" translucent />
+				<ClayBadge displayType="danger" label="Danger" translucent />
+			</div>
+		</>
+	);
+}
+
+render(<Component />);`;
+
+const badgeDarkJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
+
+const BadgeDarkJSPCode = `<clay:badge
+	dark
+	displayType="info"
+	label="Info"
+	translucent
+/>`;
+
+export const BadgeDark = () => {
+	const scope = {ClayBadge};
+
+	const codeSnippets = [
+		{
+			imports: badgeDarkImportsCode,
+			name: 'React',
+			value: BadgeDarkCode,
+		},
+		{
+			disabled: true,
+			imports: badgeDarkJSPImportsCode,
+			name: 'JSP',
+			value: BadgeDarkJSPCode,
+		},
+	];
+
+	return <Editor code={codeSnippets} scope={scope} />;
+};
+
 const badgeBetaImportsCode = `import ClayBadge from '@clayui/badge';`;
 
 const BadgeBetaCode = `const Component = () => {
-    return (
-        <>
-            <ClayBadge displayType="beta" label="Beta" />
-        </>
-    );
+	return (
+		<>
+			<ClayBadge displayType="info" label="Beta" translucent />
+		</>
+	);
 }
 
 render(<Component />);`;
@@ -91,8 +183,8 @@ render(<Component />);`;
 const badgeBetaJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
 
 const BadgeBetaJSPCode = `<clay:badge
-    displayType="beta"
-    label="Beta" 
+	displayType="beta"
+	label="Beta" 
 />`;
 
 export const BadgeBeta = () => {
@@ -118,13 +210,13 @@ export const BadgeBeta = () => {
 const badgeBetaDarkImportsCode = `import ClayBadge from '@clayui/badge';`;
 
 const BadgeBetaDarkCode = `const Component = () => {
-    return (
-        <>
-        	<div className="bg-dark p-2">
-            	<ClayBadge displayType="beta-dark" label="Beta" />
-            </div>
-        </>
-    );
+	return (
+		<>
+			<div className="bg-dark p-2">
+				<ClayBadge displayType="beta-dark" label="Beta" />
+			</div>
+		</>
+	);
 }
 
 render(<Component />);`;
@@ -132,8 +224,8 @@ render(<Component />);`;
 const badgeBetaDarkJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
 
 const BadgeBetaDarkJSPCode = `<clay:badge
-    displayType="beta-dark"
-    label="Beta" 
+	displayType="beta-dark"
+	label="Beta"
 />`;
 
 export const BadgeBetaDark = () => {

--- a/packages/clay-badge/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-badge/src/__tests__/__snapshots__/index.tsx.snap
@@ -23,3 +23,51 @@ exports[`ClayBadge renders 1`] = `
   </span>
 </span>
 `;
+
+exports[`ClayBadge renders dark and translucent 1`] = `
+<span
+  className="badge badge-info badge-translucent clay-dark"
+>
+  <span
+    className="badge-item badge-item-expand"
+  >
+    Beta
+  </span>
+</span>
+`;
+
+exports[`ClayBadge renders displayType="beta" as info and translucent 1`] = `
+<span
+  className="badge badge-info badge-translucent"
+>
+  <span
+    className="badge-item badge-item-expand"
+  >
+    Beta
+  </span>
+</span>
+`;
+
+exports[`ClayBadge renders displayType="beta-dark" as dark, info and translucent 1`] = `
+<span
+  className="badge badge-info badge-translucent clay-dark"
+>
+  <span
+    className="badge-item badge-item-expand"
+  >
+    Beta
+  </span>
+</span>
+`;
+
+exports[`ClayBadge renders translucent 1`] = `
+<span
+  className="badge badge-info badge-translucent"
+>
+  <span
+    className="badge-item badge-item-expand"
+  >
+    Beta
+  </span>
+</span>
+`;

--- a/packages/clay-badge/src/__tests__/index.tsx
+++ b/packages/clay-badge/src/__tests__/index.tsx
@@ -23,4 +23,36 @@ describe('ClayBadge', () => {
 
 		expect(testRenderer.toJSON()).toMatchSnapshot();
 	});
+
+	it('renders translucent', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayBadge displayType="info" label="Beta" translucent />
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
+	it('renders dark and translucent', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayBadge dark displayType="info" label="Beta" translucent />
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
+	it('renders displayType="beta" as info and translucent', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayBadge displayType="beta" label="Beta" />
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
+	it('renders displayType="beta-dark" as dark, info and translucent', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayBadge displayType="beta-dark" label="Beta" />
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
 });

--- a/packages/clay-badge/src/index.tsx
+++ b/packages/clay-badge/src/index.tsx
@@ -18,7 +18,14 @@ type DisplayType =
 
 interface IProps extends React.HTMLAttributes<HTMLSpanElement> {
 	/**
+	 * Flag to indicate if the badge should use the clay-dark variant.
+	 */
+	dark?: boolean;
+
+	/**
 	 * Determines the color of the badge.
+	 * The values `beta` and `beta-dark` are deprecated since v3.100.0 - use
+	 * `translucent` and `dark` instead.
 	 */
 	displayType?: DisplayType;
 
@@ -26,21 +33,52 @@ interface IProps extends React.HTMLAttributes<HTMLSpanElement> {
 	 * Info that is shown inside of the badge itself.
 	 */
 	label?: string | number;
+
+	/**
+	 * Flag to indicate if the badge should use the translucent variant.
+	 */
+	translucent?: boolean;
 }
 
 const ClayBadge = React.forwardRef<HTMLSpanElement, IProps>(
 	(
-		{className, displayType = 'primary', label, ...otherProps}: IProps,
+		{
+			className,
+			dark,
+			displayType = 'primary',
+			label,
+			translucent,
+			...otherProps
+		}: IProps,
 		ref
-	) => (
-		<span
-			{...otherProps}
-			className={classNames('badge', `badge-${displayType}`, className)}
-			ref={ref}
-		>
-			<span className="badge-item badge-item-expand">{label}</span>
-		</span>
-	)
+	) => {
+		if (displayType === 'beta') {
+			displayType = 'info';
+			translucent = true;
+		} else if (displayType === 'beta-dark') {
+			dark = true;
+			displayType = 'info';
+			translucent = true;
+		}
+
+		return (
+			<span
+				{...otherProps}
+				className={classNames(
+					'badge',
+					`badge-${displayType}`,
+					className,
+					{
+						'badge-translucent': translucent,
+						'clay-dark': dark,
+					}
+				)}
+				ref={ref}
+			>
+				<span className="badge-item badge-item-expand">{label}</span>
+			</span>
+		);
+	}
 );
 
 ClayBadge.displayName = 'ClayBadge';

--- a/packages/clay-badge/stories/Badge.stories.tsx
+++ b/packages/clay-badge/stories/Badge.stories.tsx
@@ -26,10 +26,15 @@ export default {
 };
 
 export const Default = (args: any) => (
-	<ClayBadge displayType={args.displayType} label={args.label} />
+	<ClayBadge
+		displayType={args.displayType}
+		label={args.label}
+		translucent={args.translucent}
+	/>
 );
 
 Default.args = {
 	displayType: 'primary',
 	label: '100',
+	translucent: false,
 };

--- a/packages/clay-button/docs/button.mdx
+++ b/packages/clay-button/docs/button.mdx
@@ -8,9 +8,11 @@ packageNpm: '@clayui/button'
 import {
 	ButtonBeta,
 	ButtonBetaDark,
+	ButtonClayDark,
 	ButtonDisplayTypes,
 	ButtonGroup,
 	ButtonIcon,
+	ButtonTranslucent,
 } from '$packages/clay-button/docs/index';
 
 <div class="nav-toc-absolute">
@@ -19,8 +21,10 @@ import {
 -   [Display Types](#display-types)
 -   [Group](#group)
 -   [Icon](#icon)
--   [Beta](#btn-beta)
-    -   [Dark](#btn-beta-dark)
+-   [Translucent](#btn-translucent)
+-   [Clay Dark](#btn-clay-dark)
+-   [Beta (Deprecated)](#btn-beta)
+    -   [Dark (Deprecated)](#btn-beta-dark)
 
 </div>
 </div>
@@ -49,13 +53,37 @@ You can use the high-level component `ClayButtonWithIcon` to create a button wit
 
 <ButtonIcon />
 
-## Beta(#btn-beta)
+## Translucent(#btn-translucent)
+
+The boolean attribute `translucent` renders a button with an opaque background color optimized for light backgrounds. It renders as an extra small button with rounded borders.
+
+<ButtonTranslucent />
+
+## Dark(#btn-clay-dark)
+
+The boolean attribute `dark` renders a button with an opaque background color optimized for dark backgrounds. It adds the class `clay-dark` to the button. The class `clay-dark` can be added to the parent element to make buttons contained inside render the dark variant. When adding `clay-dark` to the parent element, the `dark` attribute on the button should be omitted.
+
+<ButtonClayDark />
+
+## Beta (Deprecated)(#btn-beta)
+
+<div class="clay-site-alert alert alert-warning">
+	The property <code>displayType="beta"</code> has been deprecated in favor of
+	semantic attributes <code>displayType="info"</code> and{' '}
+	<code>translucent</code>.
+</div>
 
 A component to indicate beta features in DXP. The Button variant should be used when the component can be placed close to a non-interactive UI element, such as a title or a section. Also, a default popover is shown if the user interacts with it.
 
 <ButtonBeta />
 
-### Beta Dark(#btn-beta-dark)
+### Beta Dark (Deprecated)(#btn-beta-dark)
+
+<div class="clay-site-alert alert alert-warning">
+	The property <code>displayType="beta-dark"</code> has been deprecated in
+	favor of semantic attributes <code>dark</code>,{' '}
+	<code>displayType="info"</code> and <code>translucent</code>.
+</div>
 
 `btn-beta-dark` is a dark variant of `btn-beta` to be used with dark backgrounds.
 

--- a/packages/clay-button/docs/index.js
+++ b/packages/clay-button/docs/index.js
@@ -80,7 +80,7 @@ const buttonGroupImportsCode = `import ClayButton from '@clayui/button';`;
 
 const ButtonGroupCode = `const Component = () => {
 	return (
-        <ClayButton.Group>
+		<ClayButton.Group>
 			<ClayButton>{'This'}</ClayButton>
 			<ClayButton displayType="secondary">{'is'}</ClayButton>
 			<ClayButton>{'a'}</ClayButton>
@@ -131,6 +131,132 @@ const ButtonIcon = () => {
 
 	return <Editor code={code} imports={buttonIconImportsCode} scope={scope} />;
 };
+
+const buttonTranslucentImportsCode = `import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon;'`;
+
+const ButtonTranslucentCode = `const Component = () => {
+	return (
+		<>
+			<ClayButton displayType="primary" translucent>
+				<span className="inline-item">
+					{'Primary'}
+				</span>
+			</ClayButton>
+
+			<ClayButton displayType="success" translucent>
+				<span className="inline-item">
+					{'Success'}
+				</span>
+			</ClayButton>
+
+			<ClayButton displayType="info" translucent>
+				<span className="inline-item">
+					{'Info'}
+				</span>
+
+				<span className="inline-item inline-item-after">
+					<ClayIcon spritemap={spritemap} symbol="info-panel-open" />
+				</span>
+			</ClayButton>
+
+			<ClayButton displayType="warning" translucent>
+				<span className="inline-item">
+					{'Warning'}
+				</span>
+
+				<span className="inline-item inline-item-after">
+					<ClayIcon spritemap={spritemap} symbol="warning-full" />
+				</span>
+			</ClayButton>
+
+			<ClayButton displayType="danger" translucent>
+				<span className="inline-item">
+					{'Danger'}
+				</span>
+			</ClayButton>
+		</>
+	);
+}
+
+render(<Component />);`;
+
+const ButtonTranslucent = () => {
+	const scope = {ClayButton, ClayButtonWithIcon, ClayIcon};
+	const code = ButtonTranslucentCode;
+
+	return (
+		<Editor
+			code={code}
+			imports={buttonTranslucentImportsCode}
+			scope={scope}
+		/>
+	);
+};
+
+// START
+
+const buttonClayDarkImportsCode = `import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon;'`;
+
+const ButtonClayDarkCode = `const Component = () => {
+	return (
+		<>
+			<div className="bg-dark clay-dark p-2">
+				<ClayButton displayType="primary" translucent>
+					<span className="inline-item">
+						{'Primary'}
+					</span>
+				</ClayButton>
+
+				<ClayButton displayType="success" translucent>
+					<span className="inline-item">
+						{'Success'}
+					</span>
+				</ClayButton>
+
+				<ClayButton displayType="info" translucent>
+					<span className="inline-item">
+						{'Info'}
+					</span>
+
+					<span className="inline-item inline-item-after">
+						<ClayIcon spritemap={spritemap} symbol="info-panel-open" />
+					</span>
+				</ClayButton>
+
+				<ClayButton displayType="warning" translucent>
+					<span className="inline-item">
+						{'Warning'}
+					</span>
+
+					<span className="inline-item inline-item-after">
+						<ClayIcon spritemap={spritemap} symbol="warning-full" />
+					</span>
+				</ClayButton>
+
+				<ClayButton displayType="danger" translucent>
+					<span className="inline-item">
+						{'Danger'}
+					</span>
+				</ClayButton>
+			</div>
+		</>
+	);
+}
+
+render(<Component />);`;
+
+const ButtonClayDark = () => {
+	const scope = {ClayButton, ClayButtonWithIcon, ClayIcon};
+	const code = ButtonClayDarkCode;
+
+	return (
+		<Editor code={code} imports={buttonClayDarkImportsCode} scope={scope} />
+	);
+};
+
+// END
 
 const buttonBetaImportsCode = `import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon;'`;
@@ -198,4 +324,6 @@ export {
 	ButtonIcon,
 	ButtonBeta,
 	ButtonBetaDark,
+	ButtonTranslucent,
+	ButtonClayDark,
 };

--- a/packages/clay-button/src/Button.tsx
+++ b/packages/clay-button/src/Button.tsx
@@ -39,7 +39,14 @@ export interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 	block?: boolean;
 
 	/**
+	 * Flag to indicate if the button should use the clay-dark variant.
+	 */
+	dark?: boolean;
+
+	/**
 	 * Determines the button variant to use.
+	 * The values `beta` and `beta-dark` are deprecated since v3.100.0 - use
+	 * `translucent` and `dark` instead.
 	 */
 	displayType?: DisplayType;
 
@@ -68,6 +75,11 @@ export interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 	 * @deprecated since v3.72.0 - use `size` instead.
 	 */
 	small?: boolean;
+
+	/**
+	 * Flag to indicate if the button should use the translucent variant.
+	 */
+	translucent?: boolean;
 }
 
 const ClayButton = React.forwardRef<HTMLButtonElement, IProps>(
@@ -78,12 +90,14 @@ const ClayButton = React.forwardRef<HTMLButtonElement, IProps>(
 			borderless,
 			children,
 			className,
+			dark,
 			displayType = 'primary',
 			monospaced,
 			outline,
 			rounded,
 			size,
 			small,
+			translucent,
 			type = 'button',
 			...otherProps
 		}: IProps,
@@ -102,6 +116,15 @@ const ClayButton = React.forwardRef<HTMLButtonElement, IProps>(
 			'Button Accessibility: Component has only the Icon declared. Define an `aria-label` or `aria-labelledby` attribute that labels the interactive button that screen readers can read. The `title` attribute is optional but consult your design team.'
 		);
 
+		if (displayType === 'beta') {
+			displayType = 'info';
+			translucent = true;
+		} else if (displayType === 'beta-dark') {
+			dark = true;
+			displayType = 'info';
+			translucent = true;
+		}
+
 		return (
 			<button
 				className={classNames(className, 'btn', {
@@ -110,6 +133,8 @@ const ClayButton = React.forwardRef<HTMLButtonElement, IProps>(
 					'btn-monospaced': monospaced,
 					'btn-outline-borderless': borderless,
 					'btn-sm': small && !size,
+					'btn-translucent': translucent,
+					'clay-dark': dark,
 					[`btn-${displayType}`]:
 						displayType && !outline && !borderless,
 					[`btn-outline-${displayType}`]:

--- a/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
@@ -101,11 +101,44 @@ exports[`Button renders borderless 1`] = `
 </div>
 `;
 
+exports[`Button renders dark and translucent 1`] = `
+<div>
+  <button
+    class="btn btn-translucent clay-dark btn-info"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
 exports[`Button renders disabled 1`] = `
 <div>
   <button
     class="btn btn-primary"
     disabled=""
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`Button renders displayType="beta" as info and translucent 1`] = `
+<div>
+  <button
+    class="btn btn-translucent btn-info"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`Button renders displayType="beta-dark" as dark, info and translucent 1`] = `
+<div>
+  <button
+    class="btn btn-translucent clay-dark btn-info"
     type="button"
   >
     Button
@@ -139,6 +172,17 @@ exports[`Button renders small 1`] = `
 <div>
   <button
     class="btn btn-sm btn-primary"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`Button renders translucent 1`] = `
+<div>
+  <button
+    class="btn btn-translucent btn-info"
     type="button"
   >
     Button

--- a/packages/clay-button/src/__tests__/index.tsx
+++ b/packages/clay-button/src/__tests__/index.tsx
@@ -83,6 +83,40 @@ describe('Button', () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it('renders translucent', () => {
+		const {container} = render(
+			<Button displayType="info" translucent>
+				Button
+			</Button>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders dark and translucent', () => {
+		const {container} = render(
+			<Button dark displayType="info" translucent>
+				Button
+			</Button>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders displayType="beta" as info and translucent', () => {
+		const {container} = render(<Button displayType="beta">Button</Button>);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders displayType="beta-dark" as dark, info and translucent', () => {
+		const {container} = render(
+			<Button displayType="beta-dark">Button</Button>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
 	it('renders with a ButtonGroup', () => {
 		const {container} = render(
 			<Button.Group>

--- a/packages/clay-button/stories/Button.stories.tsx
+++ b/packages/clay-button/stories/Button.stories.tsx
@@ -11,7 +11,18 @@ export default {
 	argTypes: {
 		displayType: {
 			control: {type: 'select'},
-			options: ['link', 'primary', 'secondary', 'unstyled'],
+			options: [
+				'link',
+				'primary',
+				'secondary',
+				'success',
+				'info',
+				'warning',
+				'danger',
+				'unstyled',
+				'beta',
+				'beta-dark',
+			],
 		},
 		size: {
 			control: {type: 'select'},
@@ -26,6 +37,7 @@ export const Default = (args: any) => (
 	<ClayButton
 		block={args.block}
 		borderless={args.borderless}
+		dark={args.dark}
 		disabled={args.disabled}
 		displayType={args.displayType}
 		monospaced={args.monospaced}
@@ -33,6 +45,7 @@ export const Default = (args: any) => (
 		rounded={args.rounded}
 		size={args.size}
 		small={args.small}
+		translucent={args.translucent}
 	>
 		{args.children}
 	</ClayButton>
@@ -42,12 +55,14 @@ Default.args = {
 	block: false,
 	borderless: false,
 	children: 'Click Me',
+	dark: false,
 	disabled: false,
 	displayType: 'primary',
 	monospaced: false,
 	outline: false,
 	rounded: false,
 	small: false,
+	translucent: false,
 };
 
 export const Group = (args: any) => (

--- a/packages/clay-css/src/scss/cadmin/components/_badges.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_badges.scss
@@ -68,12 +68,7 @@
 		$selector: if(
 			index($deprecated-keys, '#{$color}') != null,
 			str-insert($color, '.badge-', 1),
-			if
-				(
-					starts-with($color, 'badge'),
-					str-insert($color, '.', 1),
-					$color
-				)
+			if(starts-with($color, 'badge'), str-insert($color, '.', 1), $color)
 		);
 
 		@if (starts-with($color, '%') or map-get($value, extend)) {

--- a/packages/clay-css/src/scss/cadmin/variables/_badges.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_badges.scss
@@ -466,10 +466,85 @@ $cadmin-badge-palette: map-deep-merge(
 		danger: $cadmin-badge-danger,
 		light: $cadmin-badge-light,
 		dark: $cadmin-badge-dark,
-		badge-beta: (
-			background-color: $cadmin-light-l1,
+		'.badge-translucent.badge-primary': (
+			background-color: rgba($cadmin-primary-d1, 0.04),
+			border-color: transparent,
+			color: $cadmin-primary-d1,
+		),
+		'.badge-translucent.badge-info, .badge-beta': (
+			background-color: rgba($cadmin-info-d1, 0.04),
+			border-color: transparent,
 			color: $cadmin-info-d1,
-			text-transform: uppercase,
+		),
+		'.badge-translucent.badge-success': (
+			background-color: rgba($cadmin-success-d1, 0.04),
+			border-color: transparent,
+			color: $cadmin-success-d1,
+		),
+		'.badge-translucent.badge-warning': (
+			background-color: rgba($cadmin-warning-d1, 0.04),
+			border-color: transparent,
+			color: $cadmin-warning-d1,
+		),
+		'.badge-translucent.badge-danger': (
+			background-color: rgba($cadmin-danger-d1, 0.04),
+			border-color: transparent,
+			color: $cadmin-danger-d1,
+		),
+		'%clay-dark-badge-translucent-primary': (
+			background-color: rgba($cadmin-primary-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-primary-l1,
+		),
+		'.clay-dark .badge-translucent.badge-primary': (
+			extend: '%clay-dark-badge-translucent-primary',
+		),
+		'.clay-dark.badge-translucent.badge-primary': (
+			extend: '%clay-dark-badge-translucent-primary',
+		),
+		'%clay-dark-badge-translucent-info': (
+			background-color: rgba($cadmin-info-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-info-l1,
+		),
+		'.clay-dark .badge-translucent.badge-info, .badge-beta-dark': (
+			extend: '%clay-dark-badge-translucent-info',
+		),
+		'.clay-dark.badge-translucent.badge-info': (
+			extend: '%clay-dark-badge-translucent-info',
+		),
+		'%clay-dark-badge-translucent-success': (
+			background-color: rgba($cadmin-success-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-success-l1,
+		),
+		'.clay-dark .badge-translucent.badge-success': (
+			extend: '%clay-dark-badge-translucent-success',
+		),
+		'.clay-dark.badge-translucent.badge-success': (
+			extend: '%clay-dark-badge-translucent-success',
+		),
+		'%clay-dark-badge-translucent-warning': (
+			background-color: rgba($cadmin-warning-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-warning-l1,
+		),
+		'.clay-dark .badge-translucent.badge-warning': (
+			extend: '%clay-dark-badge-translucent-warning',
+		),
+		'.clay-dark.badge-translucent.badge-warning': (
+			extend: '%clay-dark-badge-translucent-warning',
+		),
+		'%clay-dark-badge-translucent-danger': (
+			background-color: rgba($cadmin-danger-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-danger-l1,
+		),
+		'.clay-dark .badge-translucent.badge-danger': (
+			extend: '%clay-dark-badge-translucent-danger',
+		),
+		'.clay-dark.badge-translucent.badge-danger': (
+			extend: '%clay-dark-badge-translucent-danger',
 		),
 	),
 	$cadmin-badge-palette

--- a/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
@@ -721,6 +721,210 @@ $cadmin-btn-palette: map-deep-merge(
 				color: $cadmin-info-d1,
 			),
 		),
+		'.btn-translucent': (
+			extend: '%clay-btn-xs',
+			border-radius: clay-enable-rounded($cadmin-rounded-pill),
+		),
+		'.btn-translucent.btn-primary': (
+			background-color: rgba($cadmin-primary-d1, 0.04),
+			border-color: transparent,
+			color: $cadmin-primary-d1,
+			hover: (
+				background-color: rgba($cadmin-primary-d1, 0.06),
+				color: $cadmin-primary-d1,
+			),
+			focus: (
+				background-color: rgba($cadmin-primary-d1, 0.06),
+				color: $cadmin-primary-d1,
+			),
+			active: (
+				background-color: rgba($cadmin-primary-d1, 0.08),
+				color: $cadmin-primary-d1,
+			),
+		),
+		'.btn-translucent.btn-info, .btn-beta': (
+			background-color: rgba($cadmin-info-d1, 0.04),
+			border-color: transparent,
+			color: $cadmin-info-d1,
+			hover: (
+				background-color: rgba($cadmin-info-d1, 0.06),
+				color: $cadmin-info-d1,
+			),
+			focus: (
+				background-color: rgba($cadmin-info-d1, 0.06),
+				color: $cadmin-info-d1,
+			),
+			active: (
+				background-color: rgba($cadmin-info-d1, 0.08),
+				color: $cadmin-info-d1,
+			),
+		),
+		'.btn-translucent.btn-success': (
+			background-color: rgba($cadmin-success-d1, 0.04),
+			border-color: transparent,
+			color: $cadmin-success-d1,
+			hover: (
+				background-color: rgba($cadmin-success-d1, 0.06),
+				color: $cadmin-success-d1,
+			),
+			focus: (
+				background-color: rgba($cadmin-success-d1, 0.06),
+				color: $cadmin-success-d1,
+			),
+			active: (
+				background-color: rgba($cadmin-success-d1, 0.08),
+				color: $cadmin-success-d1,
+			),
+		),
+		'.btn-translucent.btn-warning': (
+			background-color: rgba($cadmin-warning-d1, 0.04),
+			border-color: transparent,
+			color: $cadmin-warning-d1,
+			hover: (
+				background-color: rgba($cadmin-warning-d1, 0.06),
+				color: $cadmin-warning-d1,
+			),
+			focus: (
+				background-color: rgba($cadmin-warning-d1, 0.06),
+				color: $cadmin-warning-d1,
+			),
+			active: (
+				background-color: rgba($cadmin-warning-d1, 0.08),
+				color: $cadmin-warning-d1,
+			),
+		),
+		'.btn-translucent.btn-danger': (
+			background-color: rgba($cadmin-danger-d1, 0.04),
+			border-color: transparent,
+			color: $cadmin-danger-d1,
+			hover: (
+				background-color: rgba($cadmin-danger-d1, 0.06),
+				color: $cadmin-danger-d1,
+			),
+			focus: (
+				background-color: rgba($cadmin-danger-d1, 0.06),
+				color: $cadmin-danger-d1,
+			),
+			active: (
+				background-color: rgba($cadmin-danger-d1, 0.08),
+				color: $cadmin-danger-d1,
+			),
+		),
+		'%clay-dark-btn-translucent-primary': (
+			background-color: rgba($cadmin-primary-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-primary-l1,
+			hover: (
+				background-color: rgba($cadmin-primary-l2, 0.06),
+				color: $cadmin-primary-l1,
+			),
+			focus: (
+				background-color: rgba($cadmin-primary-l2, 0.06),
+				color: $cadmin-primary-l1,
+			),
+			active: (
+				background-color: rgba($cadmin-primary-l2, 0.08),
+				color: $cadmin-primary-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-primary': (
+			extend: '%clay-dark-btn-translucent-primary',
+		),
+		'.clay-dark.btn-translucent.btn-primary': (
+			extend: '%clay-dark-btn-translucent-primary',
+		),
+		'%clay-dark-btn-translucent-info': (
+			background-color: rgba($cadmin-info-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-info-l1,
+			hover: (
+				background-color: rgba($cadmin-info-l2, 0.06),
+				color: $cadmin-info-l1,
+			),
+			focus: (
+				background-color: rgba($cadmin-info-l2, 0.06),
+				color: $cadmin-info-l1,
+			),
+			active: (
+				background-color: rgba($cadmin-info-l2, 0.08),
+				color: $cadmin-info-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-info, .btn-beta-dark': (
+			extend: '%clay-dark-btn-translucent-info',
+		),
+		'.clay-dark.btn-translucent.btn-info': (
+			extend: '%clay-dark-btn-translucent-info',
+		),
+		'%clay-dark-btn-translucent-success': (
+			background-color: rgba($cadmin-success-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-success-l1,
+			hover: (
+				background-color: rgba($cadmin-success-l2, 0.06),
+				color: $cadmin-success-l1,
+			),
+			focus: (
+				background-color: rgba($cadmin-success-l2, 0.06),
+				color: $cadmin-success-l1,
+			),
+			active: (
+				background-color: rgba($cadmin-success-l2, 0.08),
+				color: $cadmin-success-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-success': (
+			extend: '%clay-dark-btn-translucent-success',
+		),
+		'.clay-dark.btn-translucent.btn-success': (
+			extend: '%clay-dark-btn-translucent-success',
+		),
+		'%clay-dark-btn-translucent-warning': (
+			background-color: rgba($cadmin-warning-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-warning-l1,
+			hover: (
+				background-color: rgba($cadmin-warning-l2, 0.06),
+				color: $cadmin-warning-l1,
+			),
+			focus: (
+				background-color: rgba($cadmin-warning-l2, 0.06),
+				color: $cadmin-warning-l1,
+			),
+			active: (
+				background-color: rgba($cadmin-warning-l2, 0.08),
+				color: $cadmin-warning-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-warning': (
+			extend: '%clay-dark-btn-translucent-warning',
+		),
+		'.clay-dark.btn-translucent.btn-warning': (
+			extend: '%clay-dark-btn-translucent-warning',
+		),
+		'%clay-dark-btn-translucent-danger': (
+			background-color: rgba($cadmin-danger-l2, 0.04),
+			border-color: transparent,
+			color: $cadmin-danger-l1,
+			hover: (
+				background-color: rgba($cadmin-danger-l2, 0.06),
+				color: $cadmin-danger-l1,
+			),
+			focus: (
+				background-color: rgba($cadmin-danger-l2, 0.06),
+				color: $cadmin-danger-l1,
+			),
+			active: (
+				background-color: rgba($cadmin-danger-l2, 0.08),
+				color: $cadmin-danger-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-danger': (
+			extend: '%clay-dark-btn-translucent-danger',
+		),
+		'.clay-dark.btn-translucent.btn-danger': (
+			extend: '%clay-dark-btn-translucent-danger',
+		),
 	),
 	$cadmin-btn-palette
 );

--- a/packages/clay-css/src/scss/variables/_badges.scss
+++ b/packages/clay-css/src/scss/variables/_badges.scss
@@ -494,15 +494,85 @@ $badge-palette: map-deep-merge(
 		danger: $badge-danger,
 		light: $badge-light,
 		dark: $badge-dark,
-		badge-beta: (
-			background-color: rgba($info-d1, 0.04),
-			color: $info-d1,
-			text-transform: uppercase,
+		'.badge-translucent.badge-primary': (
+			background-color: rgba($primary-d1, 0.04),
+			border-color: transparent,
+			color: $primary-d1,
 		),
-		badge-beta-dark: (
+		'.badge-translucent.badge-info, .badge-beta': (
+			background-color: rgba($info-d1, 0.04),
+			border-color: transparent,
+			color: $info-d1,
+		),
+		'.badge-translucent.badge-success': (
+			background-color: rgba($success-d1, 0.04),
+			border-color: transparent,
+			color: $success-d1,
+		),
+		'.badge-translucent.badge-warning': (
+			background-color: rgba($warning-d1, 0.04),
+			border-color: transparent,
+			color: $warning-d1,
+		),
+		'.badge-translucent.badge-danger': (
+			background-color: rgba($danger-d1, 0.04),
+			border-color: transparent,
+			color: $danger-d1,
+		),
+		'%clay-dark-badge-translucent-primary': (
+			background-color: rgba($primary-l2, 0.04),
+			border-color: transparent,
+			color: $primary-l1,
+		),
+		'.clay-dark .badge-translucent.badge-primary': (
+			extend: '%clay-dark-badge-translucent-primary',
+		),
+		'.clay-dark.badge-translucent.badge-primary': (
+			extend: '%clay-dark-badge-translucent-primary',
+		),
+		'%clay-dark-badge-translucent-info': (
 			background-color: rgba($info-l2, 0.04),
+			border-color: transparent,
 			color: $info-l1,
-			text-transform: uppercase,
+		),
+		'.clay-dark .badge-translucent.badge-info, .badge-beta-dark': (
+			extend: '%clay-dark-badge-translucent-info',
+		),
+		'.clay-dark.badge-translucent.badge-info': (
+			extend: '%clay-dark-badge-translucent-info',
+		),
+		'%clay-dark-badge-translucent-success': (
+			background-color: rgba($success-l2, 0.04),
+			border-color: transparent,
+			color: $success-l1,
+		),
+		'.clay-dark .badge-translucent.badge-success': (
+			extend: '%clay-dark-badge-translucent-success',
+		),
+		'.clay-dark.badge-translucent.badge-success': (
+			extend: '%clay-dark-badge-translucent-success',
+		),
+		'%clay-dark-badge-translucent-warning': (
+			background-color: rgba($warning-l2, 0.04),
+			border-color: transparent,
+			color: $warning-l1,
+		),
+		'.clay-dark .badge-translucent.badge-warning': (
+			extend: '%clay-dark-badge-translucent-warning',
+		),
+		'.clay-dark.badge-translucent.badge-warning': (
+			extend: '%clay-dark-badge-translucent-warning',
+		),
+		'%clay-dark-badge-translucent-danger': (
+			background-color: rgba($danger-l2, 0.04),
+			border-color: transparent,
+			color: $danger-l1,
+		),
+		'.clay-dark .badge-translucent.badge-danger': (
+			extend: '%clay-dark-badge-translucent-danger',
+		),
+		'.clay-dark.badge-translucent.badge-danger': (
+			extend: '%clay-dark-badge-translucent-danger',
 		),
 	),
 	$badge-palette

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -894,24 +894,139 @@ $btn-palette: map-deep-merge(
 		light: $btn-light,
 		dark: $btn-dark,
 		link: $btn-link,
-		btn-beta: (
+		'.btn-translucent': (
+			extend: '%clay-btn-xs',
+			border-radius: $rounded-pill,
+		),
+		'.btn-translucent.btn-primary': (
+			background-color: rgba($primary-d1, 0.04),
+			border-color: transparent,
+			color: $primary-d1,
+			hover: (
+				background-color: rgba($primary-d1, 0.06),
+				color: $primary-d1,
+			),
+			focus: (
+				background-color: rgba($primary-d1, 0.06),
+				color: $primary-d1,
+			),
+			active: (
+				background-color: rgba($primary-d1, 0.08),
+				color: $primary-d1,
+			),
+		),
+		'.btn-translucent.btn-secondary': (
+			background-color: rgba($dark-l2, 0.04),
+			border-color: transparent,
+			color: $secondary,
+			hover: (
+				background-color: rgba($dark-l2, 0.06),
+				color: $secondary,
+			),
+			focus: (
+				background-color: rgba($dark-l2, 0.06),
+				color: $secondary,
+			),
+			active: (
+				background-color: rgba($dark-l2, 0.08),
+				color: $secondary,
+			),
+		),
+		'.btn-translucent.btn-info, .btn-beta': (
 			background-color: rgba($info-d1, 0.04),
+			border-color: transparent,
 			color: $info-d1,
-			text-transform: uppercase,
 			hover: (
 				background-color: rgba($info-d1, 0.06),
 				color: $info-d1,
 			),
 			focus: (
 				background-color: rgba($info-d1, 0.06),
+				color: $info-d1,
+			),
+			active: (
+				background-color: rgba($info-d1, 0.08),
 				color: $info-d1,
 			),
 		),
-		btn-beta-dark: (
+		'.btn-translucent.btn-success': (
+			background-color: rgba($success-d1, 0.04),
+			border-color: transparent,
+			color: $success-d1,
+			hover: (
+				background-color: rgba($success-d1, 0.06),
+				color: $success-d1,
+			),
+			focus: (
+				background-color: rgba($success-d1, 0.06),
+				color: $success-d1,
+			),
+			active: (
+				background-color: rgba($success-d1, 0.08),
+				color: $success-d1,
+			),
+		),
+		'.btn-translucent.btn-warning': (
+			background-color: rgba($warning-d1, 0.04),
+			border-color: transparent,
+			color: $warning-d1,
+			hover: (
+				background-color: rgba($warning-d1, 0.06),
+				color: $warning-d1,
+			),
+			focus: (
+				background-color: rgba($warning-d1, 0.06),
+				color: $warning-d1,
+			),
+			active: (
+				background-color: rgba($warning-d1, 0.08),
+				color: $warning-d1,
+			),
+		),
+		'.btn-translucent.btn-danger': (
+			background-color: rgba($danger-d1, 0.04),
+			border-color: transparent,
+			color: $danger-d1,
+			hover: (
+				background-color: rgba($danger-d1, 0.06),
+				color: $danger-d1,
+			),
+			focus: (
+				background-color: rgba($danger-d1, 0.06),
+				color: $danger-d1,
+			),
+			active: (
+				background-color: rgba($danger-d1, 0.08),
+				color: $danger-d1,
+			),
+		),
+		'%clay-dark-btn-translucent-primary': (
+			background-color: rgba($primary-l2, 0.04),
+			border-color: transparent,
+			color: $primary-l1,
+			hover: (
+				background-color: rgba($primary-l2, 0.06),
+				color: $primary-l1,
+			),
+			focus: (
+				background-color: rgba($primary-l2, 0.06),
+				color: $primary-l1,
+			),
+			active: (
+				background-color: rgba($primary-l2, 0.08),
+				color: $primary-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-primary': (
+			extend: '%clay-dark-btn-translucent-primary',
+		),
+		'.clay-dark.btn-translucent.btn-primary': (
+			extend: '%clay-dark-btn-translucent-primary',
+		),
+		'%clay-dark-btn-translucent-info': (
 			background-color: rgba($info-l2, 0.04),
 			border-color: transparent,
 			color: $info-l1,
-			text-transform: uppercase,
 			hover: (
 				background-color: rgba($info-l2, 0.06),
 				color: $info-l1,
@@ -920,6 +1035,85 @@ $btn-palette: map-deep-merge(
 				background-color: rgba($info-l2, 0.06),
 				color: $info-l1,
 			),
+			active: (
+				background-color: rgba($info-l2, 0.08),
+				color: $info-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-info, .btn-beta-dark': (
+			extend: '%clay-dark-btn-translucent-info',
+		),
+		'.clay-dark.btn-translucent.btn-info': (
+			extend: '%clay-dark-btn-translucent-info',
+		),
+		'%clay-dark-btn-translucent-success': (
+			background-color: rgba($success-l2, 0.04),
+			border-color: transparent,
+			color: $success-l1,
+			hover: (
+				background-color: rgba($success-l2, 0.06),
+				color: $success-l1,
+			),
+			focus: (
+				background-color: rgba($success-l2, 0.06),
+				color: $success-l1,
+			),
+			active: (
+				background-color: rgba($success-l2, 0.08),
+				color: $success-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-success': (
+			extend: '%clay-dark-btn-translucent-success',
+		),
+		'.clay-dark.btn-translucent.btn-success': (
+			extend: '%clay-dark-btn-translucent-success',
+		),
+		'%clay-dark-btn-translucent-warning': (
+			background-color: rgba($warning-l2, 0.04),
+			border-color: transparent,
+			color: $warning-l1,
+			hover: (
+				background-color: rgba($warning-l2, 0.06),
+				color: $warning-l1,
+			),
+			focus: (
+				background-color: rgba($warning-l2, 0.06),
+				color: $warning-l1,
+			),
+			active: (
+				background-color: rgba($warning-l2, 0.08),
+				color: $warning-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-warning': (
+			extend: '%clay-dark-btn-translucent-warning',
+		),
+		'.clay-dark.btn-translucent.btn-warning': (
+			extend: '%clay-dark-btn-translucent-warning',
+		),
+		'%clay-dark-btn-translucent-danger': (
+			background-color: rgba($danger-l2, 0.04),
+			border-color: transparent,
+			color: $danger-l1,
+			hover: (
+				background-color: rgba($danger-l2, 0.06),
+				color: $danger-l1,
+			),
+			focus: (
+				background-color: rgba($danger-l2, 0.06),
+				color: $danger-l1,
+			),
+			active: (
+				background-color: rgba($danger-l2, 0.08),
+				color: $danger-l1,
+			),
+		),
+		'.clay-dark .btn-translucent.btn-danger': (
+			extend: '%clay-dark-btn-translucent-danger',
+		),
+		'.clay-dark.btn-translucent.btn-danger': (
+			extend: '%clay-dark-btn-translucent-danger',
 		),
 	),
 	$btn-palette


### PR DESCRIPTION
Edit: We need to follow this up with https://liferay.atlassian.net/browse/LPS-201347 and remove beta variants.

https://liferay.atlassian.net/browse/LPS-198003

This adds translucent buttons and badges. I decided to stick with `.btn-translucent` and `.btn-translucent.btn-info`, instead of something like `.btn-translucent-info`. I think it will be easier to implement on the JS side.

For the dark variants, I did something different and want some feedback whether it's a good idea. We keep the class names the same,`.btn-translucent.btn-info`, but qualify it with `.clay-dark` on the parent element or component. This will apply dark styles to everything inside. I noticed we are shifting to be more accommodating with user preferences maybe can provide the dark theme version similar to cadmin by adding `.clay-dark` to the parent.

![button-translucent](https://github.com/liferay/clay/assets/788266/0769ac75-c8ba-42ec-a0a0-8f8af9ebeb0d)


![badge-translucent](https://github.com/liferay/clay/assets/788266/dd95f888-fbf2-44ef-82a9-eb720c31ada9)
