### PR TITLE
feat(@clayui/table): updates the table look

### DIFF
--- a/packages/clay-core/src/table/Cell.tsx
+++ b/packages/clay-core/src/table/Cell.tsx
@@ -114,7 +114,8 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 			onFocusChange: setIsFocused,
 		});
 		const scope = useScope();
-		const {expandable, isLoading, key, lazy, level, loadMore} = useRow();
+		const {divider, expandable, isLoading, key, lazy, level, loadMore} =
+			useRow();
 
 		const isHead = scope === Scope.Head;
 		const As = isHead ? 'th' : 'td';
@@ -160,6 +161,7 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 					'table-focus': focusWithinProps.tabIndex === 0 && isFocused,
 					'table-head-title': isHead,
 				})}
+				colSpan={divider ? 9 : undefined}
 				data-id={
 					typeof keyValue === 'number'
 						? `number,${keyValue}`

--- a/packages/clay-core/src/table/Row.tsx
+++ b/packages/clay-core/src/table/Row.tsx
@@ -97,7 +97,7 @@ function RowInner<T extends Record<string, any>>(
 		children,
 		className,
 		delimiter,
-		divider,
+		divider = false,
 		items,
 		keyValue,
 		lazy = false,
@@ -203,6 +203,7 @@ function RowInner<T extends Record<string, any>>(
 		>
 			<RowContext.Provider
 				value={{
+					divider,
 					expandable: _expandable,
 					isLoading,
 					key: keyValue!,

--- a/packages/clay-core/src/table/Table.tsx
+++ b/packages/clay-core/src/table/Table.tsx
@@ -69,6 +69,11 @@ export type Props = {
 	 * Flag to indicate which key name matches the nested rendering of the tree.
 	 */
 	nestedKey?: string;
+
+	/**
+	 * Defines the size of the table.
+	 */
+	size?: 'sm' | 'lg';
 } & React.ComponentProps<typeof RootTable>;
 
 const focusableElements = ['[role="row"]', 'td[role="gridcell"]'];
@@ -94,6 +99,7 @@ export const Table = React.forwardRef<HTMLDivElement, Props>(
 			onExpandedChange,
 			onLoadMore,
 			onSortChange,
+			size,
 			sort: externalSort,
 			nestedKey,
 			...otherProps
@@ -137,6 +143,7 @@ export const Table = React.forwardRef<HTMLDivElement, Props>(
 				{...navigationProps}
 				className={classNames(className, {
 					'table-nested-rows': nestedKey,
+					[`table-${size}`]: size,
 				})}
 				ref={ref}
 				role={nestedKey ? 'treegrid' : undefined}

--- a/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -6,7 +6,7 @@ exports[`Table basic rendering render dynamic content 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead>
         <tr>
@@ -105,7 +105,7 @@ exports[`Table basic rendering render static content 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead>
         <tr>
@@ -204,7 +204,7 @@ exports[`Table basic rendering render with sort column 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead>
         <tr>
@@ -330,7 +330,7 @@ exports[`Table basic rendering render with treegrid 1`] = `
   >
     <table
       aria-label="File Explorer"
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-nested-rows"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped table-nested-rows"
       role="treegrid"
     >
       <thead>

--- a/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -6,7 +6,7 @@ exports[`Table basic rendering render dynamic content 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead>
         <tr>
@@ -105,7 +105,7 @@ exports[`Table basic rendering render static content 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead>
         <tr>
@@ -204,7 +204,7 @@ exports[`Table basic rendering render with sort column 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead>
         <tr>
@@ -330,7 +330,7 @@ exports[`Table basic rendering render with treegrid 1`] = `
   >
     <table
       aria-label="File Explorer"
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped table-nested-rows"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped table-nested-rows"
       role="treegrid"
     >
       <thead>

--- a/packages/clay-core/src/table/context.tsx
+++ b/packages/clay-core/src/table/context.tsx
@@ -29,6 +29,7 @@ export function useTable() {
 }
 
 type RowContext = {
+	divider: boolean;
 	expandable?: boolean;
 	isLoading: boolean;
 	key: React.Key;
@@ -38,6 +39,7 @@ type RowContext = {
 };
 
 export const RowContext = React.createContext<RowContext>({
+	divider: false,
 	isLoading: false,
 	key: 0,
 	lazy: false,

--- a/packages/clay-core/stories/Table.stories.tsx
+++ b/packages/clay-core/stories/Table.stories.tsx
@@ -72,7 +72,7 @@ export const Dynamic = () => {
 				{(column) => <Cell key={column.id}>{column.name}</Cell>}
 			</Head>
 
-			<Body items={rows}>
+			<Body defaultItems={rows}>
 				{(row) => (
 					<Row>
 						<Cell>{row.name}</Cell>

--- a/packages/clay-core/stories/Table.stories.tsx
+++ b/packages/clay-core/stories/Table.stories.tsx
@@ -118,6 +118,46 @@ export const DynamicCells = () => {
 	);
 };
 
+export const Sections = () => {
+	return (
+		<Table>
+			<Head items={columns}>
+				<Cell key="name">Name</Cell>
+				<Cell key="type">Type</Cell>
+			</Head>
+
+			<Body>
+				<Row divider>
+					<Cell>Folders</Cell>
+				</Row>
+				<Row>
+					<Cell>Games</Cell>
+					<Cell>File folder</Cell>
+				</Row>
+				<Row>
+					<Cell>Program Files</Cell>
+					<Cell>File folder</Cell>
+				</Row>
+				<Row>
+					<Cell>Core</Cell>
+					<Cell>File folder</Cell>
+				</Row>
+				<Row divider>
+					<Cell>Folders</Cell>
+				</Row>
+				<Row>
+					<Cell>Games</Cell>
+					<Cell>File folder</Cell>
+				</Row>
+				<Row>
+					<Cell>Program Files</Cell>
+					<Cell>File folder</Cell>
+				</Row>
+			</Body>
+		</Table>
+	);
+};
+
 type Sorting = {
 	column: React.Key;
 	direction: 'ascending' | 'descending';

--- a/packages/clay-css/src/scss/atlas/variables/_tables.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tables.scss
@@ -1,5 +1,5 @@
 $table-bg: $white !default;
-$table-accent-bg: $gray-100 !default;
+$table-accent-bg: $light-l1 !default;
 $table-hover-bg: clay-lighten($component-active-bg, 44.9) !default;
 $table-border-color: $gray-300 !default;
 $table-font-size: 0.875rem !default;
@@ -38,11 +38,10 @@ $c-table-tfoot: () !default;
 
 $table-caption-color: $gray-900 !default;
 
-$table-divider-bg: $gray-100 !default;
+$table-divider-bg: $gray-200 !default;
 $table-divider-color: $gray-600 !default;
 $table-divider-font-size: 0.75rem !default; // 12px
 $table-divider-font-weight: $font-weight-semi-bold !default;
-$table-divider-padding: 0.4375rem 0.75rem !default;
 $table-divider-text-transform: uppercase !default;
 
 $table-quick-action-menu-accent-bg: $table-accent-bg !default;
@@ -169,9 +168,6 @@ $table-list-active-bg: $table-list-hover-bg !default;
 $table-list-disabled-color: $gray-500 !default;
 
 $table-list-head-bg: $white !default;
-
-$table-list-divider-padding-x: 0.75rem !default; // 12px
-$table-list-divider-padding-y: 0.4375rem !default; // 7px
 
 // Table List Title
 

--- a/packages/clay-css/src/scss/cadmin/components/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_tables.scss
@@ -37,6 +37,12 @@ caption {
 	caption-side: bottom;
 }
 
+// Table Lg
+
+.table-lg {
+	@include clay-table-variant($cadmin-c-table-lg);
+}
+
 // Table Sm
 
 .table-sm {

--- a/packages/clay-css/src/scss/cadmin/components/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_tables.scss
@@ -49,6 +49,10 @@ caption {
 	@include clay-table-variant($cadmin-c-table-bordered);
 }
 
+.table-head-bordered {
+	@include clay-table-variant($cadmin-c-table-head-bordered);
+}
+
 .table-borderless {
 	th,
 	td,

--- a/packages/clay-css/src/scss/cadmin/components/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_tables.scss
@@ -43,6 +43,12 @@ caption {
 	@include clay-table-variant($cadmin-c-table-lg);
 }
 
+// Table Md
+
+.table-md {
+	@include clay-table-variant($cadmin-c-table-md);
+}
+
 // Table Sm
 
 .table-sm {
@@ -72,9 +78,12 @@ caption {
 
 .table-striped {
 	tbody tr:nth-of-type(#{$cadmin-table-striped-order}) {
-		td,
-		th {
-			background-color: $cadmin-table-accent-bg;
+		&:not(.table-active):not(.table-disabled):not(.table-divider) {
+			&,
+			td,
+			th {
+				background-color: $cadmin-table-accent-bg;
+			}
 		}
 	}
 }
@@ -137,17 +146,6 @@ td.table-focus {
 	@include clay-css($cadmin-c-td-table-focus);
 }
 
-// Table Row Backgrounds
-
-.table-striped {
-	tbody .table-disabled:nth-of-type(#{$cadmin-table-striped-order}) {
-		td,
-		th {
-			background-color: $cadmin-table-disabled-bg;
-		}
-	}
-}
-
 // Dark styles
 
 .table {
@@ -184,7 +182,13 @@ td.table-focus {
 
 	&.table-striped {
 		tbody tr:nth-of-type(#{$cadmin-table-striped-order}) {
-			background-color: $cadmin-table-dark-accent-bg;
+			&:not(.table-active):not(.table-disabled):not(.table-divider) {
+				&,
+				th,
+				td {
+					background-color: $cadmin-table-dark-accent-bg;
+				}
+			}
 		}
 	}
 
@@ -264,9 +268,12 @@ td.table-focus {
 
 .table-list.table-striped {
 	tbody tr:nth-of-type(#{$cadmin-table-striped-order}) {
-		td,
-		th {
-			background-color: $cadmin-table-list-accent-bg;
+		&:not(.table-active):not(.table-disabled):not(.table-divider) {
+			&,
+			td,
+			th {
+				background-color: $cadmin-table-list-accent-bg;
+			}
 		}
 	}
 }
@@ -275,18 +282,6 @@ td.table-focus {
 
 .table-list.table-hover {
 	@include clay-table-variant($cadmin-c-table-list-table-hover);
-}
-
-// Table List Disabled
-
-.table-list.table-striped {
-	tbody .table-disabled:nth-of-type(#{$cadmin-table-striped-order}) {
-		&,
-		td,
-		th {
-			background-color: $cadmin-table-list-disabled-bg;
-		}
-	}
 }
 
 // Table List Title

--- a/packages/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -560,6 +560,23 @@ $cadmin-table-dark-hover-color: $cadmin-table-dark-color !default;
 
 $cadmin-table-dark-accent-bg: rgba($cadmin-white, 0.05) !default;
 
+// .table-head-bordered
+
+$cadmin-c-table-head-bordered: () !default;
+$cadmin-c-table-head-bordered: map-deep-merge(
+	(
+		thead: (
+			table-cell: (
+				border-left: $cadmin-table-border-width solid $cadmin-table-border-color,
+				start: (
+					border-left-width: 0,
+				),
+			),
+		),
+	),
+	$cadmin-c-table-head-bordered
+);
+
 // .table-bordered
 
 $cadmin-table-bordered-border-width: $cadmin-table-border-width !default;

--- a/packages/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -567,7 +567,8 @@ $cadmin-c-table-head-bordered: map-deep-merge(
 	(
 		thead: (
 			table-cell: (
-				border-left: $cadmin-table-border-width solid $cadmin-table-border-color,
+				border-left: $cadmin-table-border-width solid
+					$cadmin-table-border-color,
 				start: (
 					border-left-width: 0,
 				),

--- a/packages/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -54,7 +54,8 @@ $cadmin-table-striped-order: odd !default;
 // Table Cell applies to `th` and `td`
 
 $cadmin-table-cell-gutters: $cadmin-grid-gutter-width * 0.5 !default; // 15px
-$cadmin-table-cell-padding: 12px !default;
+$cadmin-table-cell-padding-lg: 17px !default;
+$cadmin-table-cell-padding: 13px !default;
 $cadmin-table-cell-padding-sm: 4.8px !default;
 
 $cadmin-table-cell-expand-min-width: 200px !default; // 200px
@@ -495,6 +496,18 @@ $cadmin-c-td-table-focus: map-deep-merge(
 			clay-enable-shadows($cadmin-component-focus-inset-box-shadow),
 	),
 	$cadmin-c-td-table-focus
+);
+
+// .table-lg
+
+$cadmin-c-table-lg: () !default;
+$cadmin-c-table-lg: map-deep-merge(
+	(
+		table-cell: (
+			padding: $cadmin-table-cell-padding-lg,
+		),
+	),
+	$cadmin-c-table-lg
 );
 
 // .table-sm

--- a/packages/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -47,16 +47,16 @@ $cadmin-table-disabled-pointer-events: none !default;
 
 // Table Striped
 
-$cadmin-table-accent-bg: $cadmin-gray-100 !default;
+$cadmin-table-accent-bg: $cadmin-light-l1 !default;
 
 $cadmin-table-striped-order: odd !default;
 
 // Table Cell applies to `th` and `td`
 
-$cadmin-table-cell-gutters: $cadmin-grid-gutter-width * 0.5 !default; // 15px
+$cadmin-table-cell-gutters: 20px !default;
 $cadmin-table-cell-padding-lg: 17px !default;
-$cadmin-table-cell-padding: 13px !default;
-$cadmin-table-cell-padding-sm: 4.8px !default;
+$cadmin-table-cell-padding: 8px 16px !default;
+$cadmin-table-cell-padding-sm: 4px 16px !default;
 
 $cadmin-table-cell-expand-min-width: 200px !default; // 200px
 
@@ -77,7 +77,7 @@ $cadmin-table-head-border-top-width: 0 !default;
 $cadmin-table-head-color: $cadmin-gray-600 !default;
 $cadmin-table-head-font-size: null !default;
 $cadmin-table-head-font-weight: $cadmin-font-weight-semi-bold !default;
-$cadmin-table-head-height: 36px !default;
+$cadmin-table-head-height: 56px !default;
 
 $cadmin-c-table-thead: () !default;
 
@@ -120,11 +120,11 @@ $cadmin-table-data-vertical-align: middle !default;
 
 // Table Divider
 
-$cadmin-table-divider-bg: $cadmin-gray-100 !default;
+$cadmin-table-divider-bg: $cadmin-gray-200 !default;
 $cadmin-table-divider-color: $cadmin-gray-600 !default;
 $cadmin-table-divider-font-size: 12px !default; // 12px
 $cadmin-table-divider-font-weight: $cadmin-font-weight-semi-bold !default;
-$cadmin-table-divider-padding: 7px 12px !default;
+$cadmin-table-divider-padding: 8px 16px 8px $cadmin-table-cell-gutters !default;
 $cadmin-table-divider-text-transform: uppercase !default;
 
 $cadmin-table-quick-action-menu-align-items: flex-start !default;
@@ -156,8 +156,8 @@ $cadmin-c-table-caption: () !default;
 $cadmin-c-table-caption: map-merge(
 	(
 		caption-side: top,
-		padding-left: $cadmin-table-cell-padding,
-		padding-right: $cadmin-table-cell-padding,
+		padding-left: nth($cadmin-table-cell-padding, 2),
+		padding-right: nth($cadmin-table-cell-padding, 2),
 	),
 	$cadmin-c-table-caption
 );
@@ -276,7 +276,7 @@ $cadmin-c-table: map-deep-merge(
 						border-bottom: $cadmin-table-head-border-bottom-width
 							solid $cadmin-table-border-color,
 						border-top-width: $cadmin-table-head-border-top-width,
-						vertical-align: bottom,
+						vertical-align: middle,
 					),
 					th: (
 						href: $cadmin-table-head-link,
@@ -286,9 +286,6 @@ $cadmin-c-table: map-deep-merge(
 		table-column-start: (
 			padding-left: $cadmin-table-cell-gutters,
 		),
-		table-column-end: (
-			padding-right: $cadmin-table-cell-gutters,
-		),
 		th: (
 			background-clip: padding-box,
 			border-top: $cadmin-table-border-width solid
@@ -296,7 +293,7 @@ $cadmin-c-table: map-deep-merge(
 			color: $cadmin-table-head-color,
 			font-size: $cadmin-table-head-font-size,
 			font-weight: $cadmin-table-head-font-weight,
-			height: $cadmin-table-head-height,
+			height: 56px,
 			padding: $cadmin-table-cell-padding,
 			position: relative,
 			vertical-align: top,
@@ -309,6 +306,7 @@ $cadmin-c-table: map-deep-merge(
 			border-right-width: $cadmin-table-data-border-right-width,
 			border-style: $cadmin-table-data-border-style,
 			border-top-width: $cadmin-table-data-border-top-width,
+			height: 56px,
 			padding: $cadmin-table-cell-padding,
 			position: relative,
 			vertical-align: $cadmin-table-data-vertical-align,
@@ -328,11 +326,13 @@ $cadmin-c-table: map-deep-merge(
 		tfoot: $cadmin-c-table-tfoot,
 		caption: $cadmin-c-table-caption,
 		table-divider: (
-			background-color: $cadmin-table-divider-bg,
 			table-cell: (
+				background-color: $cadmin-table-divider-bg,
 				color: $cadmin-table-divider-color,
 				font-size: $cadmin-table-divider-font-size,
 				font-weight: $cadmin-table-divider-font-weight,
+				height: 34px,
+				line-height: 17px,
 				padding: $cadmin-table-divider-padding,
 				text-transform: $cadmin-table-divider-text-transform,
 			),
@@ -362,8 +362,8 @@ $cadmin-c-table: map-deep-merge(
 		),
 		autofit-col: (
 			justify-content: center,
-			padding-left: $cadmin-table-cell-padding,
-			padding-right: $cadmin-table-cell-padding,
+			padding-left: nth($cadmin-table-cell-padding, 2),
+			padding-right: nth($cadmin-table-cell-padding, 2),
 			first-child: (
 				padding-left: 0,
 			),
@@ -385,8 +385,8 @@ $cadmin-c-table: map-deep-merge(
 		quick-action-menu: (
 			align-items: $cadmin-table-quick-action-menu-align-items,
 			background-color: $cadmin-table-quick-action-menu-bg,
-			padding-bottom: $cadmin-table-cell-padding,
-			padding-top: $cadmin-table-cell-padding,
+			padding-bottom: nth($cadmin-table-cell-padding, 1),
+			padding-top: nth($cadmin-table-cell-padding, 1),
 		),
 	),
 	$cadmin-c-table
@@ -510,12 +510,26 @@ $cadmin-c-table-lg: map-deep-merge(
 	$cadmin-c-table-lg
 );
 
+// .table-md
+
+$cadmin-c-table-md: () !default;
+$cadmin-c-table-md: map-deep-merge(
+	(
+		table-cell: (
+			height: 48px,
+			padding: 6px 16px,
+		),
+	),
+	$cadmin-c-table-md
+);
+
 // .table-sm
 
 $cadmin-c-table-sm: () !default;
 $cadmin-c-table-sm: map-deep-merge(
 	(
 		table-cell: (
+			height: 32px,
 			padding: $cadmin-table-cell-padding-sm,
 		),
 	),
@@ -527,12 +541,6 @@ $cadmin-c-table-sm: map-deep-merge(
 $cadmin-c-table-nested-rows: () !default;
 $cadmin-c-table-nested-rows: map-deep-merge(
 	(
-		table-column-start: (
-			padding-left: 20px,
-		),
-		table-column-end: (
-			padding-right: 20px,
-		),
 		autofit-col: (
 			padding-left: 2px,
 			padding-right: 2px,
@@ -582,7 +590,7 @@ $cadmin-c-table-head-bordered: map-deep-merge(
 			table-cell: (
 				border-left: $cadmin-table-border-width solid
 					$cadmin-table-border-color,
-				start: (
+				table-column-start: (
 					border-left-width: 0,
 				),
 			),
@@ -719,8 +727,8 @@ $cadmin-c-table-list-caption: () !default;
 
 // .table-list .table-divider
 
-$cadmin-table-list-divider-padding-x: 12px !default; // 12px
-$cadmin-table-list-divider-padding-y: 7px !default; // 7px
+$cadmin-table-list-divider-padding-x: 16px !default;
+$cadmin-table-list-divider-padding-y: 8px !default;
 
 // .table-list .quick-action-menu
 
@@ -874,7 +882,7 @@ $cadmin-c-table-list: map-merge(
 		table-divider: (
 			table-cell: (
 				padding-bottom: $cadmin-table-list-divider-padding-y,
-				padding-left: $cadmin-table-list-divider-padding-x,
+				padding-left: $cadmin-table-cell-gutters,
 				padding-right: $cadmin-table-list-divider-padding-x,
 				padding-top: $cadmin-table-list-divider-padding-y,
 			),

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -49,6 +49,10 @@ caption {
 	@include clay-table-variant($c-table-bordered);
 }
 
+.table-head-bordered {
+	@include clay-table-variant($c-table-head-bordered);
+}
+
 .table-borderless {
 	th,
 	td,

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -43,6 +43,12 @@ caption {
 	@include clay-table-variant($c-table-lg);
 }
 
+// Table Md
+
+.table-md {
+	@include clay-table-variant($c-table-md);
+}
+
 // Table Sm
 
 .table-sm {
@@ -72,9 +78,12 @@ caption {
 
 .table-striped {
 	tbody tr:nth-of-type(#{$table-striped-order}) {
-		td,
-		th {
-			background-color: $table-accent-bg;
+		&:not(.table-active):not(.table-disabled):not(.table-divider) {
+			&,
+			td,
+			th {
+				background-color: $table-accent-bg;
+			}
 		}
 	}
 }
@@ -186,17 +195,6 @@ td.table-focus {
 	}
 }
 
-// Table Disabled
-
-.table-striped {
-	tbody .table-disabled:nth-of-type(#{$table-striped-order}) {
-		td,
-		th {
-			background-color: $table-disabled-bg;
-		}
-	}
-}
-
 // Dark styles
 
 .table {
@@ -233,7 +231,13 @@ td.table-focus {
 
 	&.table-striped {
 		tbody tr:nth-of-type(#{$table-striped-order}) {
-			background-color: $table-dark-accent-bg;
+			&:not(.table-active):not(.table-disabled):not(.table-divider) {
+				&,
+				th,
+				td {
+					background-color: $table-dark-accent-bg;
+				}
+			}
 		}
 	}
 
@@ -306,9 +310,12 @@ td.table-focus {
 
 .table-list.table-striped {
 	tbody tr:nth-of-type(#{$table-striped-order}) {
-		td,
-		th {
-			background-color: $table-list-accent-bg;
+		&:not(.table-active):not(.table-disabled):not(.table-divider) {
+			&,
+			th,
+			td {
+				background-color: $table-list-accent-bg;
+			}
 		}
 	}
 }
@@ -317,16 +324,6 @@ td.table-focus {
 
 .table-list.table-hover {
 	@include clay-table-variant($c-table-list-table-hover);
-}
-
-.table-list.table-striped {
-	tbody .table-disabled:nth-of-type(#{$table-striped-order}) {
-		&,
-		td,
-		th {
-			background-color: $table-list-disabled-bg;
-		}
-	}
 }
 
 // Table List Title

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -37,6 +37,12 @@ caption {
 	caption-side: bottom;
 }
 
+// Table lg
+
+.table-lg {
+	@include clay-table-variant($c-table-lg);
+}
+
 // Table Sm
 
 .table-sm {

--- a/packages/clay-css/src/scss/mixins/_tables.scss
+++ b/packages/clay-css/src/scss/mixins/_tables.scss
@@ -58,11 +58,30 @@
 			@include clay-css($map);
 
 			thead {
-				@include clay-css(map-get($map, thead));
+				$_thead: setter(map-get($map, thead), ());
+
+				@include clay-css($_thead);
 
 				th,
 				td {
-					@include clay-css(map-deep-get($map, thead, table-cell));
+					$_thead-table-cell: setter(
+						map-get($_thead, table-cell),
+						()
+					);
+
+					@include clay-css($_thead-table-cell);
+
+					&:first-child {
+						@include clay-css(
+							map-get($_thead-table-cell, table-column-start)
+						);
+					}
+
+					&:last-child {
+						@include clay-css(
+							map-get($_thead-table-cell, table-column-end)
+						);
+					}
 				}
 
 				th {
@@ -71,16 +90,6 @@
 					a[href] {
 						@include clay-link(map-deep-get($map, thead, th, href));
 					}
-				}
-
-				th:first-child,
-				td:first-child {
-					@include clay-css(map-get($map, thead, table-cell, start));
-				}
-
-				th:last-child,
-				td:last-child {
-					@include clay-css(map-get($map, thead, table-cell, end));
 				}
 			}
 

--- a/packages/clay-css/src/scss/mixins/_tables.scss
+++ b/packages/clay-css/src/scss/mixins/_tables.scss
@@ -72,6 +72,16 @@
 						@include clay-link(map-deep-get($map, thead, th, href));
 					}
 				}
+
+				th:first-child,
+				td:first-child {
+					@include clay-css(map-get($map, thead, table-cell, start));
+				}
+
+				th:last-child,
+				td:last-child {
+					@include clay-css(map-get($map, thead, table-cell, end));
+				}
 			}
 
 			th,

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -450,6 +450,23 @@ $c-td-table-focus: map-deep-merge(
 	$c-td-table-focus
 );
 
+// .table-head-bordered
+
+$c-table-head-bordered: () !default;
+$c-table-head-bordered: map-deep-merge(
+	(
+		thead: (
+			table-cell: (
+				border-left: $table-border-width solid $table-border-color,
+				start: (
+					border-left-width: 0,
+				),
+			),
+		),
+	),
+	$c-table-head-bordered
+);
+
 // .table-bordered
 
 $table-bordered-border-width: $table-border-width !default;

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -52,9 +52,9 @@ $table-striped-order: odd !default;
 
 // Table Cell applies to `th` and `td`
 
-$table-cell-gutters: $grid-gutter-width * 0.5 !default; // 15px
-$table-cell-padding: 0.813rem !default;
-$table-cell-padding-sm: 0.3rem !default;
+$table-cell-gutters: 1.25rem !default;
+$table-cell-padding: 0.5rem 1rem !default;
+$table-cell-padding-sm: 0.25rem 1rem !default;
 $table-cell-padding-lg: 1.0625rem !default;
 
 $table-cell-expand-min-width: 12.5rem !default; // 200px
@@ -76,7 +76,7 @@ $table-head-border-top-width: 0px !default;
 $table-head-color: $gray-700 !default;
 $table-head-font-size: null !default;
 $table-head-font-weight: null !default;
-$table-head-height: 36px !default;
+$table-head-height: 56px !default;
 
 $c-table-thead: () !default;
 
@@ -108,7 +108,7 @@ $table-divider-bg: $white !default;
 $table-divider-color: null !default;
 $table-divider-font-weight: null !default;
 $table-divider-font-size: null !default;
-$table-divider-padding: $table-cell-padding !default;
+$table-divider-padding: 0.5rem 1rem 0.5rem 1.25rem !default;
 $table-divider-text-transform: null !default;
 
 $table-quick-action-menu-align-items: flex-start !default;
@@ -140,8 +140,8 @@ $c-table-caption: () !default;
 $c-table-caption: map-merge(
 	(
 		caption-side: top,
-		padding-left: $table-cell-padding,
-		padding-right: $table-cell-padding,
+		padding-left: nth($table-cell-padding, 2),
+		padding-right: nth($table-cell-padding, 2),
 	),
 	$c-table-caption
 );
@@ -241,7 +241,7 @@ $c-table: map-deep-merge(
 						border-bottom: $table-head-border-bottom-width solid
 							$table-border-color,
 						border-top-width: $table-head-border-top-width,
-						vertical-align: bottom,
+						vertical-align: middle,
 					),
 					th: (
 						href: $table-head-link,
@@ -250,9 +250,6 @@ $c-table: map-deep-merge(
 			),
 		table-column-start: (
 			padding-left: $table-cell-gutters,
-		),
-		table-column-end: (
-			padding-right: $table-cell-gutters,
 		),
 		th: (
 			background-clip: padding-box,
@@ -273,6 +270,7 @@ $c-table: map-deep-merge(
 			border-right-width: $table-data-border-right-width,
 			border-style: $table-data-border-style,
 			border-top-width: $table-data-border-top-width,
+			height: 56px,
 			padding: $table-cell-padding,
 			position: relative,
 			vertical-align: $table-data-vertical-align,
@@ -290,11 +288,13 @@ $c-table: map-deep-merge(
 		tfoot: $c-table-tfoot,
 		caption: $c-table-caption,
 		table-divider: (
-			background-color: $table-divider-bg,
 			table-cell: (
+				background-color: $table-divider-bg,
 				color: $table-divider-color,
 				font-size: $table-divider-font-size,
 				font-weight: $table-divider-font-weight,
+				height: 34px,
+				line-height: 17px,
 				padding: $table-divider-padding,
 				text-transform: $table-divider-text-transform,
 			),
@@ -324,8 +324,8 @@ $c-table: map-deep-merge(
 		),
 		autofit-col: (
 			justify-content: center,
-			padding-left: $table-cell-padding,
-			padding-right: $table-cell-padding,
+			padding-left: nth($table-cell-padding, 2),
+			padding-right: nth($table-cell-padding, 2),
 			first-child: (
 				padding-left: 0,
 			),
@@ -347,8 +347,8 @@ $c-table: map-deep-merge(
 		quick-action-menu: (
 			align-items: $table-quick-action-menu-align-items,
 			background-color: $table-quick-action-menu-bg,
-			padding-bottom: $table-cell-padding,
-			padding-top: $table-cell-padding,
+			padding-bottom: nth($table-cell-padding, 1),
+			padding-top: nth($table-cell-padding, 1),
 		),
 	),
 	$c-table
@@ -459,7 +459,7 @@ $c-table-head-bordered: map-deep-merge(
 		thead: (
 			table-cell: (
 				border-left: $table-border-width solid $table-border-color,
-				start: (
+				table-column-start: (
 					border-left-width: 0,
 				),
 			),
@@ -494,10 +494,24 @@ $c-table-sm: () !default;
 $c-table-sm: map-deep-merge(
 	(
 		table-cell: (
+			height: 32px,
 			padding: $table-cell-padding-sm,
 		),
 	),
 	$c-table-sm
+);
+
+// .table-md
+
+$c-table-md: () !default;
+$c-table-md: map-deep-merge(
+	(
+		table-cell: (
+			height: 48px,
+			padding: 0.375rem 1rem,
+		),
+	),
+	$c-table-md
 );
 
 // .table-lg
@@ -517,12 +531,6 @@ $c-table-lg: map-deep-merge(
 $c-table-nested-rows: () !default;
 $c-table-nested-rows: map-deep-merge(
 	(
-		table-column-start: (
-			padding-left: 1.25rem,
-		),
-		table-column-end: (
-			padding-right: 1.25rem,
-		),
 		autofit-col: (
 			padding-left: 0.125rem,
 			padding-right: 0.125rem,
@@ -684,8 +692,8 @@ $c-table-list-caption: () !default;
 
 // .table-list .table-divider
 
-$table-list-divider-padding-x: 0.75rem !default;
-$table-list-divider-padding-y: 0.75rem !default;
+$table-list-divider-padding-x: 1rem !default;
+$table-list-divider-padding-y: 0.5rem !default;
 
 // .table-list .quick-action-menu
 
@@ -812,7 +820,7 @@ $c-table-list: map-merge(
 		table-divider: (
 			table-cell: (
 				padding-bottom: $table-list-divider-padding-y,
-				padding-left: $table-list-divider-padding-x,
+				padding-left: 1.25rem,
 				padding-right: $table-list-divider-padding-x,
 				padding-top: $table-list-divider-padding-y,
 			),

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -53,8 +53,9 @@ $table-striped-order: odd !default;
 // Table Cell applies to `th` and `td`
 
 $table-cell-gutters: $grid-gutter-width * 0.5 !default; // 15px
-$table-cell-padding: 0.75rem !default;
+$table-cell-padding: 0.813rem !default;
 $table-cell-padding-sm: 0.3rem !default;
+$table-cell-padding-lg: 1.0625rem !default;
 
 $table-cell-expand-min-width: 12.5rem !default; // 200px
 
@@ -497,6 +498,18 @@ $c-table-sm: map-deep-merge(
 		),
 	),
 	$c-table-sm
+);
+
+// .table-lg
+
+$c-table-lg: () !default;
+$c-table-lg: map-deep-merge(
+	(
+		table-cell: (
+			padding: $table-cell-padding-lg,
+		),
+	),
+	$c-table-lg
 );
 
 // .table-nested-rows

--- a/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
@@ -6,7 +6,7 @@ exports[`ClayTable renders 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     />
   </div>
 </div>
@@ -18,7 +18,7 @@ exports[`ClayTable renders a Cell delimited 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead>
         <tr
@@ -65,7 +65,7 @@ exports[`ClayTable renders a Cell with text alignment set to center 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead>
         <tr
@@ -94,7 +94,7 @@ exports[`ClayTable renders a full bottom vertical aligned table 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped thead-valign-bottom table-valign-bottom"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped thead-valign-bottom table-valign-bottom"
     >
       <thead />
       <tbody />
@@ -109,7 +109,7 @@ exports[`ClayTable renders a no wrapped table 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-heading-nowrap table-hover table-list table-nowrap table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-heading-nowrap table-hover table-list table-head-bordered table-nowrap table-striped"
     >
       <thead />
       <tbody />
@@ -124,7 +124,7 @@ exports[`ClayTable renders a responsive table 1`] = `
     class="table-responsive table-responsive-sm"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead />
       <tbody />
@@ -139,7 +139,7 @@ exports[`ClayTable renders a responsive table 2`] = `
     class="table-responsive table-responsive-sm"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead />
       <tbody />
@@ -154,7 +154,7 @@ exports[`ClayTable renders a table hover 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead />
       <tbody />
@@ -169,7 +169,7 @@ exports[`ClayTable renders a table striped 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead />
       <tbody />
@@ -184,7 +184,7 @@ exports[`ClayTable renders a table with a Body 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <tbody />
     </table>
@@ -198,7 +198,7 @@ exports[`ClayTable renders a table with a Head 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead />
     </table>
@@ -212,7 +212,7 @@ exports[`ClayTable renders a table with a Head and Body 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead />
       <tbody />
@@ -227,7 +227,7 @@ exports[`ClayTable renders a table with an active row 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <tbody>
         <tr
@@ -245,7 +245,7 @@ exports[`ClayTable renders a table with columns bordered 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-bordered table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-bordered table-hover table-list table-head-bordered table-striped"
     >
       <thead />
       <tbody />
@@ -260,7 +260,7 @@ exports[`ClayTable renders a table with multiple Cells into Row 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <tbody>
         <tr
@@ -298,7 +298,7 @@ exports[`ClayTable renders a table with multiple rows into Body 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <tbody>
         <tr
@@ -322,7 +322,7 @@ exports[`ClayTable renders a table with multiple rows into Head 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <thead>
         <tr
@@ -346,7 +346,7 @@ exports[`ClayTable renders with a headingTitle 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <tbody>
         <tr
@@ -397,7 +397,7 @@ exports[`ClayTable renders with non wrapped cells 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
     >
       <tbody>
         <tr

--- a/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
@@ -6,7 +6,7 @@ exports[`ClayTable renders 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     />
   </div>
 </div>
@@ -94,7 +94,7 @@ exports[`ClayTable renders a full bottom vertical aligned table 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list thead-valign-bottom table-valign-bottom"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped thead-valign-bottom table-valign-bottom"
     >
       <thead />
       <tbody />
@@ -109,7 +109,7 @@ exports[`ClayTable renders a no wrapped table 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-heading-nowrap table-hover table-list table-nowrap"
+      class="table table-autofit show-quick-actions-on-hover table-heading-nowrap table-hover table-list table-nowrap table-striped"
     >
       <thead />
       <tbody />
@@ -124,7 +124,7 @@ exports[`ClayTable renders a responsive table 1`] = `
     class="table-responsive table-responsive-sm"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead />
       <tbody />
@@ -139,7 +139,7 @@ exports[`ClayTable renders a responsive table 2`] = `
     class="table-responsive table-responsive-sm"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead />
       <tbody />
@@ -154,7 +154,7 @@ exports[`ClayTable renders a table hover 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead />
       <tbody />
@@ -184,7 +184,7 @@ exports[`ClayTable renders a table with a Body 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <tbody />
     </table>
@@ -198,7 +198,7 @@ exports[`ClayTable renders a table with a Head 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead />
     </table>
@@ -212,7 +212,7 @@ exports[`ClayTable renders a table with a Head and Body 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead />
       <tbody />
@@ -227,7 +227,7 @@ exports[`ClayTable renders a table with an active row 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <tbody>
         <tr
@@ -245,7 +245,7 @@ exports[`ClayTable renders a table with columns bordered 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-bordered table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-bordered table-hover table-list table-striped"
     >
       <thead />
       <tbody />
@@ -260,7 +260,7 @@ exports[`ClayTable renders a table with multiple Cells into Row 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <tbody>
         <tr
@@ -298,7 +298,7 @@ exports[`ClayTable renders a table with multiple rows into Body 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <tbody>
         <tr
@@ -322,7 +322,7 @@ exports[`ClayTable renders a table with multiple rows into Head 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead>
         <tr
@@ -346,7 +346,7 @@ exports[`ClayTable renders with a headingTitle 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <tbody>
         <tr
@@ -397,7 +397,7 @@ exports[`ClayTable renders with non wrapped cells 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <tbody>
         <tr

--- a/packages/clay-table/src/index.tsx
+++ b/packages/clay-table/src/index.tsx
@@ -89,7 +89,7 @@ const ClayTable = React.forwardRef<HTMLDivElement, IProps>(
 			noWrap,
 			responsive = true,
 			responsiveSize,
-			striped,
+			striped = true,
 			tableVerticalAlignment,
 			...otherProps
 		}: IProps,

--- a/packages/clay-table/src/index.tsx
+++ b/packages/clay-table/src/index.tsx
@@ -111,7 +111,7 @@ const ClayTable = React.forwardRef<HTMLDivElement, IProps>(
 							'table-bordered': borderedColumns,
 							'table-heading-nowrap': headingNoWrap,
 							'table-hover': hover,
-							'table-list': !borderless,
+							'table-list table-head-bordered': !borderless,
 							'table-nowrap': noWrap,
 							'table-striped': striped,
 							[`tbody-valign-${bodyVerticalAlignment}`]:


### PR DESCRIPTION
From https://liferay.atlassian.net/wiki/spaces/PEDS/pages/2540961873/Border+Radius

With the changes in the new component and FDS initiative, this brought changes to the look of the table, such as striped by default and bordered which is only in the header, it also brought new sizes. This PR does not apply all these styles because we still need to work on the CSS part. This PR only introduces sections and striped.

### ToDo

- [x] New sizes and current update
- [x] New bordered for header only https://liferay.atlassian.net/browse/LPS-200555