### PR TITLE
fix(@clayui/core): fixes bug when rendering LiveAnnouncer on server side

### DIFF
--- a/packages/clay-core/src/live-announcer/LiveAnnouncer.tsx
+++ b/packages/clay-core/src/live-announcer/LiveAnnouncer.tsx
@@ -78,7 +78,7 @@ export const LiveAnnouncer = forwardRef<AnnouncerAPI>(function LiveAnnouncer(
 		[announce]
 	);
 
-	return createPortal(
+	const content = (
 		<VisuallyHidden liveAnnouncer>
 			<div aria-live="assertive" aria-relevant="additions" role="log">
 				{logs
@@ -94,7 +94,10 @@ export const LiveAnnouncer = forwardRef<AnnouncerAPI>(function LiveAnnouncer(
 						<div key={log.id}>{log.message}</div>
 					))}
 			</div>
-		</VisuallyHidden>,
-		document.body
+		</VisuallyHidden>
 	);
+
+	return typeof document !== 'undefined'
+		? createPortal(content, document.body)
+		: content;
 });


### PR DESCRIPTION
This is a report made by the Cloud team, they use server side rendering. So we need to check that we are not using the browser API when rendering on the server side.