### PR TITLE
LPS-202818 Update version

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_panels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_panels.scss
@@ -10,6 +10,9 @@ $panel-header-link: () !default;
 $panel-header-link: map-deep-merge(
 	(
 		transition: box-shadow 0.15s ease-in-out,
+		hover: (
+			text-decoration: $panel-header-link-hover-text-decoration,
+		),
 		focus: (
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
@@ -40,6 +43,23 @@ $panel-title-text-transform: uppercase !default;
 
 $panel-title-small-font-size: 100% !default;
 $panel-title-small-margin-left: 0.375rem !default; // 6px
+
+// Panel
+
+$panel: () !default;
+$panel: map-deep-merge(
+	(
+		panel-header: (
+			border-bottom: $panel-header-border-bottom-width solid transparent,
+			font-size: $panel-header-font-size,
+			collapsed: (
+				link: $panel-header-collapsed-link,
+			),
+			link: $panel-header-link,
+		),
+	),
+	$panel
+);
 
 // Panel Group Sm
 

--- a/packages/clay-css/src/scss/components/_panels.scss
+++ b/packages/clay-css/src/scss/components/_panels.scss
@@ -1,26 +1,11 @@
 .panel {
-	background-color: $panel-bg;
-	border-color: $panel-border-color;
-	border-style: $panel-border-style;
-	border-width: $panel-border-width;
-
-	@include border-radius($panel-border-radius);
-
-	margin-bottom: $panel-margin-bottom;
-	word-wrap: break-word;
+	@include clay-css($panel);
 }
 
 .panel-header {
-	border-bottom: $panel-header-border-bottom-width solid transparent;
+	$_header: setter(map-get($panel, panel-header), ());
 
-	@include border-top-radius($panel-header-offset-border-radius);
-
-	display: block;
-	font-size: $panel-header-font-size;
-	line-height: $panel-header-line-height;
-	padding: $panel-header-padding-y $panel-header-padding-x;
-	position: relative;
-	width: 100%;
+	@include clay-css($_header);
 
 	@if ($enable-c-inner) {
 		.c-inner {
@@ -31,12 +16,11 @@
 	}
 
 	&.collapsed {
-		@include border-bottom-radius($panel-header-offset-border-radius);
+		@include clay-css(map-get($_header, collapsed));
 	}
 
 	&.collapse-icon {
-		padding-left: $panel-header-collapse-icon-padding-left;
-		padding-right: $panel-header-collapse-icon-padding-right;
+		@include clay-css(map-get($_header, collapse-icon));
 
 		@if ($enable-c-inner) {
 			.c-inner {
@@ -47,6 +31,20 @@
 						$panel-header-collapse-icon-padding-right
 					)};
 			}
+		}
+	}
+
+	&.collapse-icon-middle {
+		$_collapse-icon-middle: setter(
+			map-get($panel, collapse-icon-middle),
+			()
+		);
+
+		@include clay-css($_collapse-icon-middle);
+
+		.collapse-icon-closed,
+		.collapse-icon-open {
+			@include clay-css(map-get($_collapse-icon-middle, collapse-icon));
 		}
 	}
 
@@ -61,10 +59,14 @@
 }
 
 .panel-header-link {
-	@include clay-link($panel-header-link);
+	$_header-link: setter(map-get($panel, panel-header), ());
+
+	@include clay-link(map-get($_header-link, link));
 
 	&.panel-header.collapsed {
-		@include clay-link($panel-header-collapsed-link);
+		$_header-collapsed: setter(map-get($_header-link, collapsed), ());
+
+		@include clay-link(map-get($_header-collapsed, link));
 	}
 
 	.collapse-icon {
@@ -82,25 +84,21 @@
 }
 
 .panel-body {
-	padding: $panel-body-padding-y $panel-header-padding-x;
+	@include clay-css(map-get($panel, panel-body));
 }
 
 .panel-footer {
-	@include border-bottom-radius($panel-footer-offset-border-radius);
-
-	border-top: $panel-footer-border-top-width solid transparent;
-	padding: $panel-footer-padding-y $panel-footer-padding-x;
+	@include clay-css(map-get($panel, panel-footer));
 }
 
 .panel-title {
-	font-size: $panel-title-font-size;
-	font-weight: $panel-title-font-weight;
-	text-transform: $panel-title-text-transform;
+	$_title: setter(map-get($panel, panel-title), ());
+
+	@include clay-css($_title);
 
 	small,
 	.small {
-		font-size: $panel-title-small-font-size;
-		margin-left: $panel-title-small-margin-left;
+		@include clay-css(map-get($_title, small));
 	}
 }
 
@@ -335,6 +333,28 @@
 
 // Panel Variants
 
+@each $color, $value in $panel-palette {
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			if(starts-with($color, 'panel'), str-insert($color, '.', 1), $color)
+		);
+
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-panel-variant($value);
+			}
+		} @else {
+			#{$selector} {
+				@include clay-panel-variant($value);
+			}
+		}
+	}
+}
+
 .panel-secondary {
 	@include clay-panel-variant($panel-secondary);
 }
@@ -343,4 +363,28 @@
 
 .panel-unstyled {
 	@include clay-panel-variant($panel-unstyled);
+}
+
+// Panel Sizes
+
+@each $color, $value in $panel-sizes {
+	@if not clay-is-map-unset($value) {
+		$selector: if(
+			starts-with($color, '.') or
+				starts-with($color, '#') or
+				starts-with($color, '%'),
+			$color,
+			if(starts-with($color, 'panel'), str-insert($color, '.', 1), $color)
+		);
+
+		@if (starts-with($color, '%') or map-get($value, extend)) {
+			#{$selector} {
+				@include clay-panel-variant($value);
+			}
+		} @else {
+			#{$selector} {
+				@include clay-panel-variant($value);
+			}
+		}
+	}
 }

--- a/packages/clay-css/src/scss/mixins/_panels.scss
+++ b/packages/clay-css/src/scss/mixins/_panels.scss
@@ -327,10 +327,34 @@
 					@include clay-link($header-link);
 				}
 
+				&.collapse-icon {
+					$_panel-header: setter(map-get($map, panel-header), ());
+
+					@include clay-css(
+						map-get($_panel-header, '&.collapse-icon')
+					);
+				}
+
 				&:not(.collapse-icon-middle) {
 					.collapse-icon-closed,
 					.collapse-icon-open {
 						@include clay-css($collapse-icon);
+					}
+				}
+
+				&.collapse-icon-middle {
+					$_collapse-icon-middle: setter(
+						map-get($map, collapse-icon-middle),
+						()
+					);
+
+					@include clay-css($_collapse-icon-middle);
+
+					.collapse-icon-closed,
+					.collapse-icon-open {
+						@include clay-css(
+							map-get($_collapse-icon-middle, collapse-icon)
+						);
 					}
 				}
 

--- a/packages/clay-css/src/scss/variables/_panels.scss
+++ b/packages/clay-css/src/scss/variables/_panels.scss
@@ -94,6 +94,71 @@ $panel-title-text-transform: null !default;
 $panel-title-small-font-size: null !default;
 $panel-title-small-margin-left: null !default;
 
+$panel: () !default;
+$panel: map-deep-merge(
+	(
+		background-color: $panel-bg,
+		border-color: $panel-border-color,
+		border-radius: clay-enable-rounded($panel-border-radius),
+		border-style: $panel-border-style,
+		border-width: $panel-border-width,
+		box-shadow: clay-enable-shadows($panel-box-shadow),
+		margin-bottom: $panel-margin-bottom,
+		word-wrap: break-word,
+		collapse-icon-middle: (
+			collapse-icon: (
+				font-size: inherit,
+			),
+		),
+		panel-header: (
+			border-bottom: $panel-header-border-bottom-width solid transparent,
+			border-top-left-radius:
+				clay-enable-rounded($panel-header-offset-border-radius),
+			border-top-right-radius:
+				clay-enable-rounded($panel-header-offset-border-radius),
+			display: block,
+			font-size: $panel-header-font-size,
+			line-height: $panel-header-line-height,
+			padding: $panel-header-padding-y $panel-header-padding-x,
+			position: relative,
+			width: 100%,
+			collapsed: (
+				border-bottom-left-radius:
+					clay-enable-rounded($panel-header-offset-border-radius),
+				border-bottom-right-radius:
+					clay-enable-rounded($panel-header-offset-border-radius),
+				link: $panel-header-collapsed-link,
+			),
+			collapse-icon: (
+				padding-left: $panel-header-collapse-icon-padding-left,
+				padding-right: $panel-header-collapse-icon-padding-right,
+			),
+			link: $panel-header-link,
+		),
+		panel-body: (
+			padding: $panel-body-padding-y $panel-body-padding-x,
+		),
+		panel-footer: (
+			border-bottom-left-radius:
+				clay-enable-rounded($panel-footer-offset-border-radius),
+			border-bottom-right-radius:
+				clay-enable-rounded($panel-footer-offset-border-radius),
+			border-top: $panel-footer-border-top-width solid transparent,
+			padding: $panel-footer-padding-y $panel-footer-padding-x,
+		),
+		panel-title: (
+			font-size: $panel-title-font-size,
+			font-weight: $panel-title-font-weight,
+			text-transform: $panel-title-text-transform,
+			small: (
+				font-size: $panel-title-small-font-size,
+				margin-left: $panel-title-small-margin-left,
+			),
+		),
+	),
+	$panel
+);
+
 // Panel Group
 
 $panel-group-panel-margin-bottom: math-sign(
@@ -211,4 +276,134 @@ $panel-unstyled: map-deep-merge(
 		),
 	),
 	$panel-unstyled
+);
+
+$panel-palette: () !default;
+$panel-palette: map-deep-merge(
+	(
+		panel-block: (
+			border-color: $gray-400,
+			collapse-icon: (
+				font-size: inherit,
+				top: 1.3125rem,
+			),
+			panel-header: (
+				font-size: 1.25rem,
+				line-height: 1.25,
+				padding: 1.15625rem 1.25rem,
+				'&.collapse-icon': (
+					padding-right: 3rem,
+				),
+			),
+			panel-title: (
+				font-size: inherit,
+				text-transform: none,
+			),
+			panel-body: (
+				padding: 0 1.25rem 1.25rem,
+			),
+			panel-footer: (
+				padding: 0 1.25rem 1.25rem,
+			),
+		),
+		panel-default: (
+			border-width: 0px,
+			panel-header: (
+				border-radius: clay-enable-rounded(0),
+				color: $gray-600,
+				font-size: 0.875rem,
+				line-height: 1.125rem,
+				padding-bottom: 0.40625rem,
+				padding-left: 0,
+				padding-right: 0,
+				padding-top: 0.40625rem,
+				text-transform: uppercase,
+				'&.collapse-icon': (
+					padding-right: 1.75rem,
+				),
+				link: (
+					border-bottom: 1px solid $gray-400,
+				),
+			),
+			collapse-icon: (
+				font-size: inherit,
+				right: 0,
+				top: 0.5rem,
+			),
+			collapse-icon-middle: (
+				collapse-icon: (
+					right: 0,
+				),
+			),
+			panel-body: (
+				padding: 1.25rem 0,
+			),
+			panel-title: (
+				font-size: inherit,
+			),
+			panel-footer: (
+				padding: 1.25rem 0,
+			),
+		),
+	),
+	$panel-palette
+);
+
+// Panel Sizes
+
+$panel-sizes: () !default;
+$panel-sizes: map-deep-merge(
+	(
+		'.panel-lg.panel-block': (
+			collapse-icon: (
+				top: 1.75rem,
+			),
+			panel-header: (
+				font-size: 1.5rem,
+				padding: 1.5rem 1.5rem,
+				'&.collapse-icon': (
+					padding-right: calc(1.5rem * 3),
+				),
+			),
+			panel-body: (
+				padding: 0 1.5rem 1.5rem,
+			),
+			panel-footer: (
+				padding: 0 1.5rem 1.5rem,
+			),
+		),
+		'.panel-sm.panel-block': (
+			collapse-icon: (
+				top: 0.9375rem,
+			),
+			panel-header: (
+				font-size: 1rem,
+				padding: 0.8125rem 1rem,
+				'&.collapse-icon': (
+					padding-right: calc(1rem * 3),
+				),
+			),
+			panel-body: (
+				padding: 0 1rem 1rem,
+			),
+			panel-footer: (
+				padding: 0 1rem 1rem,
+			),
+		),
+		'.panel-sm.panel-default': (
+			collapse-icon: (
+				top: 0.375rem,
+			),
+			panel-header: (
+				font-size: 0.75rem,
+				line-height: 1,
+				padding-bottom: 0.34375rem,
+				padding-top: 0.34375rem,
+				'&.collapse-icon': (
+					padding-right: 1.75rem,
+				),
+			),
+		),
+	),
+	$panel-sizes
 );

--- a/packages/clay-panel/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-panel/src/__tests__/__snapshots__/index.tsx.snap
@@ -36,10 +36,10 @@ exports[`ClayPanel renders 1`] = `
 exports[`ClayPanel renders with custom displayTitle 1`] = `
 <div>
   <div
-    class="panel panel-secondary"
+    class="panel"
   >
     <button
-      aria-controls="clay-id-9"
+      aria-controls="clay-id-10"
       aria-expanded="false"
       class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
       type="button"
@@ -75,9 +75,9 @@ exports[`ClayPanel renders with custom displayTitle 1`] = `
       </span>
     </button>
     <div
-      aria-labelledby="clay-id-9"
+      aria-labelledby="clay-id-10"
       class="panel-collapse collapse"
-      id="clay-id-9"
+      id="clay-id-10"
       role="region"
     >
       <div
@@ -103,7 +103,40 @@ exports[`ClayPanel renders with custom displayTitle 1`] = `
 exports[`ClayPanel renders with different displayType 1`] = `
 <div>
   <div
-    class="panel panel-secondary"
+    class="panel panel-block"
+  >
+    <div
+      class="panel-header"
+    >
+      <span
+        class="panel-title"
+      >
+        Display Title
+      </span>
+    </div>
+    <div
+      class="panel-header"
+    >
+      Header!
+    </div>
+    <div
+      class="panel-body"
+    >
+      Body!
+    </div>
+    <div
+      class="panel-footer"
+    >
+      Footer!
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayPanel renders with different size 1`] = `
+<div>
+  <div
+    class="panel panel-sm"
   >
     <div
       class="panel-header"
@@ -178,7 +211,7 @@ exports[`ClayPanel renders with multiple panels 1`] = `
       class="panel"
     >
       <button
-        aria-controls="clay-id-5"
+        aria-controls="clay-id-6"
         aria-expanded="false"
         class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
         type="button"
@@ -214,9 +247,9 @@ exports[`ClayPanel renders with multiple panels 1`] = `
         </span>
       </button>
       <div
-        aria-labelledby="clay-id-5"
+        aria-labelledby="clay-id-6"
         class="panel-collapse collapse"
-        id="clay-id-5"
+        id="clay-id-6"
         role="region"
       >
         <div
@@ -233,10 +266,10 @@ exports[`ClayPanel renders with multiple panels 1`] = `
 exports[`ClayPanel renders without displayTitle 1`] = `
 <div>
   <div
-    class="panel panel-secondary"
+    class="panel"
   >
     <button
-      aria-controls="clay-id-10"
+      aria-controls="clay-id-11"
       aria-expanded="false"
       class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
       type="button"
@@ -267,9 +300,9 @@ exports[`ClayPanel renders without displayTitle 1`] = `
       </span>
     </button>
     <div
-      aria-labelledby="clay-id-10"
+      aria-labelledby="clay-id-11"
       class="panel-collapse collapse"
-      id="clay-id-10"
+      id="clay-id-11"
       role="region"
     >
       <div

--- a/packages/clay-panel/src/__tests__/index.tsx
+++ b/packages/clay-panel/src/__tests__/index.tsx
@@ -26,7 +26,23 @@ describe('ClayPanel', () => {
 		const {container} = render(
 			<ClayPanel
 				displayTitle="Display Title"
-				displayType="secondary"
+				displayType="block"
+				spritemap="/foo/bar"
+			>
+				<ClayPanel.Header>Header!</ClayPanel.Header>
+				<ClayPanel.Body>Body!</ClayPanel.Body>
+				<ClayPanel.Footer>Footer!</ClayPanel.Footer>
+			</ClayPanel>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders with different size', () => {
+		const {container} = render(
+			<ClayPanel
+				displayTitle="Display Title"
+				size="sm"
 				spritemap="/foo/bar"
 			>
 				<ClayPanel.Header>Header!</ClayPanel.Header>
@@ -95,7 +111,6 @@ describe('ClayPanel', () => {
 						<h3>Custom Panel Title</h3>
 					</ClayPanel.Title>
 				}
-				displayType="secondary"
 				showCollapseIcon
 				spritemap="/foo/bar"
 			>
@@ -110,12 +125,7 @@ describe('ClayPanel', () => {
 
 	it('renders without displayTitle', () => {
 		const {container} = render(
-			<ClayPanel
-				collapsable
-				displayType="secondary"
-				showCollapseIcon
-				spritemap="/foo/bar"
-			>
+			<ClayPanel collapsable showCollapseIcon spritemap="/foo/bar">
 				<ClayPanel.Header>Header!</ClayPanel.Header>
 				<ClayPanel.Body>Body!</ClayPanel.Body>
 				<ClayPanel.Footer>Footer!</ClayPanel.Footer>

--- a/packages/clay-panel/src/index.tsx
+++ b/packages/clay-panel/src/index.tsx
@@ -51,7 +51,7 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Flag to indicate the visual variation of the Panel.
 	 */
-	displayType?: 'unstyled' | 'secondary';
+	displayType?: 'block' | 'default' | 'secondary' | 'unstyled';
 
 	/**
 	 * Determines if menu is expanded or not (controlled).
@@ -67,6 +67,11 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * Flag to toggle collapse icon visibility when `collapsable` is true.
 	 */
 	showCollapseIcon?: boolean;
+
+	/**
+	 * Flag to indicate the visual variation of the Panel.
+	 */
+	size?: 'lg' | 'sm';
 
 	/**
 	 * Path to spritemap for clay icons
@@ -94,6 +99,7 @@ function ClayPanel({
 	expanded,
 	onExpandedChange,
 	showCollapseIcon = true,
+	size,
 	spritemap,
 	...otherProps
 }: IProps) {
@@ -115,6 +121,7 @@ function ClayPanel({
 			{...otherProps}
 			className={classNames('panel', className, {
 				[`panel-${displayType}`]: displayType,
+				[`panel-${size}`]: size,
 			})}
 		>
 			{!collapsable && (

--- a/packages/clay-panel/stories/Panel.stories.tsx
+++ b/packages/clay-panel/stories/Panel.stories.tsx
@@ -12,7 +12,11 @@ export default {
 	argTypes: {
 		displayType: {
 			control: {type: 'select'},
-			options: ['secondary', 'unstyled', undefined],
+			options: ['default', 'block', undefined],
+		},
+		size: {
+			control: {type: 'select'},
+			options: ['lg', 'sm', undefined],
 		},
 	},
 	component: ClayPanel,
@@ -20,7 +24,11 @@ export default {
 };
 
 export const Default = (args: any) => (
-	<ClayPanel displayTitle={args.displayTitle} displayType={args.displayType}>
+	<ClayPanel
+		displayTitle={args.displayTitle}
+		displayType={args.displayType}
+		size={args.size}
+	>
 		<ClayPanel.Header>Header!</ClayPanel.Header>
 		<ClayPanel.Body>Body!</ClayPanel.Body>
 		<ClayPanel.Footer>Footer!</ClayPanel.Footer>
@@ -42,6 +50,7 @@ export const Collapsable = (args: any) => {
 				displayTitle="Toggle me for expanding!"
 				displayType={args.displayType}
 				showCollapseIcon={args.showCollapseIcon}
+				size={args.size}
 			>
 				<ClayPanel.Header>Header!</ClayPanel.Header>
 				<ClayPanel.Body>Body!</ClayPanel.Body>
@@ -61,6 +70,7 @@ export const Collapsable = (args: any) => {
 				expanded={expanded}
 				onExpandedChange={setExpanded}
 				showCollapseIcon={args.showCollapseIcon}
+				size={args.size}
 			>
 				<ClayPanel.Header>Header!</ClayPanel.Header>
 				<ClayPanel.Body>Body!</ClayPanel.Body>
@@ -100,7 +110,7 @@ export const Sheet = (args: any) => (
 				<ClayPanel
 					collapsable
 					displayTitle={item}
-					displayType="secondary"
+					displayType="unstyled"
 					key={item}
 					showCollapseIcon
 				>
@@ -117,7 +127,7 @@ Sheet.args = {
 	fluid: true,
 };
 
-export const CollapsableWithTitle = () => (
+export const CollapsableWithTitle = (args: any) => (
 	<ClayPanel
 		collapsable
 		displayTitle={
@@ -132,7 +142,9 @@ export const CollapsableWithTitle = () => (
 				<ClayLabel displayType="success">State</ClayLabel>
 			</ClayPanel.Title>
 		}
+		displayType={args.displayType}
 		showCollapseIcon
+		size={args.size}
 	>
 		<ClayPanel.Header>Header!</ClayPanel.Header>
 		<ClayPanel.Body>Body!</ClayPanel.Body>


### PR DESCRIPTION
> Dear reviewer, [there is still an ongoing conversation on slack](https://liferay.slack.com/archives/C049XG98GQL/p1700832971192009) about how to handle this new design, I originally suggested allowing any custom header in the `clay:panel` taglib, like we do with the React component, but I think it is better, in terms on consistency, to keep a reduced number of cases as far as we can.
> 
> I wanted to update the code beforehand to be sure that this was feasible and not an ugly patch, but feel free to close this PR or request an alternative if this is a bad idea.

This PR adds a new displayType for ClayPanel component, matching a new design that we need in portal to implement the following UI:

https://www.figma.com/file/zf4akVPokkJdRKvgQtHxC0/LPS-114700--Translation-improvements-for-web-content?node-id=1144%3A16180&mode=dev

There will be a another PR adding this new option to the clay:panel taglib, which is being used for this case.

![image](https://github.com/liferay/clay/assets/800645/399a2aad-a09f-45dd-8fd2-d603f49e11d9)
