### PR TITLE
fix(@clayui/core): updates the sort icon for table

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,16 +1,25 @@
 import '@clayui/css/lib/css/atlas.css';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
-import React from 'react';
+import React, {useEffect} from 'react';
+import svg4everybody from 'svg4everybody';
 import {Provider} from '@clayui/provider';
 
 export const decorators = [
-	(Story) => (
-		<Provider spritemap={spritemap}>
-			<div>
-				<Story />
-			</div>
-		</Provider>
-	),
+	(Story) => {
+		useEffect(() => {
+			svg4everybody({
+				polyfill: true,
+			});
+		}, []);
+
+		return (
+			<Provider spritemap={spritemap}>
+				<div>
+					<Story />
+				</div>
+			</Provider>
+		);
+	},
 ];
 
 export const parameters = {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 		"size-limit": "^6.0.3",
 		"source-map-loader": "^0.2.4",
 		"style-loader": "^0.23.1",
+		"svg4everybody": "^2.1.9",
 		"ts-jest": "^28.0.8",
 		"turbo": "^1.2.6",
 		"typescript": "4.7.4",

--- a/packages/clay-core/src/table/Cell.tsx
+++ b/packages/clay-core/src/table/Cell.tsx
@@ -168,6 +168,7 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 					'table-cell-ws-nowrap': !wrap,
 					'table-focus': focusWithinProps.tabIndex === 0 && isFocused,
 					'table-head-title': isHead,
+					'table-sort': isHead && sortable,
 				})}
 				colSpan={
 					divider
@@ -219,17 +220,13 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 							</span>
 						</Layout.ContentCol>
 						<Layout.ContentCol>
-							<Button
-								aria-label=""
+							<span
 								className="component-action"
-								displayType="unstyled"
-								monospaced
 								role="presentation"
-								size="xs"
 								tabIndex={-1}
 							>
 								<Icon symbol="order-arrow" />
-							</Button>
+							</span>
 						</Layout.ContentCol>
 					</Layout.ContentRow>
 				) : truncate ? (

--- a/packages/clay-core/src/table/Cell.tsx
+++ b/packages/clay-core/src/table/Cell.tsx
@@ -179,6 +179,16 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 						: undefined
 				}
 				className={classNames(className, {
+					'order-arrow-down-active': isSortable
+						? sort &&
+						  keyValue === sort.column &&
+						  sort.direction === 'descending'
+						: undefined,
+					'order-arrow-up-active': isSortable
+						? sort &&
+						  keyValue === sort.column &&
+						  sort.direction === 'ascending'
+						: undefined,
 					'table-cell-expand': truncate || expanded,
 					[`table-cell-${delimiter}`]: delimiter,
 					[`table-column-text-${textAlign}`]: textAlign,
@@ -186,7 +196,6 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 					'table-cell-ws-nowrap': !wrap,
 					'table-focus': focusWithinProps.tabIndex === 0 && isFocused,
 					'table-head-title': isHead,
-					'table-sort': isSortable,
 				})}
 				colSpan={
 					divider
@@ -223,9 +232,7 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 				style={{
 					width,
 				}}
-				tabIndex={
-					treegrid || !isSortable ? focusWithinProps.tabIndex : 1
-				}
+				tabIndex={focusWithinProps.tabIndex}
 			>
 				{isSortable ? (
 					<Layout.ContentRow>
@@ -237,13 +244,13 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 							</span>
 						</Layout.ContentCol>
 						<Layout.ContentCol>
-							<span
+							<button
+								aria-label="Sort Column"
 								className="component-action"
-								role="presentation"
-								tabIndex={-1}
+								type="button"
 							>
 								<Icon symbol="order-arrow" />
-							</span>
+							</button>
 						</Layout.ContentCol>
 					</Layout.ContentRow>
 				) : truncate ? (

--- a/packages/clay-core/src/table/Cell.tsx
+++ b/packages/clay-core/src/table/Cell.tsx
@@ -51,6 +51,11 @@ type Props = {
 	keyValue?: React.Key;
 
 	/**
+	 * Sets the `aria-label` on the sort button. The default is "Sort Column".
+	 */
+	sortAriaLabel?: string;
+
+	/**
 	 * Whether the column allows sortable. Only available in the header column.
 	 */
 	sortable?: boolean;
@@ -92,6 +97,7 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 			expanded,
 			index,
 			keyValue,
+			sortAriaLabel = 'Sort Column',
 			sortable,
 			textAlign,
 			textValue,
@@ -245,7 +251,7 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 						</Layout.ContentCol>
 						<Layout.ContentCol>
 							<button
-								aria-label="Sort Column"
+								aria-label={sortAriaLabel}
 								className="component-action"
 								type="button"
 							>

--- a/packages/clay-core/src/table/Cell.tsx
+++ b/packages/clay-core/src/table/Cell.tsx
@@ -51,11 +51,6 @@ type Props = {
 	keyValue?: React.Key;
 
 	/**
-	 * Sets the `aria-label` on the sort button. The default is "Sort Column".
-	 */
-	sortAriaLabel?: string;
-
-	/**
 	 * Whether the column allows sortable. Only available in the header column.
 	 */
 	sortable?: boolean;
@@ -97,7 +92,6 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 			expanded,
 			index,
 			keyValue,
-			sortAriaLabel = 'Sort Column',
 			sortable,
 			textAlign,
 			textValue,
@@ -251,7 +245,7 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 						</Layout.ContentCol>
 						<Layout.ContentCol>
 							<button
-								aria-label={sortAriaLabel}
+								aria-label={messages['sortDescription']}
 								className="component-action"
 								type="button"
 							>

--- a/packages/clay-core/src/table/Cell.tsx
+++ b/packages/clay-core/src/table/Cell.tsx
@@ -210,27 +210,28 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 				}}
 			>
 				{isHead && sortable ? (
-					<a
-						className="inline-item text-truncate-inline"
-						href="#"
-						onClick={(event) => event.preventDefault()}
-						role="presentation"
-						tabIndex={treegrid ? -1 : undefined}
-					>
-						<span className="text-truncate">{children}</span>
-
-						{sort && keyValue === sort.column && (
-							<span className="inline-item inline-item-after">
-								<Icon
-									symbol={
-										sort.direction === 'ascending'
-											? 'order-arrow-up'
-											: 'order-arrow-down'
-									}
-								/>
+					<Layout.ContentRow>
+						<Layout.ContentCol expand>
+							<span className="text-truncate-inline">
+								<span className="text-truncate">
+									{children}
+								</span>
 							</span>
-						)}
-					</a>
+						</Layout.ContentCol>
+						<Layout.ContentCol>
+							<Button
+								aria-label=""
+								className="component-action"
+								displayType="unstyled"
+								monospaced
+								role="presentation"
+								size="xs"
+								tabIndex={-1}
+							>
+								<Icon symbol="order-arrow" />
+							</Button>
+						</Layout.ContentCol>
+					</Layout.ContentRow>
 				) : truncate ? (
 					<span className="text-truncate-inline">
 						<span className="text-truncate">{children}</span>

--- a/packages/clay-core/src/table/Table.tsx
+++ b/packages/clay-core/src/table/Table.tsx
@@ -186,6 +186,7 @@ export const Table = React.forwardRef<HTMLDivElement, Props>(
 				className={classNames(className, {
 					'table-nested-rows': nestedKey,
 					[`table-${size}`]: size,
+					'table-sort': sort || sort === null,
 				})}
 				ref={ref}
 				role={nestedKey ? 'treegrid' : undefined}

--- a/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -352,7 +352,7 @@ exports[`Table basic rendering render with sort column 1`] = `
                 class="autofit-col"
               >
                 <button
-                  aria-label="Sort Column"
+                  aria-label="sortable column"
                   class="component-action"
                   type="button"
                 >
@@ -397,7 +397,7 @@ exports[`Table basic rendering render with sort column 1`] = `
                 class="autofit-col"
               >
                 <button
-                  aria-label="Sort Column"
+                  aria-label="sortable column"
                   class="component-action"
                   type="button"
                 >

--- a/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -330,7 +330,6 @@ exports[`Table basic rendering render with sort column 1`] = `
             class="table-head-title table-sort"
             data-id="string,name"
             style="width: auto;"
-            tabindex="-1"
           >
             <div
               class="autofit-row"
@@ -374,8 +373,12 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-sort="none"
             class="table-head-title table-sort"
             data-id="string,type"
+<<<<<<< HEAD
             style="width: auto;"
             tabindex="-1"
+=======
+            tabindex="1"
+>>>>>>> 268cb8f02 (fix(@clayui/core): fixes error when not navigating through the head with sortable enabled and fixes error when expanding unnecessarily)
           >
             <div
               class="autofit-row"

--- a/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -327,9 +327,10 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-colindex="1"
             aria-describedby="clay-id-17"
             aria-sort="none"
-            class="table-head-title table-sort"
+            class="table-head-title"
             data-id="string,name"
             style="width: auto;"
+            tabindex="-1"
           >
             <div
               class="autofit-row"
@@ -350,10 +351,10 @@ exports[`Table basic rendering render with sort column 1`] = `
               <div
                 class="autofit-col"
               >
-                <span
+                <button
+                  aria-label="Sort Column"
                   class="component-action"
-                  role="presentation"
-                  tabindex="-1"
+                  type="button"
                 >
                   <svg
                     class="lexicon-icon lexicon-icon-order-arrow"
@@ -363,7 +364,7 @@ exports[`Table basic rendering render with sort column 1`] = `
                       href="#order-arrow"
                     />
                   </svg>
-                </span>
+                </button>
               </div>
             </div>
           </th>
@@ -371,14 +372,10 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-colindex="2"
             aria-describedby="clay-id-17"
             aria-sort="none"
-            class="table-head-title table-sort"
+            class="table-head-title"
             data-id="string,type"
-<<<<<<< HEAD
             style="width: auto;"
             tabindex="-1"
-=======
-            tabindex="1"
->>>>>>> 268cb8f02 (fix(@clayui/core): fixes error when not navigating through the head with sortable enabled and fixes error when expanding unnecessarily)
           >
             <div
               class="autofit-row"
@@ -399,10 +396,10 @@ exports[`Table basic rendering render with sort column 1`] = `
               <div
                 class="autofit-col"
               >
-                <span
+                <button
+                  aria-label="Sort Column"
                   class="component-action"
-                  role="presentation"
-                  tabindex="-1"
+                  type="button"
                 >
                   <svg
                     class="lexicon-icon lexicon-icon-order-arrow"
@@ -412,7 +409,7 @@ exports[`Table basic rendering render with sort column 1`] = `
                       href="#order-arrow"
                     />
                   </svg>
-                </span>
+                </button>
               </div>
             </div>
           </th>

--- a/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -327,43 +327,91 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-colindex="1"
             aria-describedby="clay-id-17"
             aria-sort="none"
-            class="table-head-title"
+            class="table-head-title table-sort"
             data-id="string,name"
             style="width: auto;"
             tabindex="-1"
           >
-            <a
-              class="inline-item text-truncate-inline"
-              href="#"
-              role="presentation"
+            <div
+              class="autofit-row"
             >
-              <span
-                class="text-truncate"
+              <div
+                class="autofit-col autofit-col-expand"
               >
-                Name
-              </span>
-            </a>
+                <span
+                  class="text-truncate-inline"
+                >
+                  <span
+                    class="text-truncate"
+                  >
+                    Name
+                  </span>
+                </span>
+              </div>
+              <div
+                class="autofit-col"
+              >
+                <span
+                  class="component-action"
+                  role="presentation"
+                  tabindex="-1"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-order-arrow"
+                    role="presentation"
+                  >
+                    <use
+                      href="#order-arrow"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
           </th>
           <th
             aria-colindex="2"
             aria-describedby="clay-id-17"
             aria-sort="none"
-            class="table-head-title"
+            class="table-head-title table-sort"
             data-id="string,type"
             style="width: auto;"
             tabindex="-1"
           >
-            <a
-              class="inline-item text-truncate-inline"
-              href="#"
-              role="presentation"
+            <div
+              class="autofit-row"
             >
-              <span
-                class="text-truncate"
+              <div
+                class="autofit-col autofit-col-expand"
               >
-                Type
-              </span>
-            </a>
+                <span
+                  class="text-truncate-inline"
+                >
+                  <span
+                    class="text-truncate"
+                  >
+                    Type
+                  </span>
+                </span>
+              </div>
+              <div
+                class="autofit-col"
+              >
+                <span
+                  class="component-action"
+                  role="presentation"
+                  tabindex="-1"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-order-arrow"
+                    role="presentation"
+                  >
+                    <use
+                      href="#order-arrow"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
           </th>
           <th
             class="table-head-title"

--- a/packages/clay-core/src/table/useTreeNavigation.tsx
+++ b/packages/clay-core/src/table/useTreeNavigation.tsx
@@ -41,7 +41,7 @@ export function useTreeNavigation<T extends HTMLElement>({
 					Keys.Down,
 					Keys.Home,
 					Keys.End,
-				].includes(event.key) &&
+				].includes(event.key) ||
 				disabled
 			) {
 				return;

--- a/packages/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -360,6 +360,9 @@ $cadmin-c-table: map-deep-merge(
 				color: $cadmin-table-disabled-color,
 			),
 		),
+		table-sort: (
+			color: $cadmin-gray-900,
+		),
 		autofit-col: (
 			justify-content: center,
 			padding-left: nth($cadmin-table-cell-padding, 2),

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -99,6 +99,7 @@ caption {
 tr.table-focus {
 	@include clay-css($c-tr-table-focus);
 
+	th,
 	td {
 		$_td: setter(map-get($c-tr-table-focus, td), ());
 
@@ -525,6 +526,12 @@ td.table-focus {
 	.component-action:not(.show) .collapse-icon-open {
 		display: none;
 	}
+}
+
+// .table-sort
+
+.table-sort {
+	@include clay-table-variant($c-table-sort);
 }
 
 // Show Quick Action

--- a/packages/clay-css/src/scss/mixins/_tables.scss
+++ b/packages/clay-css/src/scss/mixins/_tables.scss
@@ -369,6 +369,15 @@
 				}
 			}
 
+			.table-sort[aria-sort='ascending']
+				.lexicon-icon
+				.order-arrow-arrow-up,
+			.table-sort[aria-sort='descending']
+				.lexicon-icon
+				.order-arrow-arrow-down {
+				@include clay-css(map-get($map, table-sort));
+			}
+
 			.autofit-col {
 				@include clay-css(map-get($map, autofit-col));
 

--- a/packages/clay-css/src/scss/mixins/_tables.scss
+++ b/packages/clay-css/src/scss/mixins/_tables.scss
@@ -71,6 +71,10 @@
 
 					@include clay-css($_thead-table-cell);
 
+					&:hover {
+						@include clay-css(map-get($_thead-table-cell, hover));
+					}
+
 					&:first-child {
 						@include clay-css(
 							map-get($_thead-table-cell, table-column-start)
@@ -80,6 +84,12 @@
 					&:last-child {
 						@include clay-css(
 							map-get($_thead-table-cell, table-column-end)
+						);
+					}
+
+					.component-action {
+						@include clay-css(
+							map-get($_thead-table-cell, component-action)
 						);
 					}
 				}
@@ -367,15 +377,6 @@
 						map-deep-get($map, table-disabled, table-list-title)
 					);
 				}
-			}
-
-			.table-sort[aria-sort='ascending']
-				.lexicon-icon
-				.order-arrow-arrow-up,
-			.table-sort[aria-sort='descending']
-				.lexicon-icon
-				.order-arrow-arrow-down {
-				@include clay-css(map-get($map, table-sort));
 			}
 
 			.autofit-col {

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -322,6 +322,9 @@ $c-table: map-deep-merge(
 				color: $table-disabled-color,
 			),
 		),
+		table-sort: (
+			color: $gray-900,
+		),
 		autofit-col: (
 			justify-content: center,
 			padding-left: nth($table-cell-padding, 2),

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -322,9 +322,6 @@ $c-table: map-deep-merge(
 				color: $table-disabled-color,
 			),
 		),
-		table-sort: (
-			color: $gray-900,
-		),
 		autofit-col: (
 			justify-content: center,
 			padding-left: nth($table-cell-padding, 2),
@@ -558,6 +555,30 @@ $c-table-nested-rows: map-deep-merge(
 		),
 	),
 	$c-table-nested-rows
+);
+
+// .table-sort
+
+$c-table-sort: () !default;
+$c-table-sort: map-deep-merge(
+	(
+		thead: (
+			table-cell: (
+				cursor: pointer,
+				transition: clay-enable-transitions($component-transition),
+				hover: (
+					background-color: $primary-l3,
+					color: $gray-900,
+				),
+				component-action: (
+					font-size: 0.75rem,
+					height: 1.5rem,
+					width: 1.5rem,
+				),
+			),
+		),
+	),
+	$c-table-sort
 );
 
 // Table Dark Variant

--- a/yarn.lock
+++ b/yarn.lock
@@ -24038,7 +24038,7 @@ supports-hyperlinks@^2.0.0:
 svg4everybody@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/svg4everybody/-/svg4everybody-2.1.9.tgz#5bd9f6defc133859a044646d4743fabc28db7e2d"
-  integrity sha1-W9n23vwTOFmgRGRtR0P6vCjbfi0=
+  integrity sha512-AS9WORVV/vk520ZHxGTlQzyDBizp/h6WyAYUbKhze/kwvQr43DwJpkIIPBomsUyKqN7N+h1deF92N9PmW+o+9A==
 
 svgo@^1.0.0, svgo@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
Closes [LPS-202866](https://liferay.atlassian.net/browse/LPS-202866)

The icon update is still in draft, I need to make some adjustments, @pat270, would you have any ideas on how we can try to achieve these use cases of the sorting icon state? I don't know if we have something like this in CSS.

Even though I'm using the button, I'm making it invisible to SR because we're using the head for sorting for accessibility reasons, so when you press the whole head it changes the sorting if it's enabled for the column, so we can use `aria -sort`.