### PR TITLE
fix(clayui.com): fix build error

### DIFF
--- a/clayui.com/plugins/gatsby-remark-use-clipboard/index.js
+++ b/clayui.com/plugins/gatsby-remark-use-clipboard/index.js
@@ -31,7 +31,7 @@ module.exports = ({markdownAST}) => {
 
 		const language = node.meta ? node.lang + node.meta : node.lang;
 
-		const {expanded} = parseOptions(language.match(/(?<=\{).+?(?=\})/g));
+		const {expanded} = parseOptions(language?.match(/(?<=\{).+?(?=\})/g));
 
 		const expandedClass = expanded ? ' expanded' : '';
 		const hideClass = expanded ? ' hide' : '';


### PR DESCRIPTION
The build was failing because the language could be null, strangely it seems like this has happened before but it didn't fail, it could have been some change in the package updates that could have caused this but this now fixes the clayui.com build failures and storybook.