### PR TITLE
feat(@clayui/core): adds column visibility feature

### DIFF
--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -34,6 +34,7 @@
 		"@clayui/provider": "^3.106.1",
 		"@clayui/shared": "^3.107.0",
 		"@clayui/table": "^3.108.0",
+		"@clayui/form": "^3.108.0",
 		"@tanstack/react-virtual": "3.0.0-beta.54",
 		"aria-hidden": "^1.2.2",
 		"classnames": "^2.2.6",

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -34,7 +34,7 @@
 		"@clayui/provider": "^3.106.1",
 		"@clayui/shared": "^3.107.0",
 		"@clayui/table": "^3.108.0",
-		"@clayui/form": "^3.108.0",
+		"@clayui/form": "^3.107.0",
 		"@tanstack/react-virtual": "3.0.0-beta.54",
 		"aria-hidden": "^1.2.2",
 		"classnames": "^2.2.6",

--- a/packages/clay-core/src/collection/Collection.tsx
+++ b/packages/clay-core/src/collection/Collection.tsx
@@ -53,6 +53,7 @@ function VirtualDynamicCollection<
 >({
 	as,
 	children,
+	connectNested,
 	estimateSize = 37,
 	exclude,
 	filter,
@@ -75,6 +76,7 @@ function VirtualDynamicCollection<
 
 	const state = useCollection({
 		children,
+		connectNested,
 		exclude,
 		filter,
 		filterKey,
@@ -108,6 +110,7 @@ function DynamicCollection<
 	K = unknown
 >({
 	children,
+	connectNested,
 	exclude,
 	filter,
 	filterKey,
@@ -120,6 +123,7 @@ function DynamicCollection<
 }: ICollectionProps<T, P> & Props<P, K>) {
 	const state = useCollection({
 		children,
+		connectNested,
 		exclude,
 		filter,
 		filterKey,
@@ -142,6 +146,7 @@ export function Collection<
 	as,
 	children,
 	collection,
+	connectNested,
 	estimateSize,
 	exclude,
 	filter,
@@ -202,6 +207,7 @@ export function Collection<
 			<VirtualDynamicCollection
 				{...otherProps}
 				as={as}
+				connectNested={connectNested}
 				estimateSize={estimateSize}
 				itemContainer={itemContainer}
 				items={items}
@@ -217,6 +223,7 @@ export function Collection<
 	} else {
 		content = (
 			<DynamicCollection
+				connectNested={connectNested}
 				exclude={exclude}
 				filter={filter}
 				filterKey={filterKey}

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -45,6 +45,7 @@ export type CollectionState = {
 	getFirstItem: () => {key: React.Key; value: string; index: number};
 	getItem: (key: React.Key) => {value: string; index: number};
 	getItems: () => Array<React.Key>;
+	getSize: () => number;
 	getLastItem: () => {key: React.Key; value: string; index: number};
 	hasItem: (key: React.Key) => boolean;
 	size?: number;

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -54,6 +54,18 @@ export type CollectionState = {
 
 export type Props<P, K> = {
 	/**
+	 * Flag to enable all nested collections to share the same data.
+	 */
+	connectNested?: boolean;
+
+	/**
+	 * Flag to not render items in the DOM but it does not affect the layout
+	 * record, for example when obtaining all items from the collection it
+	 * will still be there.
+	 */
+	disabledKeys?: Set<React.Key> | Array<number>;
+
+	/**
 	 * Properties that should be omitted from item data when passed to
 	 * children function.
 	 */

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -371,6 +371,10 @@ export function useCollection<
 		return Array.from(layout.current.keys());
 	}, []);
 
+	const getSize = useCallback(() => {
+		return layout.current.size;
+	}, []);
+
 	const cleanUp = useCallback(() => {
 		layout.current.forEach((value, key) => {
 			if (value.instanceId === collectionId) {
@@ -452,6 +456,7 @@ export function useCollection<
 		getItem,
 		getItems,
 		getLastItem,
+		getSize,
 		hasItem,
 		size: virtualizer ? virtualizer.getTotalSize() : undefined,
 		virtualize: !!virtualizer,

--- a/packages/clay-core/src/drop-down/Item.tsx
+++ b/packages/clay-core/src/drop-down/Item.tsx
@@ -19,6 +19,11 @@ type Props = {
 	href?: string;
 
 	/**
+	 * Item value for accessibility.
+	 */
+	textValue?: string;
+
+	/**
 	 * @ignore
 	 */
 	'data-index'?: number;
@@ -41,6 +46,7 @@ export const Item = React.forwardRef<HTMLLIElement, Props>(function ItemInner(
 		keyValue,
 		onClick,
 		style,
+		textValue: _,
 		...otherProps
 	}: Props,
 	ref

--- a/packages/clay-core/src/drop-down/Menu.tsx
+++ b/packages/clay-core/src/drop-down/Menu.tsx
@@ -164,7 +164,7 @@ function MenuInner<T extends Record<string, unknown> | string | number>(
 		),
 		items,
 		suppressTextValueWarning: false,
-		virtualizer: items ? virtualizer : undefined,
+		virtualizer: items && items.length > 70 ? virtualizer : undefined,
 	});
 
 	useOverlayPosition(

--- a/packages/clay-core/src/table/Body.tsx
+++ b/packages/clay-core/src/table/Body.tsx
@@ -126,6 +126,7 @@ function BodyInner<T extends Record<string, any>>(
 			<ScopeContext.Provider value={Scope.Body}>
 				<BodyContext.Provider value={{insert}}>
 					<Collection<T>
+						connectNested={false}
 						itemContainer={useCallback(
 							({children, item, keyValue}: ItemProps<any>) =>
 								item

--- a/packages/clay-core/src/table/Cell.tsx
+++ b/packages/clay-core/src/table/Cell.tsx
@@ -71,6 +71,11 @@ type Props = {
 	wrap?: boolean;
 
 	/**
+	 * Sets the column width.
+	 */
+	width?: string;
+
+	/**
 	 * Sets a text value if the component's content is not plain text.
 	 */
 	textValue?: string;
@@ -91,13 +96,16 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 			textAlign,
 			textValue,
 			truncate,
+			width = 'auto',
 			wrap = true,
 			...otherProps
 		},
 		ref
 	) {
 		const {
+			columnsVisibility,
 			expandedKeys,
+			headCellsCount,
 			messages,
 			onExpandedChange,
 			onSortChange,
@@ -161,7 +169,11 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 					'table-focus': focusWithinProps.tabIndex === 0 && isFocused,
 					'table-head-title': isHead,
 				})}
-				colSpan={divider ? 9 : undefined}
+				colSpan={
+					divider
+						? headCellsCount + (columnsVisibility ? 1 : 0)
+						: undefined
+				}
 				data-id={
 					typeof keyValue === 'number'
 						? `number,${keyValue}`
@@ -193,6 +205,9 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 				}}
 				ref={ref}
 				role={treegrid ? 'gridcell' : undefined}
+				style={{
+					width,
+				}}
 			>
 				{isHead && sortable ? (
 					<a

--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -15,6 +15,27 @@ import {Cell} from './Cell';
 import {Scope, ScopeContext} from './ScopeContext';
 import {useTable} from './context';
 
+type HeaderProps = {
+	name: string;
+	description: string;
+};
+
+const Header = React.forwardRef<HTMLLIElement, HeaderProps>(
+	function HeaderInner({description, name}: HeaderProps, ref) {
+		return (
+			<li key={name} ref={ref} role="presentation">
+				<div className="dropdown-subheader mb-0">
+					{name.toUpperCase()}
+				</div>
+				<div className="dropdown-section py-0 text-secondary">
+					{description}
+				</div>
+				<div className="dropdown-divider" />
+			</li>
+		);
+	}
+);
+
 type Props<T> = {
 	/**
 	 * Children content to render a dynamic or static content.
@@ -60,7 +81,18 @@ function HeadInner<T extends Record<string, any>>(
 					{columnsVisibility && (
 						<Cell keyValue="visibility" width="72px">
 							<Menu
-								items={collection.getItems()}
+								items={[
+									{
+										description:
+											messages[
+												'columnsVisibilityDescription'
+											]!,
+										name: messages[
+											'columnsVisibilityHeader'
+										]!,
+									},
+									...collection.getItems(),
+								]}
 								trigger={
 									<Button
 										aria-label={
@@ -74,42 +106,54 @@ function HeadInner<T extends Record<string, any>>(
 									</Button>
 								}
 							>
-								{(item) => (
-									<Item
-										key={item}
-										textValue={
-											collection.getItem(item).value
-										}
-									>
-										<Layout.ContentRow>
-											<Layout.ContentCol expand>
-												{collection.getItem(item).value}
-											</Layout.ContentCol>
-											<Layout.ContentCol>
-												<Toggle
-													disabled={
-														!hiddenColumns.has(
-															item
-														) &&
-														headCellsCount - 1 ===
-															hiddenColumns.size
+								{(item) =>
+									typeof item === 'object' ? (
+										<Header
+											description={item.description}
+											key={item.name}
+											name={item.name}
+										/>
+									) : (
+										<Item
+											key={item}
+											textValue={
+												collection.getItem(item).value
+											}
+										>
+											<Layout.ContentRow>
+												<Layout.ContentCol expand>
+													{
+														collection.getItem(item)
+															.value
 													}
-													onToggle={() =>
-														onHiddenColumnsChange(
-															item,
-															collection.getItem(
+												</Layout.ContentCol>
+												<Layout.ContentCol>
+													<Toggle
+														disabled={
+															!hiddenColumns.has(
 																item
-															).index
-														)
-													}
-													toggled={hiddenColumns.has(
-														item
-													)}
-												/>
-											</Layout.ContentCol>
-										</Layout.ContentRow>
-									</Item>
-								)}
+															) &&
+															headCellsCount -
+																1 ===
+																hiddenColumns.size
+														}
+														onToggle={() =>
+															onHiddenColumnsChange(
+																item,
+																collection.getItem(
+																	item
+																).index
+															)
+														}
+														toggled={hiddenColumns.has(
+															item
+														)}
+													/>
+												</Layout.ContentCol>
+											</Layout.ContentRow>
+										</Item>
+									)
+								}
 							</Menu>
 						</Cell>
 					)}

--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React from 'react';
+import Button from '@clayui/button';
+import {ClayToggle as Toggle} from '@clayui/form';
+import Icon from '@clayui/icon';
+import Layout from '@clayui/layout';
+import React, {useMemo} from 'react';
 
-import {ChildrenFunction, Collection} from '../collection';
+import {ChildrenFunction, Collection, useCollection} from '../collection';
+import {Item, Menu} from '../drop-down';
+import {Cell} from './Cell';
 import {Scope, ScopeContext} from './ScopeContext';
+import {useTable} from './context';
 
 type Props<T> = {
 	/**
@@ -24,13 +31,88 @@ function HeadInner<T extends Record<string, any>>(
 	{children, items, ...otherProps}: Props<T>,
 	ref: React.Ref<HTMLTableSectionElement>
 ) {
+	const {
+		columnsVisibility,
+		headCellsCount,
+		hiddenColumns,
+		messages,
+		onHeadCellsChange,
+		onHiddenColumnsChange,
+	} = useTable();
+
+	const collection = useCollection<T>({
+		children,
+		disabledKeys: new Set(hiddenColumns.keys()),
+		items,
+		suppressTextValueWarning: false,
+	});
+
+	useMemo(() => {
+		onHeadCellsChange(collection.getSize());
+	}, []);
+
 	return (
 		<thead {...otherProps} ref={ref}>
 			<ScopeContext.Provider value={Scope.Head}>
 				<tr>
-					<Collection items={items} suppressTextValueWarning={false}>
-						{children}
-					</Collection>
+					<Collection<T> collection={collection} />
+
+					{columnsVisibility && (
+						<Cell keyValue="visibility" width="72px">
+							<Menu
+								items={collection.getItems()}
+								trigger={
+									<Button
+										aria-label={
+											messages['columnsVisibility']
+										}
+										borderless
+										displayType="secondary"
+										monospaced
+									>
+										<Icon symbol="caret-bottom" />
+									</Button>
+								}
+							>
+								{(item) => (
+									<Item
+										key={item}
+										textValue={
+											collection.getItem(item).value
+										}
+									>
+										<Layout.ContentRow>
+											<Layout.ContentCol expand>
+												{collection.getItem(item).value}
+											</Layout.ContentCol>
+											<Layout.ContentCol>
+												<Toggle
+													disabled={
+														!hiddenColumns.has(
+															item
+														) &&
+														headCellsCount - 1 ===
+															hiddenColumns.size
+													}
+													onToggle={() =>
+														onHiddenColumnsChange(
+															item,
+															collection.getItem(
+																item
+															).index
+														)
+													}
+													toggled={hiddenColumns.has(
+														item
+													)}
+												/>
+											</Layout.ContentCol>
+										</Layout.ContentRow>
+									</Item>
+								)}
+							</Menu>
+						</Cell>
+					)}
 				</tr>
 			</ScopeContext.Provider>
 		</thead>

--- a/packages/clay-core/src/table/Row.tsx
+++ b/packages/clay-core/src/table/Row.tsx
@@ -237,7 +237,12 @@ function RowInner<T extends Record<string, any>>(
 				{columnsVisibility &&
 					!divider &&
 					collection.getSize() === headCellsCount && (
-						<Cell>{null}</Cell>
+						<Cell
+							index={headCellsCount}
+							keyValue={`${keyValue}:visibility`}
+						>
+							{null}
+						</Cell>
 					)}
 			</RowContext.Provider>
 		</tr>

--- a/packages/clay-core/src/table/Row.tsx
+++ b/packages/clay-core/src/table/Row.tsx
@@ -5,11 +5,12 @@
 
 import {Keys} from '@clayui/shared';
 import classNames from 'classnames';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 
 import {useFocusWithin} from '../aria';
-import {ChildrenFunction, Collection} from '../collection';
+import {ChildrenFunction, Collection, useCollection} from '../collection';
 import {useForwardRef} from '../hooks';
+import {Cell} from './Cell';
 import {RowContext, useBody, useTable} from './context';
 
 type Props<T> = {
@@ -105,7 +106,15 @@ function RowInner<T extends Record<string, any>>(
 	}: Props<T>,
 	outRef: React.Ref<HTMLTableRowElement>
 ) {
-	const {expandedKeys, onExpandedChange, onLoadMore, treegrid} = useTable();
+	const {
+		columnsVisibility,
+		expandedKeys,
+		headCellsCount,
+		hiddenColumns,
+		onExpandedChange,
+		onLoadMore,
+		treegrid,
+	} = useTable();
 	const {insert} = useBody();
 	const [isFocused, setIsFocused] = useState(false);
 	const focusWithinProps = useFocusWithin({
@@ -143,6 +152,17 @@ function RowInner<T extends Record<string, any>>(
 	}, [insert, keyValue, _expandable, onLoadMore, lazy]);
 
 	const ref = useForwardRef(outRef);
+
+	const disabledKeys = useMemo(
+		() => Array.from(hiddenColumns.values()),
+		[hiddenColumns]
+	);
+
+	const collection = useCollection({
+		children,
+		disabledKeys,
+		items,
+	});
 
 	return (
 		<tr
@@ -212,7 +232,13 @@ function RowInner<T extends Record<string, any>>(
 					loadMore,
 				}}
 			>
-				<Collection items={items}>{children}</Collection>
+				<Collection collection={collection} />
+
+				{columnsVisibility &&
+					!divider &&
+					collection.getSize() === headCellsCount && (
+						<Cell>{null}</Cell>
+					)}
 			</RowContext.Provider>
 		</tr>
 	);

--- a/packages/clay-core/src/table/Table.tsx
+++ b/packages/clay-core/src/table/Table.tsx
@@ -53,6 +53,8 @@ export type Props = {
 	 */
 	messages?: {
 		columnsVisibility: string;
+		columnsVisibilityDescription: string;
+		columnsVisibilityHeader: string;
 		expandable: string;
 		sortDescription: string;
 		sorting: string;
@@ -116,6 +118,9 @@ export const Table = React.forwardRef<HTMLDivElement, Props>(
 			expandedKeys: externalExpandedKeys,
 			messages = {
 				columnsVisibility: 'Manage Columns Visibility',
+				columnsVisibilityDescription:
+					'At least one column must remain visible.',
+				columnsVisibilityHeader: 'Columns Visibility',
 				expandable: 'expandable',
 				sortDescription: 'sortable column',
 				sorting: 'sorted by column {0} in {1} order',

--- a/packages/clay-core/src/table/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/table/__tests__/IncrementalInteractions.tsx
@@ -37,7 +37,7 @@ const itemsTree = [
 	},
 ];
 
-describe('Picker incremental interactions', () => {
+describe('Table incremental interactions', () => {
 	afterEach(cleanup);
 
 	it('clicking on the column does the sorting', () => {
@@ -84,7 +84,7 @@ describe('Picker incremental interactions', () => {
 						)}
 					</Head>
 
-					<Body items={items}>
+					<Body defaultItems={items}>
 						{(row) => (
 							<Row items={columns}>
 								{/** @ts-ignore */}
@@ -103,7 +103,7 @@ describe('Picker incremental interactions', () => {
 		expect(name!.getAttribute('aria-sort')).toBe('none');
 		expect(type!.getAttribute('aria-sort')).toBe('none');
 
-		const [row1Col1, , row2Col1, , row3Col1] = getAllByRole('cell');
+		const [row1Col1, , , row2Col1, , , row3Col1] = getAllByRole('cell');
 
 		expect(row1Col1!.textContent).toBe('Foo');
 		expect(row2Col1!.textContent).toBe('Bar');
@@ -114,7 +114,7 @@ describe('Picker incremental interactions', () => {
 		expect(name!.getAttribute('aria-sort')).toBe('ascending');
 		expect(type!.getAttribute('aria-sort')).toBe('none');
 
-		const [newRow1Col1, , newRow2Col1, , newRow3Col1] =
+		const [newRow1Col1, , , newRow2Col1, , , newRow3Col1] =
 			getAllByRole('cell');
 
 		expect(newRow1Col1!.textContent).toBe('Bar');
@@ -166,7 +166,7 @@ describe('Picker incremental interactions', () => {
 						)}
 					</Head>
 
-					<Body items={filteredItems}>
+					<Body defaultItems={filteredItems}>
 						{(row) => (
 							<Row items={columns}>
 								{/** @ts-ignore */}
@@ -185,7 +185,7 @@ describe('Picker incremental interactions', () => {
 		expect(name!.getAttribute('aria-sort')).toBe('ascending');
 		expect(type!.getAttribute('aria-sort')).toBe('none');
 
-		const [row1Col1, , row2Col1, , row3Col1] = getAllByRole('cell');
+		const [row1Col1, , , row2Col1, , , row3Col1] = getAllByRole('cell');
 
 		expect(row1Col1!.textContent).toBe('Bar');
 		expect(row2Col1!.textContent).toBe('Baz');
@@ -196,7 +196,7 @@ describe('Picker incremental interactions', () => {
 		expect(name!.getAttribute('aria-sort')).toBe('descending');
 		expect(type!.getAttribute('aria-sort')).toBe('none');
 
-		const [newRow1Col1, , newRow2Col1, , newRow3Col1] =
+		const [newRow1Col1, , , newRow2Col1, , , newRow3Col1] =
 			getAllByRole('cell');
 
 		expect(newRow1Col1!.textContent).toBe('Foo');
@@ -248,7 +248,7 @@ describe('Picker incremental interactions', () => {
 						)}
 					</Head>
 
-					<Body items={filteredItems}>
+					<Body defaultItems={filteredItems}>
 						{(row) => (
 							<Row items={columns}>
 								{/** @ts-ignore */}
@@ -267,7 +267,7 @@ describe('Picker incremental interactions', () => {
 		expect(name!.getAttribute('aria-sort')).toBe('ascending');
 		expect(type!.getAttribute('aria-sort')).toBe('none');
 
-		const [row1Col1, , row2Col1, , row3Col1] = getAllByRole('cell');
+		const [row1Col1, , , row2Col1, , , row3Col1] = getAllByRole('cell');
 
 		expect(row1Col1!.textContent).toBe('Bar');
 		expect(row2Col1!.textContent).toBe('Baz');
@@ -278,7 +278,7 @@ describe('Picker incremental interactions', () => {
 		expect(name!.getAttribute('aria-sort')).toBe('none');
 		expect(type!.getAttribute('aria-sort')).toBe('ascending');
 
-		const [, newRow1Col2, , newRow2Col2, , newRow3Col2] =
+		const [, newRow1Col2, , , newRow2Col2, , , newRow3Col2] =
 			getAllByRole('cell');
 
 		expect(newRow1Col2!.textContent).toBe('Files');
@@ -289,12 +289,12 @@ describe('Picker incremental interactions', () => {
 	describe('tree grid', () => {
 		it('pressing tab will move the focus to the first row', () => {
 			const {getAllByRole} = render(
-				<Table nestedKey="children">
+				<Table columnsVisibility={false} nestedKey="children">
 					<Head items={columns}>
 						{(column) => <Cell key={column.id}>{column.name}</Cell>}
 					</Head>
 
-					<Body items={itemsTree}>
+					<Body defaultItems={itemsTree}>
 						{(row) => (
 							<Row items={columns}>
 								{(column) => (
@@ -320,12 +320,12 @@ describe('Picker incremental interactions', () => {
 
 		it('pressing tab again will move the focus to the next element outside the table', () => {
 			const {getAllByRole} = render(
-				<Table nestedKey="children">
+				<Table columnsVisibility={false} nestedKey="children">
 					<Head items={columns}>
 						{(column) => <Cell key={column.id}>{column.name}</Cell>}
 					</Head>
 
-					<Body items={itemsTree}>
+					<Body defaultItems={itemsTree}>
 						{(row) => (
 							<Row items={columns}>
 								{(column) => (
@@ -356,7 +356,7 @@ describe('Picker incremental interactions', () => {
 		describe('keyboard interaction on row', () => {
 			it('pressing the down arrow key moves focus to the row below', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
@@ -393,14 +393,14 @@ describe('Picker incremental interactions', () => {
 
 			it('pressing the up arrow key moves focus to the row above', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
 							)}
 						</Head>
 
-						<Body items={itemsTree}>
+						<Body defaultItems={itemsTree}>
 							{(row) => (
 								<Row items={columns}>
 									{(column) => (
@@ -434,14 +434,14 @@ describe('Picker incremental interactions', () => {
 
 			it('press the left arrow key to collapse the node with expandable', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
 							)}
 						</Head>
 
-						<Body items={itemsTree}>
+						<Body defaultItems={itemsTree}>
 							{(row) => (
 								<Row items={columns}>
 									{(column) => (
@@ -481,14 +481,14 @@ describe('Picker incremental interactions', () => {
 
 			it('pressing the left arrow key moves the focus to the row on the level above', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
 							)}
 						</Head>
 
-						<Body items={itemsTree}>
+						<Body defaultItems={itemsTree}>
 							{(row) => (
 								<Row items={columns}>
 									{(column) => (
@@ -534,14 +534,14 @@ describe('Picker incremental interactions', () => {
 
 			it('pressing the right arrow key moves the focus to the first cell', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
 							)}
 						</Head>
 
-						<Body items={itemsTree}>
+						<Body defaultItems={itemsTree}>
 							{(row) => (
 								<Row items={columns}>
 									{(column) => (
@@ -579,14 +579,14 @@ describe('Picker incremental interactions', () => {
 		describe('keyboard interaction on cell', () => {
 			it('pressing the up arrow key moves the focus to the cell above', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
 							)}
 						</Head>
 
-						<Body items={itemsTree}>
+						<Body defaultItems={itemsTree}>
 							{(row) => (
 								<Row items={columns}>
 									{(column) => (
@@ -626,14 +626,14 @@ describe('Picker incremental interactions', () => {
 
 			it('pressing the down arrow key moves focus to the cell below', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
 							)}
 						</Head>
 
-						<Body items={itemsTree}>
+						<Body defaultItems={itemsTree}>
 							{(row) => (
 								<Row items={columns}>
 									{(column) => (
@@ -669,14 +669,14 @@ describe('Picker incremental interactions', () => {
 
 			it('pressing the right arrow key moves focus to the cell to the right', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
 							)}
 						</Head>
 
-						<Body items={itemsTree}>
+						<Body defaultItems={itemsTree}>
 							{(row) => (
 								<Row items={columns}>
 									{(column) => (
@@ -712,14 +712,14 @@ describe('Picker incremental interactions', () => {
 
 			it('pressing the left arrow key moves the focus to the right cell', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
 							)}
 						</Head>
 
-						<Body items={itemsTree}>
+						<Body defaultItems={itemsTree}>
 							{(row) => (
 								<Row items={columns}>
 									{(column) => (
@@ -759,14 +759,14 @@ describe('Picker incremental interactions', () => {
 
 			it('pressing the left arrow key in the first cell moves the focus to the row', () => {
 				const {getAllByRole} = render(
-					<Table nestedKey="children">
+					<Table columnsVisibility={false} nestedKey="children">
 						<Head items={columns}>
 							{(column) => (
 								<Cell key={column.id}>{column.name}</Cell>
 							)}
 						</Head>
 
-						<Body items={itemsTree}>
+						<Body defaultItems={itemsTree}>
 							{(row) => (
 								<Row items={columns}>
 									{(column) => (

--- a/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -6,13 +6,15 @@ exports[`Table basic rendering render dynamic content 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped table-valign-middle"
+      style="table-layout: fixed;"
     >
       <thead>
         <tr>
           <th
             class="table-head-title"
             data-id="string,name"
+            style="width: auto;"
             tabindex="-1"
           >
             Name
@@ -20,9 +22,37 @@ exports[`Table basic rendering render dynamic content 1`] = `
           <th
             class="table-head-title"
             data-id="string,type"
+            style="width: auto;"
             tabindex="-1"
           >
             Type
+          </th>
+          <th
+            class="table-head-title"
+            data-id="string,visibility"
+            style="width: 72px;"
+            tabindex="-1"
+          >
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-controls="clay-id-12"
+                aria-haspopup="true"
+                aria-label="Manage Columns Visibility"
+                class="dropdown-toggle btn btn-monospaced btn-outline-borderless btn-outline-secondary"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-bottom"
+                  role="presentation"
+                >
+                  <use
+                    href="#caret-bottom"
+                  />
+                </svg>
+              </button>
+            </div>
           </th>
         </tr>
       </thead>
@@ -36,6 +66,7 @@ exports[`Table basic rendering render dynamic content 1`] = `
             aria-colindex="1"
             class=""
             data-id="string,name"
+            style="width: auto;"
             tabindex="-1"
           >
             Foo
@@ -44,10 +75,18 @@ exports[`Table basic rendering render dynamic content 1`] = `
             aria-colindex="2"
             class=""
             data-id="string,type"
+            style="width: auto;"
             tabindex="-1"
           >
             Foo
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,1:visibility"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
         <tr
           class=""
@@ -58,6 +97,7 @@ exports[`Table basic rendering render dynamic content 1`] = `
             aria-colindex="1"
             class=""
             data-id="string,name"
+            style="width: auto;"
             tabindex="-1"
           >
             Bar
@@ -66,10 +106,18 @@ exports[`Table basic rendering render dynamic content 1`] = `
             aria-colindex="2"
             class=""
             data-id="string,type"
+            style="width: auto;"
             tabindex="-1"
           >
             Bar
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,2:visibility"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
         <tr
           class=""
@@ -80,6 +128,7 @@ exports[`Table basic rendering render dynamic content 1`] = `
             aria-colindex="1"
             class=""
             data-id="string,name"
+            style="width: auto;"
             tabindex="-1"
           >
             Baz
@@ -88,10 +137,18 @@ exports[`Table basic rendering render dynamic content 1`] = `
             aria-colindex="2"
             class=""
             data-id="string,type"
+            style="width: auto;"
             tabindex="-1"
           >
             Baz
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,3:visibility"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
       </tbody>
     </table>
@@ -105,13 +162,15 @@ exports[`Table basic rendering render static content 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped table-valign-middle"
+      style="table-layout: fixed;"
     >
       <thead>
         <tr>
           <th
             class="table-head-title"
             data-id="string,name"
+            style="width: auto;"
             tabindex="-1"
           >
             Name
@@ -119,9 +178,37 @@ exports[`Table basic rendering render static content 1`] = `
           <th
             class="table-head-title"
             data-id="string,type"
+            style="width: auto;"
             tabindex="-1"
           >
             Type
+          </th>
+          <th
+            class="table-head-title"
+            data-id="string,visibility"
+            style="width: 72px;"
+            tabindex="-1"
+          >
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-controls="clay-id-4"
+                aria-haspopup="true"
+                aria-label="Manage Columns Visibility"
+                class="dropdown-toggle btn btn-monospaced btn-outline-borderless btn-outline-secondary"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-bottom"
+                  role="presentation"
+                >
+                  <use
+                    href="#caret-bottom"
+                  />
+                </svg>
+              </button>
+            </div>
           </th>
         </tr>
       </thead>
@@ -135,6 +222,7 @@ exports[`Table basic rendering render static content 1`] = `
             aria-colindex="1"
             class=""
             data-id="string,$.0"
+            style="width: auto;"
             tabindex="-1"
           >
             Foo
@@ -143,10 +231,18 @@ exports[`Table basic rendering render static content 1`] = `
             aria-colindex="2"
             class=""
             data-id="string,$.1"
+            style="width: auto;"
             tabindex="-1"
           >
             Foo
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,undefined:visibility"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
         <tr
           class=""
@@ -157,6 +253,7 @@ exports[`Table basic rendering render static content 1`] = `
             aria-colindex="1"
             class=""
             data-id="string,$.0"
+            style="width: auto;"
             tabindex="-1"
           >
             Bar
@@ -165,10 +262,18 @@ exports[`Table basic rendering render static content 1`] = `
             aria-colindex="2"
             class=""
             data-id="string,$.1"
+            style="width: auto;"
             tabindex="-1"
           >
             Bar
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,undefined:visibility"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
         <tr
           class=""
@@ -179,6 +284,7 @@ exports[`Table basic rendering render static content 1`] = `
             aria-colindex="1"
             class=""
             data-id="string,$.0"
+            style="width: auto;"
             tabindex="-1"
           >
             Baz
@@ -187,10 +293,18 @@ exports[`Table basic rendering render static content 1`] = `
             aria-colindex="2"
             class=""
             data-id="string,$.1"
+            style="width: auto;"
             tabindex="-1"
           >
             Baz
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,undefined:visibility"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
       </tbody>
     </table>
@@ -204,16 +318,18 @@ exports[`Table basic rendering render with sort column 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped table-valign-middle"
+      style="table-layout: fixed;"
     >
       <thead>
         <tr>
           <th
             aria-colindex="1"
-            aria-describedby="clay-id-13"
+            aria-describedby="clay-id-17"
             aria-sort="none"
             class="table-head-title"
             data-id="string,name"
+            style="width: auto;"
             tabindex="-1"
           >
             <a
@@ -230,10 +346,11 @@ exports[`Table basic rendering render with sort column 1`] = `
           </th>
           <th
             aria-colindex="2"
-            aria-describedby="clay-id-13"
+            aria-describedby="clay-id-17"
             aria-sort="none"
             class="table-head-title"
             data-id="string,type"
+            style="width: auto;"
             tabindex="-1"
           >
             <a
@@ -248,6 +365,33 @@ exports[`Table basic rendering render with sort column 1`] = `
               </span>
             </a>
           </th>
+          <th
+            class="table-head-title"
+            data-id="string,visibility"
+            style="width: 72px;"
+            tabindex="-1"
+          >
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-controls="clay-id-20"
+                aria-haspopup="true"
+                aria-label="Manage Columns Visibility"
+                class="dropdown-toggle btn btn-monospaced btn-outline-borderless btn-outline-secondary"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-bottom"
+                  role="presentation"
+                >
+                  <use
+                    href="#caret-bottom"
+                  />
+                </svg>
+              </button>
+            </div>
+          </th>
         </tr>
       </thead>
       <tbody>
@@ -260,6 +404,7 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-colindex="1"
             class=""
             data-id="string,$.0"
+            style="width: auto;"
             tabindex="-1"
           >
             Foo
@@ -268,10 +413,18 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-colindex="2"
             class=""
             data-id="string,$.1"
+            style="width: auto;"
             tabindex="-1"
           >
             Foo
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,undefined:visibility"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
         <tr
           class=""
@@ -282,6 +435,7 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-colindex="1"
             class=""
             data-id="string,$.0"
+            style="width: auto;"
             tabindex="-1"
           >
             Bar
@@ -290,10 +444,18 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-colindex="2"
             class=""
             data-id="string,$.1"
+            style="width: auto;"
             tabindex="-1"
           >
             Bar
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,undefined:visibility"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
         <tr
           class=""
@@ -304,6 +466,7 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-colindex="1"
             class=""
             data-id="string,$.0"
+            style="width: auto;"
             tabindex="-1"
           >
             Baz
@@ -312,10 +475,18 @@ exports[`Table basic rendering render with sort column 1`] = `
             aria-colindex="2"
             class=""
             data-id="string,$.1"
+            style="width: auto;"
             tabindex="-1"
           >
             Baz
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,undefined:visibility"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
       </tbody>
     </table>
@@ -330,8 +501,9 @@ exports[`Table basic rendering render with treegrid 1`] = `
   >
     <table
       aria-label="File Explorer"
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped table-nested-rows"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped table-valign-middle table-nested-rows"
       role="treegrid"
+      style="table-layout: fixed;"
     >
       <thead>
         <tr>
@@ -339,6 +511,7 @@ exports[`Table basic rendering render with treegrid 1`] = `
             class="table-head-title"
             data-id="string,name"
             role="gridcell"
+            style="width: auto;"
             tabindex="-1"
           >
             Name
@@ -347,9 +520,38 @@ exports[`Table basic rendering render with treegrid 1`] = `
             class="table-head-title"
             data-id="string,type"
             role="gridcell"
+            style="width: auto;"
             tabindex="-1"
           >
             Type
+          </th>
+          <th
+            class="table-head-title"
+            data-id="string,visibility"
+            role="gridcell"
+            style="width: 72px;"
+            tabindex="-1"
+          >
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-controls="clay-id-28"
+                aria-haspopup="true"
+                aria-label="Manage Columns Visibility"
+                class="dropdown-toggle btn btn-monospaced btn-outline-borderless btn-outline-secondary"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-bottom"
+                  role="presentation"
+                >
+                  <use
+                    href="#caret-bottom"
+                  />
+                </svg>
+              </button>
+            </div>
           </th>
         </tr>
       </thead>
@@ -368,6 +570,7 @@ exports[`Table basic rendering render with treegrid 1`] = `
             class=""
             data-id="string,1:name"
             role="gridcell"
+            style="width: auto;"
             tabindex="-1"
           >
             <div
@@ -386,10 +589,19 @@ exports[`Table basic rendering render with treegrid 1`] = `
             class=""
             data-id="string,1:type"
             role="gridcell"
+            style="width: auto;"
             tabindex="-1"
           >
             Folder
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,1:visibility"
+            role="gridcell"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
         <tr
           aria-expanded="false"
@@ -406,6 +618,7 @@ exports[`Table basic rendering render with treegrid 1`] = `
             class=""
             data-id="string,2:name"
             role="gridcell"
+            style="width: auto;"
             tabindex="-1"
           >
             <div
@@ -443,10 +656,19 @@ exports[`Table basic rendering render with treegrid 1`] = `
             class=""
             data-id="string,2:type"
             role="gridcell"
+            style="width: auto;"
             tabindex="-1"
           >
             Folder
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,2:visibility"
+            role="gridcell"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
         <tr
           aria-level="1"
@@ -462,6 +684,7 @@ exports[`Table basic rendering render with treegrid 1`] = `
             class=""
             data-id="string,10:name"
             role="gridcell"
+            style="width: auto;"
             tabindex="-1"
           >
             <div
@@ -480,10 +703,19 @@ exports[`Table basic rendering render with treegrid 1`] = `
             class=""
             data-id="string,10:type"
             role="gridcell"
+            style="width: auto;"
             tabindex="-1"
           >
             Folder
           </td>
+          <td
+            aria-colindex="3"
+            class=""
+            data-id="string,10:visibility"
+            role="gridcell"
+            style="width: auto;"
+            tabindex="-1"
+          />
         </tr>
       </tbody>
     </table>

--- a/packages/clay-core/src/table/context.tsx
+++ b/packages/clay-core/src/table/context.tsx
@@ -11,12 +11,17 @@ export type Sorting = {
 };
 
 type Context = {
+	columnsVisibility: boolean;
 	expandedKeys: Set<React.Key>;
+	headCellsCount: number;
+	hiddenColumns: Map<React.Key, number>;
 	messages: Record<string, string>;
 	nestedKey?: string;
 	onExpandedChange: (keys: Set<React.Key>) => void;
+	onHeadCellsChange: (value: number) => void;
 	onLoadMore?: (item: unknown) => Promise<Array<any> | undefined>;
 	onSortChange: (sorting: Sorting | null, textValue: string) => void;
+	onHiddenColumnsChange: (column: React.Key, index: number) => void;
 	sort: Sorting | null;
 	sortDescriptionId: string;
 	treegrid: boolean;


### PR DESCRIPTION
Ticket [LPS-202287](https://liferay.atlassian.net/browse/LPS-202287)

This PR is still a draft but it adds the main functionality of being able to hide the column, by default we are leaving this functionality always activated but it is possible to deactivate it using the `columnsVisibility` API.

There are still visual details to adjust that are related to DropDown, like the DropDown header and the new switch size, I will work on that tomorrow.