### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get Author's Username
         id: get_author
-        run: echo "::set-output name=author::${{ github.event.issue.user.login }}"
+        run: echo "author=${{ github.event.issue.user.login }}" >> $GITHUB_OUTPUT
 
       - name: Add Comment
         uses: actions/github-script@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           sha_new=$(git rev-parse HEAD)
           echo $sha_new
-          echo "::set-output name=SHA::$sha_new"
+          echo "SHA=$sha_new" >> $GITHUB_OUTPUT
       - run:
           echo ${{ steps.sha.outputs.SHA }}
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


