### PR TITLE
fix(@clayui/core): fixes bug when not focusing on the first item

### DIFF
--- a/packages/clay-core/src/drop-down/Menu.tsx
+++ b/packages/clay-core/src/drop-down/Menu.tsx
@@ -98,10 +98,13 @@ type Props<T> = {
 	};
 
 	style?: React.CSSProperties;
+
+	UNSAFE_focusableElements?: Array<string>;
 } & Omit<Partial<ICollectionProps<T, unknown>>, 'virtualize'>;
 
 function MenuInner<T extends Record<string, unknown> | string | number>(
 	{
+		UNSAFE_focusableElements,
 		active: externalActive,
 		alwaysClose = true,
 		as: As = 'div',
@@ -197,6 +200,7 @@ function MenuInner<T extends Record<string, unknown> | string | number>(
 		activation: 'manual',
 		collection: items && items.length > 70 ? collection : undefined,
 		containerRef: menuRef,
+		focusableElements: UNSAFE_focusableElements,
 		loop: true,
 		orientation: 'vertical',
 		typeahead: true,
@@ -290,7 +294,10 @@ function MenuInner<T extends Record<string, unknown> | string | number>(
 									// to commit the changes to the DOM so that the elements are
 									// visible and we can move the focus.
 									setTimeout(() => {
-										const list = getFocusableList(menuRef);
+										const list = getFocusableList(
+											menuRef,
+											UNSAFE_focusableElements
+										);
 
 										if (list.length) {
 											list[0]!.focus();

--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -23,7 +23,7 @@ type HeaderProps = {
 const Header = React.forwardRef<HTMLLIElement, HeaderProps>(
 	function HeaderInner({description, name}: HeaderProps, ref) {
 		return (
-			<li key={name} ref={ref} role="presentation">
+			<li key={name} ref={ref} role="presentation" tabIndex={-1}>
 				<div className="dropdown-subheader mb-0">
 					{name.toUpperCase()}
 				</div>
@@ -81,6 +81,7 @@ function HeadInner<T extends Record<string, any>>(
 					{columnsVisibility && (
 						<Cell keyValue="visibility" width="72px">
 							<Menu
+								alwaysClose={false}
 								items={[
 									{
 										description:
@@ -120,6 +121,13 @@ function HeadInner<T extends Record<string, any>>(
 									) : (
 										<Item
 											key={item}
+											onClick={() =>
+												onHiddenColumnsChange(
+													item,
+													collection.getItem(item)
+														.index
+												)
+											}
 											textValue={
 												collection.getItem(item).value
 											}
@@ -146,15 +154,8 @@ function HeadInner<T extends Record<string, any>>(
 																1 ===
 																hiddenColumns.size
 														}
-														onToggle={() =>
-															onHiddenColumnsChange(
-																item,
-																collection.getItem(
-																	item
-																).index
-															)
-														}
 														sizing="sm"
+														tabIndex={-1}
 														toggled={hiddenColumns.has(
 															item
 														)}

--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -81,6 +81,9 @@ function HeadInner<T extends Record<string, any>>(
 					{columnsVisibility && (
 						<Cell keyValue="visibility" width="72px">
 							<Menu
+								UNSAFE_focusableElements={[
+									'input[role="switch"]',
+								]}
 								alwaysClose={false}
 								items={[
 									{
@@ -128,6 +131,7 @@ function HeadInner<T extends Record<string, any>>(
 														.index
 												)
 											}
+											tabIndex={-1}
 											textValue={
 												collection.getItem(item).value
 											}
@@ -154,8 +158,31 @@ function HeadInner<T extends Record<string, any>>(
 																1 ===
 																hiddenColumns.size
 														}
+														onChange={(event) => {
+															event.stopPropagation();
+
+															onHiddenColumnsChange(
+																item,
+																collection.getItem(
+																	item
+																).index
+															);
+														}}
+														onKeyDown={(event) => {
+															switch (event.key) {
+																case 'Enter':
+																	onHiddenColumnsChange(
+																		item,
+																		collection.getItem(
+																			item
+																		).index
+																	);
+																	break;
+																default:
+																	break;
+															}
+														}}
 														sizing="sm"
-														tabIndex={-1}
 														toggled={hiddenColumns.has(
 															item
 														)}


### PR DESCRIPTION
Ticket [LPD-16299](https://liferay.atlassian.net/browse/LPD-16299)

This fixes the bug when not being able to navigate via keyboard in the Columns Visibility of the table and improves accessibility, I'm still not sure what would be the best case here for toggle accessibility because DropDown is a menuitem list, so we still need to have the focus of the switch so that it announce correctly through SR, otherwise the announce will only be for the menuitem. Any idea?