### PR TITLE
fix(@clayui/css): LPD-15629 Accessibility link and text should have 3…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -434,7 +434,7 @@ $headings-color: null !default;
 // Body
 
 $body-bg: $white !default;
-$body-color: $gray-900 !default;
+$body-color: $dark-d1 !default;
 $body-moz-osx-font-smoothing: $moz-osx-font-smoothing !default;
 $body-webkit-font-smoothing: $webkit-font-smoothing !default;
 $body-text-align: inherit !default;

--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -681,7 +681,7 @@ $cadmin-reset: map-merge(
 // Body
 
 $cadmin-body-bg: $cadmin-white !default;
-$cadmin-body-color: $cadmin-gray-900 !default;
+$cadmin-body-color: $cadmin-dark-d1 !default;
 
 // Button
 


### PR DESCRIPTION
…:1 color contrast

https://liferay.atlassian.net/browse/LPD-15629

This changes body text color to #1c1c24 so it will have at least a 3:1 contrast ratio with link colors #0b5fff. When we have inline links with text, the contrast between link and text wasn't high enough.

```
The quick brown fox jumped <a href="#example">over</a> the lazy dog.
```

![color-contrast](https://github.com/liferay/clay/assets/788266/2de5fe15-911b-4bed-b751-3d3b674f4aa7)
