### PR TITLE
fix(@clayui/core): LPS-203851 fixes bug when keeping DropDown open in TreeView actions in Firefox

### DIFF
--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -265,6 +265,7 @@ export const TreeViewItem = React.forwardRef<
 					onBlur={(event) => {
 						if (
 							actions &&
+							event.relatedTarget &&
 							!item.itemRef.current?.contains(
 								event.relatedTarget as HTMLElement
 							)

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -242,8 +242,12 @@ export const Actions = () => (
 					</Button>
 					<DropDownWithItems
 						items={[
-							{label: 'One'},
-							{label: 'Two'},
+							{
+								href: '#',
+								label: 'One',
+								onClick: (event) => event.preventDefault(),
+							},
+							{href: '#', label: 'Two'},
 							{label: 'Three'},
 						]}
 						trigger={


### PR DESCRIPTION
Ticket [LPS-203851](https://liferay.atlassian.net/browse/LPS-203851)

Well, basically this is a follow-up fix where the original fix only fixed the bug in Chrome and still kept reproducing in Firefox. After some tests it seems that the problem was always happening when the DropDown Item is a link, when clicking on the link the TreeView node's blur event is triggered first than the dropdown item, causing the dropdown trigger to disappear and the menu was repositioned and for some reason it didn't trigger the click on the DropDown item afterwards. I still haven't found a clear explanation about this behavior and because it happens in Firefox, my assumption is still the order of events and perhaps the cancellation midway.

To prevent the DropDown trigger from disappearing, I'm just adding that in the blur of the TreeView node the `event.relatedTarget` is different from null or undefined, this does the trick because the click needs to be on some valid node so we can check if the click it still happens in DropDown or outside.