### PR TITLE
fix(@clayui/pagination): LPD-1285 accessibility issues on prev, next …

### DIFF
--- a/packages/clay-core/src/drop-down/Menu.tsx
+++ b/packages/clay-core/src/drop-down/Menu.tsx
@@ -214,7 +214,7 @@ function MenuInner<T extends Record<string, unknown> | string | number>(
 	return (
 		<div className="dropdown" ref={containerRef}>
 			{React.cloneElement(trigger, {
-				'aria-controls': ariaControlsId,
+				'aria-controls': active ? ariaControlsId : undefined,
 				'aria-expanded': active,
 				'aria-haspopup': 'true',
 				className: classNames(

--- a/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -37,7 +37,6 @@ exports[`Table basic rendering render dynamic content 1`] = `
               class="dropdown"
             >
               <button
-                aria-controls="clay-id-12"
                 aria-haspopup="true"
                 aria-label="Manage Columns Visibility"
                 class="dropdown-toggle btn btn-monospaced btn-outline-borderless btn-outline-secondary"
@@ -193,7 +192,6 @@ exports[`Table basic rendering render static content 1`] = `
               class="dropdown"
             >
               <button
-                aria-controls="clay-id-4"
                 aria-haspopup="true"
                 aria-label="Manage Columns Visibility"
                 class="dropdown-toggle btn btn-monospaced btn-outline-borderless btn-outline-secondary"
@@ -423,7 +421,6 @@ exports[`Table basic rendering render with sort column 1`] = `
               class="dropdown"
             >
               <button
-                aria-controls="clay-id-20"
                 aria-haspopup="true"
                 aria-label="Manage Columns Visibility"
                 class="dropdown-toggle btn btn-monospaced btn-outline-borderless btn-outline-secondary"
@@ -584,7 +581,6 @@ exports[`Table basic rendering render with treegrid 1`] = `
               class="dropdown"
             >
               <button
-                aria-controls="clay-id-28"
                 aria-haspopup="true"
                 aria-label="Manage Columns Visibility"
                 class="dropdown-toggle btn btn-monospaced btn-outline-borderless btn-outline-secondary"

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -99,7 +99,6 @@ exports[`ClayPaginationBar renders 1`] = `
             class="dropdown"
           >
             <button
-              aria-controls="clay-id-5"
               aria-haspopup="true"
               aria-label="Show pages 4 through 9"
               class="dropdown-toggle page-link btn btn-unstyled"
@@ -128,6 +127,7 @@ exports[`ClayPaginationBar renders 1`] = `
             aria-label="Go to the next page, 2"
             class="page-link"
             data-testid="nextArrow"
+            role="button"
             tabindex="0"
           >
             <svg
@@ -220,7 +220,6 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
             class="dropdown"
           >
             <button
-              aria-controls="clay-id-8"
               aria-haspopup="true"
               aria-label="Show pages 4 through 9"
               class="dropdown-toggle page-link btn btn-unstyled"
@@ -249,6 +248,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
             aria-label="Go to the next page, 2"
             class="page-link"
             data-testid="nextArrow"
+            role="button"
             tabindex="0"
           >
             <svg

--- a/packages/clay-pagination/src/PaginationWithBasicItems.tsx
+++ b/packages/clay-pagination/src/PaginationWithBasicItems.tsx
@@ -164,6 +164,11 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 					disabled={internalActive === 1}
 					href={previousHref}
 					onClick={() => setActive(previousPage)}
+					role={
+						previousHref || internalActive === 1
+							? undefined
+							: 'button'
+					}
 				>
 					<ClayIcon spritemap={spritemap} symbol="angle-left" />
 				</Pagination.Item>
@@ -217,6 +222,11 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 					disabled={internalActive === totalPages}
 					href={nextHref}
 					onClick={() => setActive(nextPage)}
+					role={
+						nextHref || internalActive === totalPages
+							? undefined
+							: 'button'
+					}
 				>
 					<ClayIcon spritemap={spritemap} symbol="angle-right" />
 				</Pagination.Item>

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -15,6 +15,7 @@ exports[`ClayPagination renders 1`] = `
           aria-label="Go to the previous page, 11"
           class="page-link"
           data-testid="prevArrow"
+          role="button"
           tabindex="0"
         >
           <svg
@@ -45,7 +46,6 @@ exports[`ClayPagination renders 1`] = `
           class="dropdown"
         >
           <button
-            aria-controls="clay-id-2"
             aria-haspopup="true"
             aria-label="Show pages 2 through 9"
             class="dropdown-toggle page-link btn btn-unstyled"
@@ -118,7 +118,6 @@ exports[`ClayPagination renders 1`] = `
           class="dropdown"
         >
           <button
-            aria-controls="clay-id-4"
             aria-haspopup="true"
             aria-label="Show pages 15 through 24"
             class="dropdown-toggle page-link btn btn-unstyled"
@@ -147,6 +146,7 @@ exports[`ClayPagination renders 1`] = `
           aria-label="Go to the next page, 13"
           class="page-link"
           data-testid="nextArrow"
+          role="button"
           tabindex="0"
         >
           <svg


### PR DESCRIPTION
…and ellipsis buttons

https://liferay.atlassian.net/browse/LPD-1285

This adds `role="button"` to the prev and next buttons. Axe flags these because there is no href attribute. This also adds `aria-controls="clay-id-#"` on the ellipsis button when it is active. The dropdown-menu is lazy loaded and Axe can't associate `aria-controls` to the dropdown-menu.

Axe Errors
![accessibility-errors](https://github.com/liferay/clay/assets/788266/2ddf402c-7cb1-4d5b-968d-8731df533e7c)

After Fix
![accessibility-fixed](https://github.com/liferay/clay/assets/788266/4c38fc4a-6e67-4938-ad55-16519e1954e6)
