### PR TITLE
feat: add cron job to run clayui.com's nightly build

### DIFF
--- a/.github/workflows/clay-nightly.yml
+++ b/.github/workflows/clay-nightly.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Curl request
-        run: curl -X POST -d {} ${{ secrets.NETLIFY_WEBHOOK }}
+        run: curl -X POST -d {} https://api.netlify.com/build_hooks/${{ secrets.NETLIFY_WEBHOOK }}

--- a/.github/workflows/clay-nightly.yml
+++ b/.github/workflows/clay-nightly.yml
@@ -1,0 +1,13 @@
+name: Clayui.com Nightly Build
+
+on:
+  schedule:
+    # Run at At 02:00 AM UTC (07:00 PM PDT)
+    - cron: '0 2 * * *'
+jobs:
+  build:
+    name: Request Netlify Webhook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Curl request
+        run: curl -X POST -d {} ${{ secrets.NETLIFY_WEBHOOK }}


### PR DESCRIPTION
Before merging this we need to add the build hook to the secret of the Github repository, I think we need to open a ticket for this.