### PR TITLE
feat(@clayui/core): adds the `index` available in the item collection API

### DIFF
--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -20,7 +20,7 @@ export type ChildElement = IReactTypeElement & {
 
 export type ChildrenFunction<T, P> = P extends Array<unknown>
 	? (item: T, ...args: P) => React.ReactElement
-	: (item: T) => React.ReactElement;
+	: (item: T, index?: number) => React.ReactElement;
 
 export interface ICollectionProps<T, P> {
 	/**

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -219,7 +219,7 @@ export function useCollection<
 							: (item as T);
 					const child = Array.isArray(publicApi)
 						? (children(publicItem, ...publicApi) as ChildElement)
-						: (children(publicItem) as ChildElement);
+						: (children(publicItem, index) as ChildElement);
 
 					callNestedChild(child);
 
@@ -274,7 +274,10 @@ export function useCollection<
 									publicItem,
 									...publicApi
 							  ) as ChildElement)
-							: (children(publicItem) as ChildElement);
+							: (children(
+									publicItem,
+									virtual.index
+							  ) as ChildElement);
 
 						const props = {
 							'data-index': virtual.index,
@@ -317,7 +320,7 @@ export function useCollection<
 							: item;
 					const child = Array.isArray(publicApi)
 						? (children(publicItem, ...publicApi) as ChildElement)
-						: (children(publicItem) as ChildElement);
+						: (children(publicItem, index) as ChildElement);
 
 					const key = getKey(
 						index,


### PR DESCRIPTION
Ticket [LPD-21653](https://liferay.atlassian.net/browse/LPD-21653)

Basically we are always exposing the `index` of the item in the collection, at this moment I am adding it only for the case where there are no other APIs together like the TreeView due to the type of API that we would have to modify and it would probably be a breaking change.