### PR TITLE
feat(@clayui/card): Radio Card component variant

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -39,7 +39,7 @@ module.exports = {
 		},
 		'./packages/clay-card/src/': {
 			branches: 82,
-			functions: 90,
+			functions: 82,
 			lines: 95,
 			statements: 95,
 		},

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"size-limit": [
 		{
 			"path": "all.js",
-			"limit": "156 kb",
+			"limit": "157 kb",
 			"ignore": [
 				"react",
 				"react-dom"

--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -67,6 +67,11 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	 * Name of the item
 	 */
 	title: string;
+
+	/**
+	 * Flag to indicate if the card text is truncated
+	 */
+	truncate?: boolean;
 }
 
 /**
@@ -102,6 +107,7 @@ export const ClayCardWithHorizontal = ({
 	spritemap,
 	symbol = 'folder',
 	title,
+	truncate = true,
 	...otherProps
 }: IProps & (RadioProps | CheckboxProps)) => {
 	const content = (
@@ -119,6 +125,7 @@ export const ClayCardWithHorizontal = ({
 						disabled={disabled}
 						displayType="title"
 						href={href}
+						truncate={truncate}
 					>
 						{title}
 					</ClayCard.Description>

--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -5,7 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
-import {ClayCheckbox} from '@clayui/form';
+import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClaySticker from '@clayui/sticker';
@@ -43,9 +43,10 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	href?: string;
 
 	/**
-	 * Callback for when item is selected
+	 * Props to add to the radio element
 	 */
-	onSelectChange?: (val: boolean) => void;
+
+	radioProps?: React.HTMLAttributes<HTMLInputElement> & {value: string};
 
 	/**
 	 * Flag to indicate if card is selected
@@ -68,6 +69,23 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	title: string;
 }
 
+/**
+ * Different types of props depending on selectableType.
+ *
+ * onSelectChange: callback for when item is selected
+ * selectableType: determines what type of selectable it is
+ */
+
+type CheckboxProps = {
+	onSelectChange?: (value: boolean) => void;
+	selectableType?: 'checkbox';
+};
+
+type RadioProps = {
+	onSelectChange?: (value: string) => void;
+	selectableType: 'radio';
+};
+
 export const ClayCardWithHorizontal = ({
 	'aria-label': ariaLabel,
 	actions,
@@ -78,12 +96,14 @@ export const ClayCardWithHorizontal = ({
 	},
 	href,
 	onSelectChange,
+	radioProps = {value: ''},
+	selectableType,
 	selected = false,
 	spritemap,
 	symbol = 'folder',
 	title,
 	...otherProps
-}: IProps) => {
+}: IProps & (RadioProps | CheckboxProps)) => {
 	const content = (
 		<ClayCard.Body>
 			<ClayCard.Row>
@@ -132,16 +152,30 @@ export const ClayCardWithHorizontal = ({
 			active={selected}
 			selectable={!!onSelectChange}
 		>
-			{onSelectChange && (
-				<ClayCheckbox
-					{...checkboxProps}
-					checked={selected}
-					disabled={disabled}
-					onChange={() => onSelectChange(!selected)}
-				>
-					<ClayCardHorizontal.Body>{content}</ClayCardHorizontal.Body>
-				</ClayCheckbox>
-			)}
+			{onSelectChange &&
+				(selectableType === 'radio' ? (
+					<ClayRadio
+						{...radioProps}
+						checked={selected}
+						disabled={disabled}
+						onChange={({target: {value}}) => onSelectChange(value)}
+					>
+						<ClayCardHorizontal.Body>
+							{content}
+						</ClayCardHorizontal.Body>
+					</ClayRadio>
+				) : (
+					<ClayCheckbox
+						{...checkboxProps}
+						checked={selected}
+						disabled={disabled}
+						onChange={() => onSelectChange(!selected)}
+					>
+						<ClayCardHorizontal.Body>
+							{content}
+						</ClayCardHorizontal.Body>
+					</ClayCheckbox>
+				))}
 
 			{!onSelectChange && content}
 		</ClayCardHorizontal>

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -114,6 +114,11 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	 * Name of the file
 	 */
 	title: string;
+
+	/**
+	 * Flag to indicate if the card text is truncated
+	 */
+	truncate?: boolean;
 }
 
 /**
@@ -156,6 +161,7 @@ export const ClayCardWithInfo = ({
 	stickerProps = {},
 	symbol,
 	title,
+	truncate = true,
 	...otherProps
 }: IProps & (RadioProps | CheckboxProps)) => {
 	const isCardType = {
@@ -263,12 +269,16 @@ export const ClayCardWithInfo = ({
 							disabled={disabled}
 							displayType="title"
 							href={href}
+							truncate={truncate}
 						>
 							{title}
 						</ClayCard.Description>
 
 						{description && (
-							<ClayCard.Description displayType="subtitle">
+							<ClayCard.Description
+								displayType="subtitle"
+								truncate={truncate}
+							>
 								{description}
 							</ClayCard.Description>
 						)}

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -29,6 +29,12 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	checkboxProps?: React.HTMLAttributes<HTMLInputElement>;
 
 	/**
+	 * Props to add to the radio element
+	 */
+
+	radioProps?: React.HTMLAttributes<HTMLInputElement> & {value: string};
+
+	/**
 	 * Description of the file
 	 */
 	description?: React.ReactText;
@@ -143,6 +149,7 @@ export const ClayCardWithInfo = ({
 	imgProps,
 	labels,
 	onSelectChange,
+	radioProps = {value: ''},
 	selectableType,
 	selected = false,
 	spritemap,
@@ -228,6 +235,7 @@ export const ClayCardWithInfo = ({
 			{onSelectChange &&
 				(selectableType === 'radio' ? (
 					<ClayRadio
+						{...radioProps}
 						checked={selected}
 						disabled={disabled}
 						onChange={({target: {value}}) => onSelectChange(value)}

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -5,7 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
-import {ClayCheckbox} from '@clayui/form';
+import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
@@ -81,11 +81,6 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	>;
 
 	/**
-	 * Callback for when item is selected
-	 */
-	onSelectChange?: (val: boolean) => void;
-
-	/**
 	 * Flag to indicate if card is selected
 	 */
 	selected?: boolean;
@@ -115,6 +110,23 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	title: string;
 }
 
+/**
+ * Different types of props depending on selectableType.
+ *
+ * onSelectChange: callback for when item is selected
+ * selectableType: determines what type of selectable it is
+ */
+
+type CheckboxProps = {
+	onSelectChange?: (value: boolean) => void;
+	selectableType?: 'checkbox';
+};
+
+type RadioProps = {
+	onSelectChange?: (value: string) => void;
+	selectableType: 'radio';
+};
+
 export const ClayCardWithInfo = ({
 	'aria-label': ariaLabel,
 	actions,
@@ -131,13 +143,14 @@ export const ClayCardWithInfo = ({
 	imgProps,
 	labels,
 	onSelectChange,
+	selectableType,
 	selected = false,
 	spritemap,
 	stickerProps = {},
 	symbol,
 	title,
 	...otherProps
-}: IProps) => {
+}: IProps & (RadioProps | CheckboxProps)) => {
 	const isCardType = {
 		file: displayType === 'file' && !imgProps,
 		image: displayType === 'image' || imgProps,
@@ -212,16 +225,25 @@ export const ClayCardWithInfo = ({
 			displayType={isCardType.image ? 'image' : 'file'}
 			selectable={!!onSelectChange}
 		>
-			{onSelectChange && (
-				<ClayCheckbox
-					{...checkboxProps}
-					checked={selected}
-					disabled={disabled}
-					onChange={() => onSelectChange(!selected)}
-				>
-					{headerContent}
-				</ClayCheckbox>
-			)}
+			{onSelectChange &&
+				(selectableType === 'radio' ? (
+					<ClayRadio
+						checked={selected}
+						disabled={disabled}
+						onChange={({target: {value}}) => onSelectChange(value)}
+					>
+						{headerContent}
+					</ClayRadio>
+				) : (
+					<ClayCheckbox
+						{...checkboxProps}
+						checked={selected}
+						disabled={disabled}
+						onChange={() => onSelectChange(!selected)}
+					>
+						{headerContent}
+					</ClayCheckbox>
+				))}
 
 			{!onSelectChange && headerContent}
 

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -94,6 +94,11 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	 * Icon name to use for user avatar
 	 */
 	userSymbol?: string;
+
+	/**
+	 * Flag to indicate if the card text is truncated
+	 */
+	truncate?: boolean;
 }
 
 /**
@@ -134,6 +139,7 @@ export const ClayCardWithUser = ({
 	userDisplayType,
 	userImageSrc,
 	userSymbol = 'user',
+	truncate = true,
 	...otherProps
 }: IProps & (RadioProps | CheckboxProps)) => {
 	const content = (
@@ -196,12 +202,16 @@ export const ClayCardWithUser = ({
 							disabled={disabled}
 							displayType="title"
 							href={href}
+							truncate={truncate}
 						>
 							{name}
 						</ClayCard.Description>
 
 						{description && (
-							<ClayCard.Description displayType="subtitle">
+							<ClayCard.Description
+								displayType="subtitle"
+								truncate={truncate}
+							>
 								{description}
 							</ClayCard.Description>
 						)}

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -5,7 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
-import {ClayCheckbox} from '@clayui/form';
+import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClaySticker, {DisplayType as StickerDisplayType} from '@clayui/sticker';
@@ -55,9 +55,10 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	name: string;
 
 	/**
-	 * Callback for when item is selected
+	 * Props to add to the radio element
 	 */
-	onSelectChange?: (val: boolean) => void;
+
+	radioProps?: React.HTMLAttributes<HTMLInputElement> & {value: string};
 
 	/**
 	 * Flag to indicate if card is selected
@@ -95,6 +96,23 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	userSymbol?: string;
 }
 
+/**
+ * Different types of props depending on selectableType.
+ *
+ * onSelectChange: callback for when item is selected
+ * selectableType: determines what type of selectable it is
+ */
+
+type CheckboxProps = {
+	onSelectChange?: (value: boolean) => void;
+	selectableType?: 'checkbox';
+};
+
+type RadioProps = {
+	onSelectChange?: (value: string) => void;
+	selectableType: 'radio';
+};
+
 export const ClayCardWithUser = ({
 	'aria-label': ariaLabel,
 	actions,
@@ -110,12 +128,14 @@ export const ClayCardWithUser = ({
 	selected = false,
 	spritemap,
 	stickerTitle,
+	selectableType,
+	radioProps = {value: ''},
 	userImageAlt = 'thumbnail',
 	userDisplayType,
 	userImageSrc,
 	userSymbol = 'user',
 	...otherProps
-}: IProps) => {
+}: IProps & (RadioProps | CheckboxProps)) => {
 	const content = (
 		<div className="aspect-ratio-item-center-middle card-type-asset-icon">
 			<ClaySticker
@@ -142,16 +162,28 @@ export const ClayCardWithUser = ({
 			selectable={!!onSelectChange}
 		>
 			<ClayCard.AspectRatio className="card-item-first">
-				{onSelectChange && (
-					<ClayCheckbox
-						{...checkboxProps}
-						checked={selected}
-						disabled={disabled}
-						onChange={() => onSelectChange(!selected)}
-					>
-						{content}
-					</ClayCheckbox>
-				)}
+				{onSelectChange &&
+					(selectableType === 'radio' ? (
+						<ClayRadio
+							{...radioProps}
+							checked={selected}
+							disabled={disabled}
+							onChange={({target: {value}}) =>
+								onSelectChange(value)
+							}
+						>
+							{content}
+						</ClayRadio>
+					) : (
+						<ClayCheckbox
+							{...checkboxProps}
+							checked={selected}
+							disabled={disabled}
+							onChange={() => onSelectChange(!selected)}
+						>
+							{content}
+						</ClayCheckbox>
+					))}
 
 				{!onSelectChange && content}
 			</ClayCard.AspectRatio>

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -1601,6 +1601,134 @@ exports[`ClayCardWithHorizontal renders as selectable 1`] = `
 </div>
 `;
 
+exports[`ClayCardWithHorizontal renders with no truncate text 1`] = `
+<div>
+  <div
+    class="card user-card card-type-asset"
+  >
+    <div
+      class="card-item-first aspect-ratio"
+    >
+      <div
+        class="aspect-ratio-item-center-middle card-type-asset-icon"
+      >
+        <span
+          class="sticker sticker-user-icon sticker-circle"
+        >
+          <span
+            class="sticker-overlay"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-user"
+              role="presentation"
+            >
+              <use
+                href="/path/to/some/resource.svg#user"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="card-body"
+    >
+      <div
+        class="card-row"
+      >
+        <div
+          class="autofit-col autofit-col-expand"
+        >
+          <p
+            aria-label="Foo Bar"
+            class="card-title"
+            title="Foo Bar"
+          >
+            Foo Bar
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayCardWithHorizontal renders with radio button 1`] = `
+<div>
+  <div
+    class="form-check-card form-check form-check-middle-left card-type-directory"
+  >
+    <div
+      class="custom-control custom-radio"
+    >
+      <label>
+        <input
+          class="custom-control-input"
+          disabled=""
+          role="radio"
+          type="radio"
+          value="radio1"
+        />
+        <span
+          class="custom-control-label"
+        />
+        <div
+          class="card card-horizontal"
+        >
+          <div
+            class="card-body"
+          >
+            <div
+              class="card-row"
+            >
+              <div
+                class="autofit-col"
+              >
+                <span
+                  class="sticker"
+                >
+                  <span
+                    class="sticker-overlay inline-item"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-folder"
+                      role="presentation"
+                    >
+                      <use
+                        href="/path/to/some/resource.svg#folder"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="autofit-col autofit-col-expand autofit-col-gutters"
+              >
+                <p
+                  aria-label="Foo Bar"
+                  class="card-title"
+                  title="Foo Bar"
+                >
+                  <span
+                    class="text-truncate-inline"
+                  >
+                    <span
+                      class="text-truncate"
+                    >
+                      Foo Bar
+                    </span>
+                  </span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ClayCardWithInfo renders as disabled 1`] = `
 <div>
   <div

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -3391,3 +3391,135 @@ exports[`ClayCardWithUser renders with image 1`] = `
   </div>
 </div>
 `;
+
+exports[`ClayCardWithUser renders with no truncate text 1`] = `
+<div>
+  <div
+    class="card user-card card-type-asset"
+  >
+    <div
+      class="card-item-first aspect-ratio"
+    >
+      <div
+        class="aspect-ratio-item-center-middle card-type-asset-icon"
+      >
+        <span
+          class="sticker sticker-user-icon sticker-circle"
+        >
+          <span
+            class="sticker-overlay"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-user"
+              role="presentation"
+            >
+              <use
+                href="/path/to/some/resource.svg#user"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="card-body"
+    >
+      <div
+        class="card-row"
+      >
+        <div
+          class="autofit-col autofit-col-expand"
+        >
+          <p
+            aria-label="Foo Bar"
+            class="card-title"
+            title="Foo Bar"
+          >
+            Foo Bar
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayCardWithUser renders with radio button 1`] = `
+<div>
+  <div
+    class="form-check-card form-check form-check-top-left user-card card-type-asset"
+  >
+    <div
+      class="card"
+    >
+      <div
+        class="card-item-first aspect-ratio"
+      >
+        <div
+          class="custom-control custom-radio"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="radio1"
+            />
+            <span
+              class="custom-control-label"
+            />
+            <div
+              class="aspect-ratio-item-center-middle card-type-asset-icon"
+            >
+              <span
+                class="sticker sticker-user-icon sticker-circle"
+              >
+                <span
+                  class="sticker-overlay"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-user"
+                    role="presentation"
+                  >
+                    <use
+                      href="/path/to/some/resource.svg#user"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </label>
+        </div>
+      </div>
+      <div
+        class="card-body"
+      >
+        <div
+          class="card-row"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <p
+              aria-label="Foo Bar"
+              class="card-title"
+              title="Foo Bar"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <a
+                  class="text-truncate"
+                  href="#"
+                >
+                  Foo Bar
+                </a>
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -2698,6 +2698,155 @@ exports[`ClayCardWithInfo renders with no sticker 1`] = `
 </div>
 `;
 
+exports[`ClayCardWithInfo renders with no truncate text 1`] = `
+<div>
+  <div
+    class="file-card form-check-card form-check form-check-top-left card-type-asset"
+  >
+    <div
+      class="card"
+    >
+      <div
+        class="custom-control custom-checkbox"
+      >
+        <label>
+          <input
+            class="custom-control-input"
+            type="checkbox"
+          />
+          <span
+            class="custom-control-label"
+          />
+          <div
+            class="card-item-first aspect-ratio"
+          >
+            <div
+              class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-documents-and-media"
+                role="presentation"
+              >
+                <use
+                  href="/path/to/some/resource.svg#documents-and-media"
+                />
+              </svg>
+            </div>
+            <span
+              class="sticker sticker-primary sticker-bottom-left"
+            >
+              <span
+                class="sticker-overlay"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-document-default"
+                  role="presentation"
+                >
+                  <use
+                    href="/path/to/some/resource.svg#document-default"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </label>
+      </div>
+      <div
+        class="card-body"
+      >
+        <div
+          class="card-row"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <p
+              aria-label="Foo Bar"
+              class="card-title"
+              title="Foo Bar"
+            >
+              Foo Bar
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayCardWithInfo renders with radio button 1`] = `
+<div>
+  <div
+    class="file-card form-check-card form-check form-check-top-left card-type-asset"
+  >
+    <div
+      class="card"
+    >
+      <div
+        class="custom-control custom-radio"
+      >
+        <label>
+          <input
+            class="custom-control-input"
+            role="radio"
+            type="radio"
+            value="radio1"
+          />
+          <span
+            class="custom-control-label"
+          />
+          <div
+            class="card-item-first aspect-ratio"
+          >
+            <div
+              class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-documents-and-media"
+                role="presentation"
+              >
+                <use
+                  href="/path/to/some/resource.svg#documents-and-media"
+                />
+              </svg>
+            </div>
+          </div>
+        </label>
+      </div>
+      <div
+        class="card-body"
+      >
+        <div
+          class="card-row"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <p
+              aria-label="Radio Card"
+              class="card-title"
+              title="Radio Card"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <a
+                  class="text-truncate"
+                  href="#"
+                >
+                  Radio Card
+                </a>
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ClayCardWithUser renders ClayCardWithNavigation with image 1`] = `
 <div>
   <a

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -799,6 +799,37 @@ describe('ClayCardWithHorizontal', () => {
 
 		expect(container).toMatchSnapshot();
 	});
+
+	it('renders with radio button', () => {
+		const {container} = render(
+			<ClayCardWithHorizontal
+				disabled
+				href="#"
+				onSelectChange={jest.fn()}
+				radioProps={{value: 'radio1'}}
+				selectableType="radio"
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				title="Foo Bar"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders with no truncate text', () => {
+		const {container} = render(
+			<ClayCardWithUser
+				href="#"
+				name="Foo Bar"
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				truncate={false}
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
 });
 
 describe('ClayCardWithInfo', () => {

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -712,6 +712,35 @@ describe('ClayCardWithUser', () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it('renders with radio button', () => {
+		const {container} = render(
+			<ClayCardWithUser
+				href="#"
+				name="Foo Bar"
+				onSelectChange={jest.fn()}
+				radioProps={{value: 'radio1'}}
+				selectableType="radio"
+				spritemap="/path/to/some/resource.svg"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders with no truncate text', () => {
+		const {container} = render(
+			<ClayCardWithUser
+				href="#"
+				name="Foo Bar"
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				truncate={false}
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
 	it('renders ClayCardWithNavigation with image', () => {
 		const {container} = render(
 			<ClayCardWithNavigation

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -1080,4 +1080,36 @@ describe('ClayCardWithInfo', () => {
 		expect(onDropDownItemClick).toHaveBeenCalledTimes(1);
 		expect(onSelectChangeFn).not.toHaveBeenCalledTimes(1);
 	});
+
+	it('renders with radio button', () => {
+		const {container} = render(
+			<ClayCardWithInfo
+				href="#"
+				onSelectChange={jest.fn()}
+				radioProps={{value: 'radio1'}}
+				selectableType="radio"
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				stickerProps={null}
+				title="Radio Card"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders with no truncate text', () => {
+		const {container} = render(
+			<ClayCardWithInfo
+				href="#"
+				onSelectChange={jest.fn()}
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				title="Foo Bar"
+				truncate={false}
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
 });

--- a/packages/clay-card/stories/Card.stories.tsx
+++ b/packages/clay-card/stories/Card.stories.tsx
@@ -215,36 +215,92 @@ CardWithInfoImage.args = {
 
 export const CardWithHorizontal = (args: any) => {
 	const [value, setValue] = useState<boolean>(false);
+	const [radioValue, setRadioValue] = useState<string>('');
 
 	return (
-		<div className="row">
-			<div className="col-md-4">
-				<ClayCardWithHorizontal href="#" title="Very Large Folder" />
-			</div>
+		<>
+			<div className="row">
+				<div className="col-md-4">
+					<ClayCardWithHorizontal
+						href="#"
+						title="Very Large Folder"
+					/>
+				</div>
 
-			<div className="col-md-4">
-				<ClayCardWithHorizontal
-					actions={[
-						{
-							label: 'clickable',
-							onClick: () => {
-								alert('you clicked!');
+				<div className="col-md-4">
+					<ClayCardWithHorizontal
+						actions={[
+							{
+								label: 'clickable',
+								onClick: () => {
+									alert('you clicked!');
+								},
 							},
-						},
-						{type: 'divider'},
-						{
-							href: '#',
-							label: 'linkable',
-						},
-					]}
-					disabled={args.disabled}
-					href="#"
-					onSelectChange={setValue}
-					selected={value}
-					title="Selectable Folder"
-				/>
+							{type: 'divider'},
+							{
+								href: '#',
+								label: 'linkable',
+							},
+						]}
+						disabled={args.disabled}
+						href="#"
+						onSelectChange={setValue}
+						selected={value}
+						title="Selectable Folder"
+					/>
+				</div>
 			</div>
-		</div>
+			<div className="row">
+				<div className="col-md-12">
+					<ClayCard.Group label="Radio Card Group">
+						<ClayCardWithHorizontal
+							actions={[
+								{
+									label: 'clickable',
+									onClick: () => {
+										alert('you clicked!');
+									},
+								},
+								{type: 'divider'},
+								{
+									href: '#',
+									label: 'linkable',
+								},
+							]}
+							disabled={args.disabled}
+							href="#"
+							onSelectChange={setRadioValue}
+							radioProps={{value: 'radio1'}}
+							selectableType="radio"
+							selected={radioValue === 'radio1'}
+							title="Radio Selectable Folder 1"
+						/>
+						<ClayCardWithHorizontal
+							actions={[
+								{
+									label: 'clickable',
+									onClick: () => {
+										alert('you clicked!');
+									},
+								},
+								{type: 'divider'},
+								{
+									href: '#',
+									label: 'linkable',
+								},
+							]}
+							disabled={args.disabled}
+							href="#"
+							onSelectChange={setRadioValue}
+							radioProps={{value: 'radio2'}}
+							selectableType="radio"
+							selected={radioValue === 'radio2'}
+							title="Radio Selectable Folder 2"
+						/>
+					</ClayCard.Group>
+				</div>
+			</div>
+		</>
 	);
 };
 

--- a/packages/clay-card/stories/Card.stories.tsx
+++ b/packages/clay-card/stories/Card.stories.tsx
@@ -339,43 +339,75 @@ export const CardWithNavigation = () => (
 
 export const CardWithUser = (args: any) => {
 	const [value, setValue] = useState<boolean>(false);
+	const [radioValue, setRadioValue] = useState<string>('');
 
 	return (
-		<div className="row">
-			<div className="col-md-4">
-				<ClayCardWithUser
-					actions={[
-						{
-							label: 'clickable',
-							onClick: () => {
-								alert('you clicked!');
+		<>
+			<div className="row">
+				<div className="col-md-4">
+					<ClayCardWithUser
+						actions={[
+							{
+								label: 'clickable',
+								onClick: () => {
+									alert('you clicked!');
+								},
 							},
-						},
-						{type: 'divider'},
-						{
-							href: '#',
-							label: 'linkable',
-						},
-					]}
-					description="Assistant to the regional manager"
-					disabled={args.disabled}
-					href="#"
-					name="Abraham Kuyper"
-					onSelectChange={setValue}
-					selected={value}
-					stickerTitle="User Icon"
-				/>
+							{type: 'divider'},
+							{
+								href: '#',
+								label: 'linkable',
+							},
+						]}
+						description="Assistant to the regional manager"
+						disabled={args.disabled}
+						href="#"
+						name="Abraham Kuyper"
+						onSelectChange={setValue}
+						selected={value}
+						stickerTitle="User Icon"
+					/>
+				</div>
+				<div className="col-md-4">
+					<ClayCardWithUser
+						description="Assistant to the regional manager"
+						disabled={args.disabled}
+						name="Abraham Kuyper"
+						stickerTitle="User Icon"
+						userImageSrc="https://via.placeholder.com/256"
+					/>
+				</div>
 			</div>
-			<div className="col-md-4">
-				<ClayCardWithUser
-					description="Assistant to the regional manager"
-					disabled={args.disabled}
-					name="Abraham Kuyper"
-					stickerTitle="User Icon"
-					userImageSrc="https://via.placeholder.com/256"
-				/>
+
+			<div className="row">
+				<div className="col-md-12">
+					<ClayCard.Group label="Radio Card Group">
+						<ClayCardWithUser
+							description="Assistant to the regional manager"
+							disabled={args.disabled}
+							name="Abraham Kuyper I"
+							onSelectChange={setRadioValue}
+							radioProps={{value: 'radio1'}}
+							selectableType="radio"
+							selected={radioValue === 'radio1'}
+							stickerTitle="User Icon"
+							userImageSrc="https://via.placeholder.com/256"
+						/>
+						<ClayCardWithUser
+							description="Assistant to the regional manager"
+							disabled={args.disabled}
+							name="Abraham Kuyper II"
+							onSelectChange={setRadioValue}
+							radioProps={{value: 'radio2'}}
+							selectableType="radio"
+							selected={radioValue === 'radio2'}
+							stickerTitle="User Icon"
+							userImageSrc="https://via.placeholder.com/256"
+						/>
+					</ClayCard.Group>
+				</div>
 			</div>
-		</div>
+		</>
 	);
 };
 

--- a/packages/clay-card/stories/Card.stories.tsx
+++ b/packages/clay-card/stories/Card.stories.tsx
@@ -121,6 +121,7 @@ export const CardWithInfo = (args: any) => {
 							selected={radioValue === 'radio1'}
 							stickerProps={null}
 							title="Radio Card 1"
+							truncate={false}
 						/>
 						<ClayCardWithInfo
 							description="A cool description"
@@ -136,6 +137,7 @@ export const CardWithInfo = (args: any) => {
 							selected={radioValue === 'radio2'}
 							stickerProps={null}
 							title="Radio Card 2"
+							truncate={false}
 						/>
 					</ClayCard.Group>
 				</div>

--- a/packages/clay-card/stories/Card.stories.tsx
+++ b/packages/clay-card/stories/Card.stories.tsx
@@ -43,65 +43,104 @@ const ClayCheckboxWithState = (props: any) => {
 
 export const CardWithInfo = (args: any) => {
 	const [value, setValue] = useState<boolean>(false);
+	const [radioValue, setRadioValue] = useState<string>('');
 
 	return (
-		<div className="row">
-			<div className="col-md-4">
-				<ClayCardWithInfo
-					description="A cool description"
-					href="#"
-					labels={[
-						{
-							displayType: 'success',
-							value: 'Awesome',
-						},
-					]}
-					stickerProps={{
-						title: 'File',
-					}}
-					title="Very Large File"
-				/>
-			</div>
-
-			<div className="col-md-4">
-				<ClayCardWithInfo
-					actions={[
-						{
-							label: 'clickable',
-							onClick: () => {
-								alert('you clicked!');
+		<>
+			<div className="row">
+				<div className="col-md-4">
+					<ClayCardWithInfo
+						description="A cool description"
+						href="#"
+						labels={[
+							{
+								displayType: 'success',
+								value: 'Awesome',
 							},
-						},
-						{type: 'divider'},
-						{
-							href: '#',
-							label: 'linkable',
-						},
-					]}
-					description="A cool description"
-					disabled={args.disabled}
-					href="#"
-					labels={[
-						{
-							displayType: 'success',
-							value: 'Awesome',
-						},
-						{
+						]}
+						stickerProps={{
+							title: 'File',
+						}}
+						title="Very Large File"
+					/>
+				</div>
+
+				<div className="col-md-4">
+					<ClayCardWithInfo
+						actions={[
+							{
+								label: 'clickable',
+								onClick: () => {
+									alert('you clicked!');
+								},
+							},
+							{type: 'divider'},
+							{
+								href: '#',
+								label: 'linkable',
+							},
+						]}
+						description="A cool description"
+						disabled={args.disabled}
+						href="#"
+						labels={[
+							{
+								displayType: 'success',
+								value: 'Awesome',
+							},
+							{
+								displayType: 'danger',
+								value: 'Crazy',
+							},
+						]}
+						onSelectChange={(newVal) => setValue(newVal)}
+						selected={value}
+						stickerProps={{
+							content: 'DOC',
 							displayType: 'danger',
-							value: 'Crazy',
-						},
-					]}
-					onSelectChange={(newVal) => setValue(newVal)}
-					selected={value}
-					stickerProps={{
-						content: 'DOC',
-						displayType: 'danger',
-						title: 'Document',
-					}}
-					title="Selectable File"
-				/>
+							title: 'Document',
+						}}
+						title="Selectable File"
+					/>
+				</div>
 			</div>
-		</div>
+			<div className="row">
+				<div className="col-md-12">
+					<ClayCard.Group label="Radio Card Group">
+						<ClayCardWithInfo
+							description="A cool description"
+							labels={[
+								{
+									displayType: 'danger',
+									value: 'Crazy',
+								},
+							]}
+							onSelectChange={(value) => setRadioValue(value)}
+							radioProps={{value: 'radio1'}}
+							selectableType="radio"
+							selected={radioValue === 'radio1'}
+							stickerProps={null}
+							title="Radio Card 1"
+						/>
+						<ClayCardWithInfo
+							description="A cool description"
+							labels={[
+								{
+									displayType: 'success',
+									value: 'Awesome',
+								},
+							]}
+							onSelectChange={(value) => setRadioValue(value)}
+							radioProps={{value: 'radio2'}}
+							selectableType="radio"
+							selected={radioValue === 'radio2'}
+							stickerProps={null}
+							title="Radio Card 2"
+						/>
+					</ClayCard.Group>
+				</div>
+			</div>
+		</>
 	);
 };
 


### PR DESCRIPTION
Hi guys!

According to this issue https://liferay.atlassian.net/browse/LPD-1261, on the Echo team we need a new variant of cards that have radio buttons, so here I'm sending  a solution for this.

A new prop has been added, which is `selectableType`. This prop defines whether the selectable element will have a checkbox or a radio button. In addition, A `radioProps` prop is also added to be able to pass the necessary props to the radio input. Along with all this, a new case in storybook has been added with two radio cards, to see the behavior of these cards:


https://github.com/liferay/clay/assets/9701095/b414ad66-bb10-4c40-9684-cfe88b0cda4a



Finally, to give the user the option of not truncating the text (it's another requirement in our design and in general accessibility), a new `truncate` prop has been added to CardWithInfo, which is a flag that determines if the text is truncate or not.

Let me know what you think about the solution, any feedback is welcome :smile:. 

Thanks in advance!

cc @marcoscv-work 