### PR TITLE
fix(@clayui/navigation-bar): fixes navbar size bug when resizing

### DIFF
--- a/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ClayNavigationBar collapses the previously expanded dropdown when trigger element is clicked 1`] = `
 <div
   class="navbar-collapse collapse"
-  style="height: 0px"
+  style="height: auto"
 >
   <div
     class="container-fluid container-fluid-max-xl"
@@ -191,7 +191,7 @@ exports[`ClayNavigationBar renders a custom item 1`] = `
 exports[`ClayNavigationBar renders a dropdown when clicking the trigger element from NavigationBar 1`] = `
 <div
   class="navbar-collapse show"
-  style="height: 0px"
+  style="height: auto"
 >
   <div
     class="container-fluid container-fluid-max-xl"

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -137,10 +137,16 @@ function ClayNavigationBar({
 						onEnter={(element: HTMLElement) =>
 							element.setAttribute('style', `height: 0px`)
 						}
+						onEntered={(element: HTMLElement) =>
+							element.setAttribute('style', `height: auto`)
+						}
 						onEntering={(element: HTMLElement) =>
 							setElementFullHeight(element)
 						}
 						onExit={(element) => setElementFullHeight(element)}
+						onExited={(element) =>
+							element.setAttribute('style', `height: auto`)
+						}
 						onExiting={(element) =>
 							element.setAttribute('style', `height: 0px`)
 						}


### PR DESCRIPTION
Ticket [LPD-20600](https://liferay.atlassian.net/browse/LPD-20600)

The size of the navbar when interacting with it in a mobile version and returning to the screen size on the desktop ends up breaking because we use animation via CSS together with JS and we end up leaving the height of the navbar fixed for the animation to happen but we don't clean it after it ends so this ends up breaking when returning to the desktop screen instead of mobile, now we are clearing the height after the animation ends.