### PR TITLE
feat(@clayui/core): adds new width API for the picker

### DIFF
--- a/packages/clay-core/docs/picker.js
+++ b/packages/clay-core/docs/picker.js
@@ -20,30 +20,27 @@ import React from 'react';`;
 
 	const code = `const CustomWidth = () => {
 	return (
-		<div style={{width: '240px'}}>
+		<div style={{width: '100px'}}>
 			<Form.Group>
 				<label htmlFor="picker" id="picker-label">
-					Choose a fruit
+					Year
 				</label>
 				<Picker
-					width="flexible"
+					width={85}
 					aria-labelledby="picker-label"
 					id="picker"
 					items={[
-						'Apple',
-						'Banana',
-						'Mangos',
-						'Blueberry',
-						'Boysenberry',
-						'Cherry',
-						'Cranberry',
-						'Eggplant',
-						'Fig',
-						'Grape',
-						'Guava',
-						'Huckleberry',
+						'2020',
+						'2021',
+						'2022',
+						'2023',
+						'2024',
+						'2025',
+						'2026',
+						'2027',
+						'2028',
 					]}
-					placeholder="Select a fruit"
+					placeholder="Year"
 				>
 					{(item) => <Option key={item}>{item}</Option>}
 				</Picker>

--- a/packages/clay-core/docs/picker.js
+++ b/packages/clay-core/docs/picker.js
@@ -13,6 +13,52 @@ import Layout from '@clayui/layout';
 import {useId} from '@clayui/shared';
 import React from 'react';
 
+const PickerWidthExample = () => {
+	const imports = `import {Option, Picker} from '@clayui/core';
+import Form from '@clayui/form';
+import React from 'react';`;
+
+	const code = `const CustomWidth = () => {
+	return (
+		<div style={{width: '240px'}}>
+			<Form.Group>
+				<label htmlFor="picker" id="picker-label">
+					Choose a fruit
+				</label>
+				<Picker
+					width="flexible"
+					aria-labelledby="picker-label"
+					id="picker"
+					items={[
+						'Apple',
+						'Banana',
+						'Mangos',
+						'Blueberry',
+						'Boysenberry',
+						'Cherry',
+						'Cranberry',
+						'Eggplant',
+						'Fig',
+						'Grape',
+						'Guava',
+						'Huckleberry',
+					]}
+					placeholder="Select a fruit"
+				>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			</Form.Group>
+		</div>
+	);
+};
+
+render(<CustomWidth />)`;
+
+	return (
+		<Editor code={code} imports={imports} scope={{Form, Option, Picker}} />
+	);
+};
+
 const exampleImports = `import {Option, Picker} from '@clayui/core';
 import Form from '@clayui/form';
 import React from 'react';`;
@@ -262,6 +308,7 @@ const PickerGroupExample = () => {
 	);
 };
 export {
+	PickerWidthExample,
 	PickerExample,
 	PickerGroupExample,
 	PickerTriggerExample,

--- a/packages/clay-core/docs/picker.mdx
+++ b/packages/clay-core/docs/picker.mdx
@@ -155,7 +155,7 @@ The composition allows you to customize the component or add new features. See s
 
 <PickerGroupExample />
 
-## Flexibe width
+## Flexible width
 
 <PickerWidthExample />
 

--- a/packages/clay-core/docs/picker.mdx
+++ b/packages/clay-core/docs/picker.mdx
@@ -7,6 +7,7 @@ storybookPath: 'design-system-components-picker'
 ---
 
 import {
+	PickerWidthExample,
 	PickerExample,
 	PickerGroupExample,
 	PickerTriggerExample,
@@ -26,6 +27,7 @@ import {
     -   [Custom Trigger](#custom-trigger)
     -   [Custom Options](#custom-options)
     -   [Group](#group)
+-   [Flexibe width](#flexibe-width)
 -   [Hybrid component](#hybrid-component)
 
 </div>
@@ -152,6 +154,10 @@ The composition allows you to customize the component or add new features. See s
 ### Group
 
 <PickerGroupExample />
+
+## Flexibe width
+
+<PickerWidthExample />
 
 ## Hybrid component
 

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -127,7 +127,7 @@ export type Props<T> = {
 	selectedKey?: React.Key;
 
 	/**
-	 * Flag to define the panel width.
+	 * Sets the fixed width of the panel.
 	 */
 	width?: number;
 

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -127,9 +127,9 @@ export type Props<T> = {
 	selectedKey?: React.Key;
 
 	/**
-	 * Flag to define the panel width behavior.
+	 * Flag to define the panel width.
 	 */
-	width?: 'flexible' | 'fixed';
+	width?: number;
 
 	/**
 	 * Sets the className for the React.Portal Menu element.
@@ -168,7 +168,7 @@ export function Picker<T extends Record<string, any> | string | number>({
 	onSelectionChange,
 	placeholder = 'Select an option',
 	selectedKey: externalSelectedKey,
-	width = 'fixed',
+	width,
 	...otherProps
 }: Props<T>) {
 	const [active, setActive] = useControlledState({
@@ -527,23 +527,25 @@ export function Picker<T extends Record<string, any> | string | number>({
 				>
 					<div
 						className={classNames(
-							'dropdown-menu dropdown-menu-indicator-start dropdown-menu-select show',
+							'dropdown-menu dropdown-menu-indicator-start dropdown-menu-select dropdown-menu-width-shrink show',
 							{
-								'dropdown-menu-height-lg dropdown-menu-width-shrink':
+								'dropdown-menu-height-lg':
 									UNSAFE_behavior === 'secondary',
 							}
 						)}
 						ref={menuRef}
 						role="presentation"
-						style={
-							width === 'flexible' &&
-							(triggerRef.current?.clientWidth || 0) > 160
-								? {
-										maxWidth: 'none',
-										width: `${triggerRef.current?.clientWidth}px`,
-								  }
-								: {}
-						}
+						style={{
+							maxWidth: 'none',
+							width: `${
+								typeof width === 'number'
+									? width
+									: (triggerRef.current?.clientWidth || 0) >
+									  160
+									? triggerRef.current?.clientWidth
+									: 160
+							}px`,
+						}}
 					>
 						{UNSAFE_behavior === 'secondary' &&
 							(isArrowVisible === 'top' ||

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -127,6 +127,11 @@ export type Props<T> = {
 	selectedKey?: React.Key;
 
 	/**
+	 * Flag to define the panel width behavior.
+	 */
+	width?: 'flexible' | 'fixed';
+
+	/**
 	 * Sets the className for the React.Portal Menu element.
 	 */
 	UNSAFE_menuClassName?: string;
@@ -163,6 +168,7 @@ export function Picker<T extends Record<string, any> | string | number>({
 	onSelectionChange,
 	placeholder = 'Select an option',
 	selectedKey: externalSelectedKey,
+	width = 'fixed',
 	...otherProps
 }: Props<T>) {
 	const [active, setActive] = useControlledState({
@@ -529,6 +535,15 @@ export function Picker<T extends Record<string, any> | string | number>({
 						)}
 						ref={menuRef}
 						role="presentation"
+						style={
+							width === 'flexible' &&
+							(triggerRef.current?.clientWidth || 0) > 160
+								? {
+										maxWidth: 'none',
+										width: `${triggerRef.current?.clientWidth}px`,
+								  }
+								: {}
+						}
 					>
 						{UNSAFE_behavior === 'secondary' &&
 							(isArrowVisible === 'top' ||

--- a/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -132,9 +132,9 @@ exports[`Picker basic rendering renders open component by default 1`] = `
   </div>
   <div>
     <div
-      class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select show"
+      class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select dropdown-menu-width-shrink show"
       role="presentation"
-      style="left: -999px; top: -995px;"
+      style="max-width: none; width: 160px; left: -999px; top: -995px;"
     >
       <ul
         class="inline-scroller list-unstyled"

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -225,3 +225,45 @@ export const CustomGroup = () => {
 		</div>
 	);
 };
+
+export const Width = ({width}: {width: 'fixed' | 'flexible'}) => {
+	const pickerId = useId();
+	const labelId = useId();
+
+	return (
+		<div style={{width: '250px'}}>
+			<Form.Group>
+				<label htmlFor={pickerId} id={labelId}>
+					Choose a fruit
+				</label>
+				<Picker aria-labelledby={labelId} id={pickerId} width={width}>
+					<Option key="apple">Apple</Option>
+					<Option disabled key="banana">
+						Banana
+					</Option>
+					<Option key="mangos">Mangos</Option>
+					<Option key="blueberry">Blueberry</Option>
+					<Option key="boysenberry">Boysenberry</Option>
+					<Option key="cherry">Cherry</Option>
+					<Option key="cranberry">Cranberry</Option>
+					<Option key="eggplant">Eggplant</Option>
+					<Option key="fig">Fig</Option>
+					<Option key="grape">Grape</Option>
+					<Option key="guava">Guava</Option>
+					<Option key="huckleberry">Huckleberry</Option>
+				</Picker>
+			</Form.Group>
+		</div>
+	);
+};
+
+Width.args = {
+	width: 'flexible',
+};
+
+Width.argTypes = {
+	width: {
+		control: {type: 'select'},
+		options: ['fixed', 'flexible'],
+	},
+};

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -226,44 +226,83 @@ export const CustomGroup = () => {
 	);
 };
 
-export const Width = ({width}: {width: 'fixed' | 'flexible'}) => {
+export const Width = () => {
 	const pickerId = useId();
 	const labelId = useId();
 
 	return (
-		<div style={{width: '250px'}}>
-			<Form.Group>
-				<label htmlFor={pickerId} id={labelId}>
-					Choose a fruit
-				</label>
-				<Picker aria-labelledby={labelId} id={pickerId} width={width}>
-					<Option key="apple">Apple</Option>
-					<Option disabled key="banana">
-						Banana
-					</Option>
-					<Option key="mangos">Mangos</Option>
-					<Option key="blueberry">Blueberry</Option>
-					<Option key="boysenberry">Boysenberry</Option>
-					<Option key="cherry">Cherry</Option>
-					<Option key="cranberry">Cranberry</Option>
-					<Option key="eggplant">Eggplant</Option>
-					<Option key="fig">Fig</Option>
-					<Option key="grape">Grape</Option>
-					<Option key="guava">Guava</Option>
-					<Option key="huckleberry">Huckleberry</Option>
-				</Picker>
-			</Form.Group>
-		</div>
+		<>
+			<div style={{width: '250px'}}>
+				<Form.Group>
+					<label htmlFor={pickerId} id={labelId}>
+						Choose a fruit
+					</label>
+					<Picker aria-labelledby={labelId} id={pickerId}>
+						<Option key="apple">Apple</Option>
+						<Option disabled key="banana">
+							Banana
+						</Option>
+						<Option key="mangos">Mangos</Option>
+						<Option key="blueberry">Blueberry</Option>
+						<Option key="boysenberry">Boysenberry</Option>
+						<Option key="cherry">Cherry</Option>
+						<Option key="cranberry">Cranberry</Option>
+						<Option key="eggplant">Eggplant</Option>
+						<Option key="fig">Fig</Option>
+						<Option key="grape">Grape</Option>
+						<Option key="guava">Guava</Option>
+						<Option key="huckleberry">Huckleberry</Option>
+					</Picker>
+				</Form.Group>
+			</div>
+
+			<div style={{width: '100px'}}>
+				<Form.Group>
+					<label htmlFor={pickerId} id={labelId}>
+						Choose a fruit
+					</label>
+					<Picker
+						aria-labelledby={labelId}
+						id={pickerId}
+						placeholder="Fruit"
+					>
+						<Option key="apple">Apple</Option>
+						<Option disabled key="banana">
+							Banana
+						</Option>
+						<Option key="mangos">Mangos</Option>
+						<Option key="blueberry">Blueberry</Option>
+						<Option key="boysenberry">Boysenberry</Option>
+						<Option key="cherry">Cherry</Option>
+						<Option key="cranberry">Cranberry</Option>
+						<Option key="eggplant">Eggplant</Option>
+						<Option key="fig">Fig</Option>
+						<Option key="grape">Grape</Option>
+						<Option key="guava">Guava</Option>
+						<Option key="huckleberry">Huckleberry</Option>
+					</Picker>
+				</Form.Group>
+			</div>
+
+			<div style={{width: '100px'}}>
+				<Form.Group>
+					<label htmlFor={pickerId} id={labelId}>
+						Year
+					</label>
+					<Picker
+						aria-labelledby={labelId}
+						id={pickerId}
+						placeholder="Year"
+						width={85}
+					>
+						<Option key="2020">2020</Option>
+						<Option key="2021">2021</Option>
+						<Option key="2022">2022</Option>
+						<Option key="2023">2023</Option>
+						<Option key="2024">2024</Option>
+					</Picker>
+				</Form.Group>
+			</div>
+		</>
 	);
-};
-
-Width.args = {
-	width: 'flexible',
-};
-
-Width.argTypes = {
-	width: {
-		control: {type: 'select'},
-		options: ['fixed', 'flexible'],
-	},
 };

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -943,6 +943,7 @@ $dropdown-menu-palette: () !default;
 $dropdown-menu-palette: map-deep-merge(
 	(
 		'.dropdown-menu-select.dropdown-menu': (
+			min-width: 160px,
 			dropdown-header: (
 				padding-bottom: 0.375rem,
 				padding-left: 1.75rem,

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -943,7 +943,6 @@ $dropdown-menu-palette: () !default;
 $dropdown-menu-palette: map-deep-merge(
 	(
 		'.dropdown-menu-select.dropdown-menu': (
-			min-width: 160px,
 			dropdown-header: (
 				padding-bottom: 0.375rem,
 				padding-left: 1.75rem,

--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -109,6 +109,7 @@ const ClayDatePickerDateNavigation = ({
 							)
 						}
 						selectedKey={String(currentMonth.getFullYear())}
+						width={85}
 					>
 						{(item) => (
 							<Option key={item.value}>


### PR DESCRIPTION
Ticket [LPD-23824](https://liferay.atlassian.net/browse/LPD-23824)

Well basically we are adding the `width` API to define the size behavior of the Picker Panel, when marking the `flexible` API the panel will adapt to the size of the trigger and the minimum of 160px or fixed with the minimum of 160px. I believe this is a simple API rather than having an API that the developer can define the size of because it is not responsive and this adds a lot of flexibility beyond what is described.
