### PR TITLE
fix(@clayui/core): fixes bug when not rendering the action cell

### DIFF
--- a/packages/clay-core/src/table/Row.tsx
+++ b/packages/clay-core/src/table/Row.tsx
@@ -153,10 +153,16 @@ function RowInner<T extends Record<string, any>>(
 
 	const ref = useForwardRef(outRef);
 
-	const visibleKeys = useMemo(
-		() => Array.from(visibleColumns.values()),
-		[visibleColumns]
-	);
+	const visibleKeys = useMemo(() => {
+		const count = React.Children.count(children);
+
+		return [
+			...Array.from(visibleColumns.values()),
+			...(columnsVisibility && count > visibleColumns.size
+				? [count - 1]
+				: []),
+		];
+	}, [columnsVisibility, visibleColumns]);
 
 	const collection = useCollection({
 		children,


### PR DESCRIPTION
This is a bug that was discovered when implementing the new Table to the FrontEndDataSet [LPD-24920](https://liferay.atlassian.net/browse/LPD-24920). Basically when we have column visibility enabled if we want to render the actions in the last cell it is not rendering the element, so now this fixes this for this use case.