### PR TITLE
feat(@clayui/core): add new API to omit a column to columns visibility

### DIFF
--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -53,6 +53,7 @@ function HeadInner<T extends Record<string, any>>(
 	ref: React.Ref<HTMLTableSectionElement>
 ) {
 	const {
+		alwaysVisibleColumns,
 		columnsVisibility,
 		messages,
 		onHeadCellsChange,
@@ -97,7 +98,12 @@ function HeadInner<T extends Record<string, any>>(
 											'columnsVisibilityHeader'
 										]!,
 									},
-									...collection.getItems(),
+									...collection
+										.getItems()
+										.filter(
+											(item) =>
+												!alwaysVisibleColumns.has(item)
+										),
 								]}
 								style={{
 									maxWidth: '210px',

--- a/packages/clay-core/src/table/Table.tsx
+++ b/packages/clay-core/src/table/Table.tsx
@@ -19,6 +19,12 @@ import type {AnnouncerAPI} from '../live-announcer';
 
 export type Props = {
 	/**
+	 * Defines the columns that are always visible and will be ignored by the
+	 * visible columns functionality.
+	 */
+	alwaysVisibleColumns?: Set<React.Key>;
+
+	/**
 	 * Flag to enable column visibility control.
 	 */
 	columnsVisibility?: boolean;
@@ -109,6 +115,7 @@ const defaultSet = new Set<React.Key>();
 export const Table = React.forwardRef<HTMLDivElement, Props>(
 	function TableInner(
 		{
+			alwaysVisibleColumns = new Set(),
 			columnsVisibility = true,
 			children,
 			className,
@@ -203,6 +210,7 @@ export const Table = React.forwardRef<HTMLDivElement, Props>(
 				>
 					<TableContext.Provider
 						value={{
+							alwaysVisibleColumns,
 							columnsVisibility,
 							expandedKeys,
 							headCellsCount,

--- a/packages/clay-core/src/table/context.tsx
+++ b/packages/clay-core/src/table/context.tsx
@@ -11,6 +11,7 @@ export type Sorting = {
 };
 
 type Context = {
+	alwaysVisibleColumns: Set<React.Key>;
 	columnsVisibility: boolean;
 	expandedKeys: Set<React.Key>;
 	headCellsCount: number;


### PR DESCRIPTION
This is a use case that was discovered when integrating ClayTable with FDS where the selection column will always be visible and is not shown in the columns visibility menu. So we are adding a new API to allow omitting the column and always making it visible, something that is important for the table to continue functioning and is not necessarily part of the data structure. An option would also be to add the OOTB selection feature with controlled state, because this way, when clicking on select all, the dev can implement the selection of all items in the backend.