### PR TITLE
fix(@clayui/core): Fixes bug when rendering the last columns visibility cell for dynamic rendering

### DIFF
--- a/packages/clay-core/src/table/Row.tsx
+++ b/packages/clay-core/src/table/Row.tsx
@@ -154,7 +154,9 @@ function RowInner<T extends Record<string, any>>(
 	const ref = useForwardRef(outRef);
 
 	const visibleKeys = useMemo(() => {
-		const count = React.Children.count(children);
+		// This is a speculation/inference about the size of items to decide
+		// to render a last cell as an action.
+		const count = items ? items.length : React.Children.count(children);
 
 		return [
 			...Array.from(visibleColumns.values()),
@@ -162,7 +164,7 @@ function RowInner<T extends Record<string, any>>(
 				? [count - 1]
 				: []),
 		];
-	}, [columnsVisibility, visibleColumns]);
+	}, [columnsVisibility, items?.length, visibleColumns]);
 
 	const collection = useCollection({
 		children,


### PR DESCRIPTION
Follow-up #5817

I had only done the test for the case of static rendering but had not done the coverage for the case of dynamic rendering, an important point is that we do this as a speculation of the size of the items within a row but this value can change if necessary in the cell, I believe that the best thing is for the developer to avoid cases like this so as not to break other table behaviors along with collection, so it always passes the items that will be rendered. This is also great for recommending that they are pure functions and have no side effects.