### PR TITLE
fix(@clayui/empty-state): fixes bug when always trying to render the image for reduced motion when disabled

### DIFF
--- a/packages/clay-empty-state/src/index.tsx
+++ b/packages/clay-empty-state/src/index.tsx
@@ -69,7 +69,7 @@ const ClayEmptyState = ({
 		}
 		if (imgSrcReducedMotion) {
 			return imgSrcReducedMotion;
-		} else if (imgSrc) {
+		} else if (imgSrc && imgSrcReducedMotion !== null) {
 			const url = new URL(
 				imgSrc,
 				imgSrc?.match(/http:\/\/|https:\/\//)


### PR DESCRIPTION
Follow-up #5819

We made a change that broke the behavior where there are some cases where reduced motion is not necessary because the main image is static and so we have to disable the use of reduced motion by setting the `imgSrcReducedMotion` variable to `null`.