### PR TITLE
feat(@clayui/card): LPD-1261 Add name to group all radio type inputs

### DIFF
--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -46,7 +46,10 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	 * Props to add to the radio element
 	 */
 
-	radioProps?: React.HTMLAttributes<HTMLInputElement> & {value: string};
+	radioProps?: React.HTMLAttributes<HTMLInputElement> & {
+		name: string;
+		value: string;
+	};
 
 	/**
 	 * Flag to indicate if card is selected
@@ -101,7 +104,7 @@ export const ClayCardWithHorizontal = ({
 	},
 	href,
 	onSelectChange,
-	radioProps = {value: ''},
+	radioProps = {name: '', value: ''},
 	selectableType,
 	selected = false,
 	spritemap,

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -32,7 +32,10 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	 * Props to add to the radio element
 	 */
 
-	radioProps?: React.HTMLAttributes<HTMLInputElement> & {value: string};
+	radioProps?: React.HTMLAttributes<HTMLInputElement> & {
+		name: string;
+		value: string;
+	};
 
 	/**
 	 * Description of the file
@@ -154,7 +157,7 @@ export const ClayCardWithInfo = ({
 	imgProps,
 	labels,
 	onSelectChange,
-	radioProps = {value: ''},
+	radioProps = {name: '', value: ''},
 	selectableType,
 	selected = false,
 	spritemap,

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -58,7 +58,10 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	 * Props to add to the radio element
 	 */
 
-	radioProps?: React.HTMLAttributes<HTMLInputElement> & {value: string};
+	radioProps?: React.HTMLAttributes<HTMLInputElement> & {
+		name: string;
+		value: string;
+	};
 
 	/**
 	 * Flag to indicate if card is selected
@@ -134,7 +137,7 @@ export const ClayCardWithUser = ({
 	spritemap,
 	stickerTitle,
 	selectableType,
-	radioProps = {value: ''},
+	radioProps = {name: '', value: ''},
 	userImageAlt = 'thumbnail',
 	userDisplayType,
 	userImageSrc,

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -1665,6 +1665,7 @@ exports[`ClayCardWithHorizontal renders with radio button 1`] = `
         <input
           class="custom-control-input"
           disabled=""
+          name="cards"
           role="radio"
           type="radio"
           value="radio1"
@@ -2917,6 +2918,7 @@ exports[`ClayCardWithInfo renders with radio button 1`] = `
         <label>
           <input
             class="custom-control-input"
+            name="cards"
             role="radio"
             type="radio"
             value="radio1"
@@ -3461,6 +3463,7 @@ exports[`ClayCardWithUser renders with radio button 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="cards"
               role="radio"
               type="radio"
               value="radio1"

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -718,7 +718,7 @@ describe('ClayCardWithUser', () => {
 				href="#"
 				name="Foo Bar"
 				onSelectChange={jest.fn()}
-				radioProps={{value: 'radio1'}}
+				radioProps={{name: 'cards', value: 'radio1'}}
 				selectableType="radio"
 				spritemap="/path/to/some/resource.svg"
 			/>
@@ -835,7 +835,7 @@ describe('ClayCardWithHorizontal', () => {
 				disabled
 				href="#"
 				onSelectChange={jest.fn()}
-				radioProps={{value: 'radio1'}}
+				radioProps={{name: 'cards', value: 'radio1'}}
 				selectableType="radio"
 				selected={false}
 				spritemap="/path/to/some/resource.svg"
@@ -1146,7 +1146,7 @@ describe('ClayCardWithInfo', () => {
 			<ClayCardWithInfo
 				href="#"
 				onSelectChange={jest.fn()}
-				radioProps={{value: 'radio1'}}
+				radioProps={{name: 'cards', value: 'radio1'}}
 				selectableType="radio"
 				selected={false}
 				spritemap="/path/to/some/resource.svg"

--- a/packages/clay-card/stories/Card.stories.tsx
+++ b/packages/clay-card/stories/Card.stories.tsx
@@ -116,7 +116,7 @@ export const CardWithInfo = (args: any) => {
 								},
 							]}
 							onSelectChange={(value) => setRadioValue(value)}
-							radioProps={{value: 'radio1'}}
+							radioProps={{name: 'cards', value: 'radio1'}}
 							selectableType="radio"
 							selected={radioValue === 'radio1'}
 							stickerProps={null}
@@ -132,7 +132,7 @@ export const CardWithInfo = (args: any) => {
 								},
 							]}
 							onSelectChange={(value) => setRadioValue(value)}
-							radioProps={{value: 'radio2'}}
+							radioProps={{name: 'cards', value: 'radio2'}}
 							selectableType="radio"
 							selected={radioValue === 'radio2'}
 							stickerProps={null}
@@ -270,7 +270,7 @@ export const CardWithHorizontal = (args: any) => {
 							disabled={args.disabled}
 							href="#"
 							onSelectChange={setRadioValue}
-							radioProps={{value: 'radio1'}}
+							radioProps={{name: 'cards', value: 'radio1'}}
 							selectableType="radio"
 							selected={radioValue === 'radio1'}
 							title="Radio Selectable Folder 1"
@@ -292,7 +292,7 @@ export const CardWithHorizontal = (args: any) => {
 							disabled={args.disabled}
 							href="#"
 							onSelectChange={setRadioValue}
-							radioProps={{value: 'radio2'}}
+							radioProps={{name: 'cards', value: 'radio2'}}
 							selectableType="radio"
 							selected={radioValue === 'radio2'}
 							title="Radio Selectable Folder 2"
@@ -387,7 +387,7 @@ export const CardWithUser = (args: any) => {
 							disabled={args.disabled}
 							name="Abraham Kuyper I"
 							onSelectChange={setRadioValue}
-							radioProps={{value: 'radio1'}}
+							radioProps={{name: 'cards', value: 'radio1'}}
 							selectableType="radio"
 							selected={radioValue === 'radio1'}
 							stickerTitle="User Icon"
@@ -398,7 +398,7 @@ export const CardWithUser = (args: any) => {
 							disabled={args.disabled}
 							name="Abraham Kuyper II"
 							onSelectChange={setRadioValue}
-							radioProps={{value: 'radio2'}}
+							radioProps={{name: 'cards', value: 'radio2'}}
 							selectableType="radio"
 							selected={radioValue === 'radio2'}
 							stickerTitle="User Icon"


### PR DESCRIPTION
Hi guys!,

I am sending this pull because while fixing this bug https://liferay.atlassian.net/browse/LPD-1261, I realized the following:

https://github.com/liferay/clay/assets/9701095/51e8abd8-830f-4812-b611-c29b2eecbefe

As you see in the video, when you navigate by keyboard, the navigation does not recognize which radio button is selected, and when you return to the cards, the radio input that is not selected is focused.

This happens because to group the radio buttons in a group it is necessary to add the same `name` to all the inputs [https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role#:~:text=When%20using%20HTML%27s%20native%20input%20radio%20button%2C%20%3Cinput%20type%3D%22radio%22%3E%2C%20the%20radio%20buttons%20are%20grouped%20when%20each%20of%20input%20radio%20buttons%20in%20the%20group%20is%20given%20the%20same%20name).

For that reason, for the radio buttons to work correctly I have added the `name` as required in `radioProps` (apart from `value`), this being the correct behavior:


https://github.com/liferay/clay/assets/9701095/4712d646-2b32-422f-8d45-624ffd5991b2

Let me know what you think, thanks in advance! :smiley: 