### PR TITLE
fix(@clayui/css) LPD-27401 - Allow long word links to break into multiple lines.

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_tables.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tables.scss
@@ -55,7 +55,7 @@ $table-title-link: () !default;
 $table-title-link: map-deep-merge(
 	(
 		border-radius: 1px,
-		display: inline-flex,
+		display: inline,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		focus: (
@@ -107,7 +107,7 @@ $table-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $gray-900,
-		display: inline-flex,
+		display: inline,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -186,7 +186,7 @@ $table-list-title-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $gray-900,
-		display: inline-flex,
+		display: inline,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -207,7 +207,7 @@ $table-list-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $gray-900,
-		display: inline-flex,
+		display: inline,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (

--- a/packages/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -185,7 +185,7 @@ $cadmin-table-title-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $cadmin-gray-900,
-		display: inline-flex,
+		display: inline,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -206,7 +206,7 @@ $cadmin-table-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $cadmin-gray-900,
-		display: inline-flex,
+		display: inline,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -228,7 +228,7 @@ $cadmin-table-action-link: map-deep-merge(
 		align-items: center,
 		border-radius: $cadmin-btn-border-radius,
 		color: $cadmin-gray-600,
-		display: inline-flex,
+		display: inline,
 		font-size: 16px,
 		height: 32px,
 		justify-content: center,
@@ -761,7 +761,7 @@ $cadmin-table-list-title-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $cadmin-gray-900,
-		display: inline-flex,
+		display: inline,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -782,7 +782,7 @@ $cadmin-table-list-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $cadmin-gray-900,
-		display: inline-flex,
+		display: inline,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -803,7 +803,7 @@ $cadmin-table-list-action-link: map-deep-merge(
 	(
 		align-items: center,
 		color: $cadmin-gray-600,
-		display: inline-flex,
+		display: inline,
 		font-size: 16px,
 		height: 32px,
 		justify-content: center,


### PR DESCRIPTION
## Jira ticket
https://liferay.atlassian.net/browse/LPD-27401

## Issue
Table links with long words cannot break into multiple lines. The problem is the combination of the `display: inline-flex` property of the link elements with long words.

## UI before
![word-wrap-before](https://github.com/liferay/clay/assets/132653342/37c3c601-802e-4086-bd93-4042c7dc97a6)

The second and fifth link samples should behave in the same way as the normal text.

## UI after
![word-wrap-after](https://github.com/liferay/clay/assets/132653342/d2010d8a-bae6-4b96-9c82-0364a6f8b04f)
