### PR TITLE
fix(@clayui/css): LPD-27401 Refactor. Change display property to allo…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_tables.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tables.scss
@@ -55,7 +55,7 @@ $table-title-link: () !default;
 $table-title-link: map-deep-merge(
 	(
 		border-radius: 1px,
-		display: inline-flex,
+		display: inline-block,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		focus: (
@@ -107,7 +107,7 @@ $table-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $gray-900,
-		display: inline-flex,
+		display: inline-block,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -186,7 +186,7 @@ $table-list-title-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $gray-900,
-		display: inline-flex,
+		display: inline-block,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -207,7 +207,7 @@ $table-list-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $gray-900,
-		display: inline-flex,
+		display: inline-block,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (

--- a/packages/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -185,7 +185,7 @@ $cadmin-table-title-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $cadmin-gray-900,
-		display: inline-flex,
+		display: inline-block,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -206,7 +206,7 @@ $cadmin-table-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $cadmin-gray-900,
-		display: inline-flex,
+		display: inline-block,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -761,7 +761,7 @@ $cadmin-table-list-title-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $cadmin-gray-900,
-		display: inline-flex,
+		display: inline-block,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
@@ -782,7 +782,7 @@ $cadmin-table-list-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		color: $cadmin-gray-900,
-		display: inline-flex,
+		display: inline-block,
 		max-width: 100%,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (


### PR DESCRIPTION
…w long words break into multiple lines

https://liferay.atlassian.net/browse/LPD-27654

![Screen Shot 2024-06-05 at 1 39 20 PM](https://github.com/liferay/clay/assets/788266/699d44ba-5b19-4b11-b737-766db15d0091)

@juanjofgliferay I ended up using inline-block instead of inline to keep the focus border cleaner.