### PR TITLE
refactor(@clayui/popover): LPD-15613 Popover: closeOnClickOutside prop does not work with keyboard interaction

### DIFF
--- a/packages/clay-modal/src/Hook.ts
+++ b/packages/clay-modal/src/Hook.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {FOCUSABLE_ELEMENTS, Keys} from '@clayui/shared';
-import React from 'react';
+import {FOCUSABLE_ELEMENTS, Keys, stack} from '@clayui/shared';
+import React, {useEffect} from 'react';
 
 /**
  * A hook that takes care of controlling click, keyup and keydown events
@@ -14,7 +14,9 @@ import React from 'react';
 const useUserInteractions = (
 	modalElementRef: React.MutableRefObject<any>,
 	modalBodyElementRef: React.MutableRefObject<any>,
-	onClick: () => void
+	onClick: () => void,
+	show: boolean,
+	content: boolean
 ) => {
 	const mouseEventTargetRef = React.useRef<EventTarget | null>(null);
 
@@ -32,6 +34,13 @@ const useUserInteractions = (
 	};
 
 	const handleKeydown = (event: KeyboardEvent) => {
+		if (
+			event.key === Keys.Esc &&
+			stack[stack.length - 1] === modalElementRef
+		) {
+			onClick();
+		}
+
 		if (event.key === Keys.Tab) {
 			if (
 				modalElementRef.current &&
@@ -58,12 +67,6 @@ const useUserInteractions = (
 					event.preventDefault();
 				}
 			}
-		}
-	};
-
-	const handleKeyup = (event: KeyboardEvent) => {
-		if (event.key === Keys.Esc) {
-			onClick();
 		}
 	};
 
@@ -97,19 +100,17 @@ const useUserInteractions = (
 	 * Just listen for keyup, keydown, and click when
 	 * changeAttachEvent is true.
 	 */
-	React.useEffect(() => {
+	useEffect(() => {
 		document.addEventListener('keydown', handleKeydown);
-		document.addEventListener('keyup', handleKeyup);
 		document.addEventListener('mousedown', handleDocumentMouseDown);
 		document.addEventListener('mouseup', handleDocumentMouseUp);
 
 		return () => {
 			document.removeEventListener('keydown', handleKeydown);
-			document.removeEventListener('keyup', handleKeyup);
 			document.removeEventListener('mousedown', handleDocumentMouseDown);
 			document.removeEventListener('mouseup', handleDocumentMouseUp);
 		};
-	}, []);
+	}, [show, content]);
 };
 
 export {useUserInteractions};

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal, IPortalBaseProps} from '@clayui/shared';
+import {ClayPortal, IPortalBaseProps, stack} from '@clayui/shared';
 import {suppressOthers} from 'aria-hidden';
 import classNames from 'classnames';
 import React, {useEffect, useMemo, useRef} from 'react';
@@ -105,7 +105,9 @@ const ClayModal = ({
 	useUserInteractions(
 		modalElementRef,
 		modalBodyElementRef,
-		() => !disableAutoClose && observer.dispatch(ObserverType.Close)
+		() => !disableAutoClose && observer.dispatch(ObserverType.Close),
+		show,
+		content
 	);
 
 	useEffect(() => {
@@ -126,7 +128,25 @@ const ClayModal = ({
 	}, []);
 
 	useEffect(() => {
-		if (modalElementRef.current && show) {
+		if (show && content) {
+			stack.push(modalElementRef);
+		}
+
+		return () => {
+			const index = stack.indexOf(modalElementRef);
+
+			if (index >= 0) {
+				stack.splice(index, 1);
+			}
+		};
+	}, [show, modalElementRef, content]);
+
+	useEffect(() => {
+		if (
+			modalElementRef.current &&
+			show &&
+			stack[stack.length - 1] === modalElementRef
+		) {
 			// Hide everything from ARIA except the Modal Body
 			return suppressOthers(modalElementRef.current);
 		}

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -166,7 +166,7 @@ describe('Modal -> IncrementalInteractions', () => {
 		expect(document.querySelector(modalElSelector)).toBeDefined();
 	});
 
-	it('close the modal when pressing ESC', () => {
+	it('close the modal when pressing ESC', async () => {
 		const {container} = render(<ModalWithState initialVisible />);
 
 		act(() => {
@@ -182,7 +182,7 @@ describe('Modal -> IncrementalInteractions', () => {
 		expect(backdropEl).toBeDefined();
 		expect(modalEl).toBeDefined();
 
-		fireEvent.keyUp(container, {key: 'Escape'});
+		fireEvent.keyDown(container, {key: 'Escape'});
 
 		expect(document.body.classList).not.toContain('modal-open');
 		expect(document.querySelector(backdropElSelector)).toBeNull();

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -9,6 +9,7 @@ import {
 	InternalDispatch,
 	doAlign,
 	observeRect,
+	stack,
 	useControlledState,
 } from '@clayui/shared';
 import classNames from 'classnames';
@@ -241,26 +242,49 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 		}, [closeOnClickOutside, trigger]);
 
 		useEffect(() => {
-			const handleKeyDown = (event: KeyboardEvent) => {
-				if (event.key === 'Escape') {
-					setShow(false);
-				}
-			};
-
-			const onBlur = (event: FocusEvent) => {
-				if (event.view === undefined) {
-					setShow(false);
-				}
-			};
-
-			window.addEventListener('keydown', handleKeyDown);
-			window.addEventListener('blur', onBlur);
+			if (internalShow) {
+				stack.push(popoverRef);
+			}
 
 			return () => {
-				window.removeEventListener('keydown', handleKeyDown);
-				window.removeEventListener('blur', onBlur);
+				const index = stack.indexOf(popoverRef);
+
+				if (index >= 0) {
+					stack.splice(index, 1);
+				}
 			};
-		}, []);
+		}, [internalShow, popoverRef]);
+
+		useEffect(() => {
+			const handleKeyDown = (event: KeyboardEvent) => {
+				if (
+					event.key === 'Escape' &&
+					stack[stack.length - 1] === popoverRef
+				) {
+					setShow(false);
+					triggerRef.current?.focus();
+				}
+			};
+
+			const onBlur = (event: any) => {
+				if (
+					popoverRef.current &&
+					!popoverRef.current.contains(event.relatedTarget)
+				) {
+					setShow(false);
+				}
+			};
+
+			if (internalShow) {
+				document.addEventListener('keydown', handleKeyDown);
+				window.addEventListener('blur', onBlur);
+
+				return () => {
+					document.removeEventListener('keydown', handleKeyDown);
+					window.removeEventListener('blur', onBlur);
+				};
+			}
+		}, [internalShow]);
 
 		let content = (
 			<div

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -247,10 +247,18 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 				}
 			};
 
+			const onBlur = (event: FocusEvent) => {
+				if (event.view === undefined) {
+					setShow(false);
+				}
+			};
+
 			window.addEventListener('keydown', handleKeyDown);
+			window.addEventListener('blur', onBlur);
 
 			return () => {
 				window.removeEventListener('keydown', handleKeyDown);
+				window.removeEventListener('blur', onBlur);
 			};
 		}, []);
 

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -14,6 +14,7 @@ export {LinkOrButton} from './LinkOrButton';
 export {MouseSafeArea} from './MouseSafeArea';
 export {observeRect} from './observeRect';
 export {Overlay} from './Overlay';
+export {stack} from './stack';
 export {setElementFullHeight} from './setElementFullHeight';
 export {sub} from './sub';
 export {useDebounce} from './useDebounce';

--- a/packages/clay-shared/src/stack.ts
+++ b/packages/clay-shared/src/stack.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export const stack: Array<React.RefObject<Element>> = [];


### PR DESCRIPTION
Jira issue: https://liferay.atlassian.net/browse/LPD-15613

**Issue**

1. The popover remains open after interacting with the Tab key.
2. If the popover is on a modal, when the Escape Key is pressed, both popover and modal are closed

**Evidence**

https://github.com/liferay/clay/assets/47724428/977048ed-b189-4de8-979b-9ebb39854cb3

