### PR TITLE
docs(Picker): Fix the documentation path to flexible width example

### DIFF
--- a/packages/clay-core/docs/picker.mdx
+++ b/packages/clay-core/docs/picker.mdx
@@ -27,7 +27,7 @@ import {
     -   [Custom Trigger](#custom-trigger)
     -   [Custom Options](#custom-options)
     -   [Group](#group)
--   [Flexibe width](#flexibe-width)
+-   [Flexible width](#flexible-width)
 -   [Hybrid component](#hybrid-component)
 
 </div>


### PR DESCRIPTION
This was an issue I found during the investigation of bug on ClayPicker