### PR TITLE
fix(@clayui/picker): LPD-28522 Fix language selector not displaying correctly on web content

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -58,8 +58,8 @@ module.exports = {
 		'./packages/clay-core/src/picker/': {
 			branches: 59,
 			functions: 66,
-			lines: 77,
-			statements: 77,
+			lines: 76,
+			statements: 76,
 		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 56,

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -382,16 +382,7 @@ export function Picker<T extends Record<string, any> | string | number>({
 		);
 	}
 
-	const clientWidth = triggerRef.current?.clientWidth;
-	let menuMinWidth = '160px';
-	let menuWidth = 'auto';
-
-	if (typeof width === 'number') {
-		menuMinWidth = `${clientWidth || 0}px`;
-		menuWidth = `${width}px`;
-	} else if ((clientWidth || 0) > 160) {
-		menuMinWidth = `${clientWidth}px`;
-	}
+	const clientWidth = triggerRef.current?.clientWidth || 0;
 
 	return (
 		<>
@@ -548,8 +539,13 @@ export function Picker<T extends Record<string, any> | string | number>({
 						role="presentation"
 						style={{
 							maxWidth: 'none',
-							minWidth: menuMinWidth,
-							width: menuWidth,
+							minWidth: !width
+								? `${Math.max(160, clientWidth)}px`
+								: undefined,
+							width:
+								typeof width === 'number'
+									? `${Math.max(width, clientWidth)}px`
+									: undefined,
 						}}
 					>
 						{UNSAFE_behavior === 'secondary' &&

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -127,9 +127,9 @@ export type Props<T> = {
 	selectedKey?: React.Key;
 
 	/**
-	 * Sets the fixed width of the panel.
+	 * Sets the width of the panel.
 	 */
-	width?: number;
+	width?: number | string;
 
 	/**
 	 * Sets the className for the React.Portal Menu element.
@@ -382,6 +382,20 @@ export function Picker<T extends Record<string, any> | string | number>({
 		);
 	}
 
+	const getComponentWidth = () => {
+		if (typeof width === 'string' && width === 'auto') {
+			return width;
+		}
+
+		if (typeof width === 'number' && width > 160) {
+			return `${width}px`;
+		}
+
+		const clientWidth = triggerRef?.current?.clientWidth || 0;
+
+		return clientWidth > 160 ? `${clientWidth}px` : '160px';
+	};
+
 	return (
 		<>
 			<LiveAnnouncer ref={announcerAPI} />
@@ -537,14 +551,7 @@ export function Picker<T extends Record<string, any> | string | number>({
 						role="presentation"
 						style={{
 							maxWidth: 'none',
-							width: `${
-								typeof width === 'number'
-									? width
-									: (triggerRef.current?.clientWidth || 0) >
-									  160
-									? triggerRef.current?.clientWidth
-									: 160
-							}px`,
+							width: getComponentWidth(),
 						}}
 					>
 						{UNSAFE_behavior === 'secondary' &&

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -129,7 +129,7 @@ export type Props<T> = {
 	/**
 	 * Sets the width of the panel.
 	 */
-	width?: number | string;
+	width?: number;
 
 	/**
 	 * Sets the className for the React.Portal Menu element.
@@ -382,19 +382,16 @@ export function Picker<T extends Record<string, any> | string | number>({
 		);
 	}
 
-	const getComponentWidth = () => {
-		if (typeof width === 'string' && width === 'auto') {
-			return width;
-		}
+	const clientWidth = triggerRef.current?.clientWidth;
+	let menuMinWidth = '160px';
+	let menuWidth = 'auto';
 
-		if (typeof width === 'number' && width > 160) {
-			return `${width}px`;
-		}
-
-		const clientWidth = triggerRef?.current?.clientWidth || 0;
-
-		return clientWidth > 160 ? `${clientWidth}px` : '160px';
-	};
+	if (typeof width === 'number') {
+		menuMinWidth = `${clientWidth || 0}px`;
+		menuWidth = `${width}px`;
+	} else if ((clientWidth || 0) > 160) {
+		menuMinWidth = `${clientWidth}px`;
+	}
 
 	return (
 		<>
@@ -551,7 +548,8 @@ export function Picker<T extends Record<string, any> | string | number>({
 						role="presentation"
 						style={{
 							maxWidth: 'none',
-							width: getComponentWidth(),
+							minWidth: menuMinWidth,
+							width: menuWidth,
 						}}
 					>
 						{UNSAFE_behavior === 'secondary' &&

--- a/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -134,7 +134,7 @@ exports[`Picker basic rendering renders open component by default 1`] = `
     <div
       class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select dropdown-menu-width-shrink show"
       role="presentation"
-      style="max-width: none; min-width: 160px; width: auto; left: -999px; top: -995px;"
+      style="max-width: none; min-width: 160px; left: -999px; top: -995px;"
     >
       <ul
         class="inline-scroller list-unstyled"

--- a/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -134,7 +134,7 @@ exports[`Picker basic rendering renders open component by default 1`] = `
     <div
       class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select dropdown-menu-width-shrink show"
       role="presentation"
-      style="max-width: none; width: 160px; left: -999px; top: -995px;"
+      style="max-width: none; min-width: 160px; width: auto; left: -999px; top: -995px;"
     >
       <ul
         class="inline-scroller list-unstyled"

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -231,8 +231,8 @@ export const Width = () => {
 	const labelId = useId();
 
 	return (
-		<>
-			<div style={{width: '250px'}}>
+		<div style={{display: 'flex'}}>
+			<div style={{marginRight: '50px', width: '250px'}}>
 				<Form.Group>
 					<label htmlFor={pickerId} id={labelId}>
 						Choose a fruit
@@ -260,7 +260,7 @@ export const Width = () => {
 				</Form.Group>
 			</div>
 
-			<div style={{width: '100px'}}>
+			<div style={{marginRight: '80px', width: '100px'}}>
 				<Form.Group>
 					<label htmlFor={pickerId} id={labelId}>
 						Choose a fruit
@@ -289,7 +289,7 @@ export const Width = () => {
 				</Form.Group>
 			</div>
 
-			<div style={{width: '100px'}}>
+			<div style={{marginRight: '50px', width: '100px'}}>
 				<Form.Group>
 					<label htmlFor={pickerId} id={labelId}>
 						Year
@@ -310,7 +310,7 @@ export const Width = () => {
 				</Form.Group>
 			</div>
 
-			<div style={{width: '100px'}}>
+			<div style={{marginRight: '50px', width: '100px'}}>
 				<Form.Group>
 					<label htmlFor={pickerId} id={labelId}>
 						Long Option Year
@@ -331,6 +331,6 @@ export const Width = () => {
 					</Picker>
 				</Form.Group>
 			</div>
-		</>
+		</div>
 	);
 };

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -237,7 +237,11 @@ export const Width = () => {
 					<label htmlFor={pickerId} id={labelId}>
 						Choose a fruit
 					</label>
-					<Picker aria-labelledby={labelId} id={pickerId}>
+					<Picker
+						aria-labelledby={labelId}
+						defaultActive
+						id={pickerId}
+					>
 						<Option key="apple">Apple</Option>
 						<Option disabled key="banana">
 							Banana
@@ -263,6 +267,7 @@ export const Width = () => {
 					</label>
 					<Picker
 						aria-labelledby={labelId}
+						defaultActive
 						id={pickerId}
 						placeholder="Fruit"
 					>
@@ -291,6 +296,7 @@ export const Width = () => {
 					</label>
 					<Picker
 						aria-labelledby={labelId}
+						defaultActive
 						id={pickerId}
 						placeholder="Year"
 						width={85}
@@ -311,6 +317,7 @@ export const Width = () => {
 					</label>
 					<Picker
 						aria-labelledby={labelId}
+						defaultActive
 						id={pickerId}
 						placeholder="Year"
 					>

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -303,6 +303,27 @@ export const Width = () => {
 					</Picker>
 				</Form.Group>
 			</div>
+
+			<div style={{width: '100px'}}>
+				<Form.Group>
+					<label htmlFor={pickerId} id={labelId}>
+						Long Option Year
+					</label>
+					<Picker
+						aria-labelledby={labelId}
+						id={pickerId}
+						placeholder="Year"
+					>
+						<Option key="2020">
+							2020 was really a looooooooong year
+						</Option>
+						<Option key="2021">2021</Option>
+						<Option key="2022">2022</Option>
+						<Option key="2023">2023</Option>
+						<Option key="2024">2024</Option>
+					</Picker>
+				</Form.Group>
+			</div>
 		</>
 	);
 };


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-28522

### Motivation
The language selector is not displaying correctly: the labels of the status are overlapping the language key and the number of fields is not appearing.
![image](https://github.com/liferay/clay/assets/47724428/ce47817a-5ca3-486f-a585-4c8add052c83)

### Proposed Solution
Be able to set an auto width so that the menu can grow with the content.


### Screenshots
![image](https://github.com/liferay/clay/assets/47724428/c07e6219-dfa0-4fa6-988f-5b78cde6333e)

### Commits
- **fix(@clayui/picker): LPD-28522 Add option to add auto width**
- **fix(@clayui/picker): LPD-28522 Update picker stories**
