### PR TITLE
chore(@clayui/core): adds support for resizer indicator in table

### DIFF
--- a/packages/clay-core/src/table/Cell.tsx
+++ b/packages/clay-core/src/table/Cell.tsx
@@ -79,12 +79,32 @@ type Props = {
 	 * Sets a text value if the component's content is not plain text.
 	 */
 	textValue?: string;
+
+	/**
+	 * @ignore
+	 */
+	UNSAFE_resizable?: boolean;
+
+	/**
+	 * @ignore
+	 */
+	UNSAFE_resizerClassName?: string;
+
+	/**
+	 * @ignore
+	 */
+	UNSAFE_resizerOnMouseDown?: (
+		event: React.MouseEvent<HTMLDivElement, MouseEvent>
+	) => void;
 } & React.ThHTMLAttributes<HTMLTableCellElement> &
 	React.TdHTMLAttributes<HTMLTableCellElement>;
 
 export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 	function CellInner(
 		{
+			UNSAFE_resizable,
+			UNSAFE_resizerClassName,
+			UNSAFE_resizerOnMouseDown,
 			align,
 			children,
 			className,
@@ -324,6 +344,13 @@ export const Cell = React.forwardRef<HTMLTableCellElement, Props>(
 					</Layout.ContentRow>
 				) : (
 					children
+				)}
+
+				{UNSAFE_resizable && (
+					<div
+						className={UNSAFE_resizerClassName}
+						onMouseDown={UNSAFE_resizerOnMouseDown}
+					/>
 				)}
 			</As>
 		);


### PR DESCRIPTION
Well, I ended up thinking a lot about this... to "fix" the visual bug of the resizer indicator in FDS when using the new ClayTable and the cell activates sort. The indicator that FDS adds as `children` to the cell needs to be positioned on the edges of the cell but when it has sort it fails due to the internal HTML structure changing to support the visual states that we have to cover the Lexicon and this also ends up due to the properties CSS that prevent this.

A first solution I thought of was to add a new API to add new `right` or `left` elements in a cell independent of the internal structure when truncate or sort is enabled but this can add flexibility that we don't want and can break the Lexicon extension principles so to not go along this line of development as we will be developing the resizer implementation I added an initial surface to start implementing the resizer but extremely simple with the APIs that the FDS needs, in the future they will be removed and we will only have a resizable property. This is one reason why I'm adding it as UNSAFE and also marking it so it doesn't appear in the documentation.