### PR TITLE
LPD-33580 Add menu element attributes to the clay localized Input API

### DIFF
--- a/packages/clay-localized-input/src/index.tsx
+++ b/packages/clay-localized-input/src/index.tsx
@@ -95,6 +95,7 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 			id,
 			label = 'Check for translations',
 			locales,
+			menuElementAttrs,
 			onSelectedLocaleChange,
 			onTranslationsChange,
 			placeholder = 'Text to translate...',
@@ -146,6 +147,7 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 					<ClayInput.GroupItem shrink>
 						<ClayDropDown
 							active={active}
+							menuElementAttrs={menuElementAttrs}
 							onActiveChange={setActive}
 							trigger={
 								<ClayButton


### PR DESCRIPTION
Hey team, my goal here is to be able to use menuElementAttrs thought the Clay Input Localized.

Related [issue](https://liferay.atlassian.net/browse/LPD-18759)

My ultimate goal is to implement this new property in Frontend-infra's InputLocalized component to set the z-index to dropdown.