### PR TITLE
feat(@clayui/localized-input): LPD-33580 Add menu element attributes to the clay localized Input API

### DIFF
--- a/packages/clay-localized-input/src/index.tsx
+++ b/packages/clay-localized-input/src/index.tsx
@@ -9,6 +9,7 @@ import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
+import {IPortalBaseProps} from '@clayui/shared';
 import React from 'react';
 
 interface IItem {
@@ -40,6 +41,11 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	 * Label of the input
 	 */
 	label?: React.ReactText;
+
+	/**
+	 * Prop to pass DOM element attributes to DropDown.Menu
+	 */
+	menuElementAttrs?: React.HTMLAttributes<HTMLDivElement> & IPortalBaseProps;
 
 	/**
 	 * Content to be prepended in case you want to localize a URL.
@@ -95,6 +101,7 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 			id,
 			label = 'Check for translations',
 			locales,
+			menuElementAttrs,
 			onSelectedLocaleChange,
 			onTranslationsChange,
 			placeholder = 'Text to translate...',
@@ -146,6 +153,7 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 					<ClayInput.GroupItem shrink>
 						<ClayDropDown
 							active={active}
+							menuElementAttrs={menuElementAttrs}
 							onActiveChange={setActive}
 							trigger={
 								<ClayButton


### PR DESCRIPTION
Hey team, my goal here is to be able to use menuElementAttrs thought the Clay Input Localized.

Related [issue](https://liferay.atlassian.net/browse/LPD-18759)

My ultimate goal is to implement this new property in Frontend-infra's InputLocalized component to set the z-index to dropdown.


I was trying to implement a test like that:

```
it("renders with menu element attributes", () => {
const {container} = render(
	<ClayLocalizedInput
		id="locale1"
		locales={locales}
                menuElementAttrs={{className: 'custom-class'}}
		onSelectedLocaleChange={() => {}}
		onTranslationsChange={() => {}}
		selectedLocale={locales[0]!}
		spritemap="/path/to/svg"
		translations={{
			'en-US': 'Apple',
			'es-ES': 'Manzana',
		}}
	/>
);

fireEvent.click(
	container.querySelector('.dropdown-toggle') as HTMLButtonElement,
	{}
);

const dropdownMenu = document.querySelector('.dropdown-menu') as HTMLButtonElement;

expect(dropdownMenu).toHaveClass('custom-class');
```

But I wasn't successful, my `dropdownMenu` got a null value and I unfortunately didn't have the necessary time to debug. I hope everything is ok with the contribution.