### PR TITLE
LPD-33629 $modal-palette map should output pseudo classes for .close

### DIFF
--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -373,7 +373,20 @@
 	@each $key, $value in $map {
 		@if not clay-is-map-unset($value) {
 			@if (type-of($value) == 'map') {
+				$pseudo-classes: 'active', 'disabled', 'first-child', 'focus',
+					'hover', 'last-child', 'visited';
+
+				$pseudo-elements: 'after', 'before';
+
 				$valid-prefixes: '#', '&', '.', '>', '@', '~', '+', '[';
+
+				@if (index($pseudo-classes, $key)) {
+					$key: str-insert($key, '&:', 1);
+				}
+
+				@if (index($pseudo-elements, $key)) {
+					$key: str-insert($key, '&::', 1);
+				}
 
 				$selector: if(
 					index($valid-prefixes, str-slice($key, 1, 1)),


### PR DESCRIPTION
    - Added pseudo class and element keywords to filter for in the mixin `clay-map-to-css`

https://liferay.atlassian.net/browse/LPD-33629

Added a work around to make keys like hover, focus, disabled work when recursively generating selectors, but we should start encouraging using key names wrapped in quotes like '&:hover'.