### PR TITLE
fix(@clayui/drop-down): fixes bug with chrome blocking element focus when clicking outside the menu

### DIFF
--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -326,6 +326,7 @@ function ClayDropDown<T>({
 						navigationProps.onKeyDown(event);
 					}}
 					ref={menuElementRef}
+					suppress={[triggerElementRef, menuElementRef]}
 					triggerRef={triggerElementRef}
 					width={menuWidth}
 				>

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -200,6 +200,7 @@ const Menu = React.forwardRef<HTMLDivElement, IProps>(
 
 		return (
 			<Overlay
+				inert
 				isCloseOnInteractOutside={closeOnClickOutside}
 				isKeyboardDismiss
 				isModal={lock}

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -200,7 +200,6 @@ const Menu = React.forwardRef<HTMLDivElement, IProps>(
 
 		return (
 			<Overlay
-				inert
 				isCloseOnInteractOutside={closeOnClickOutside}
 				isKeyboardDismiss
 				isModal={lock}

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -2,10 +2,7 @@
 
 exports[`ClayDropDownWithDrilldown renders 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="dropdown"
     >
@@ -216,10 +213,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
 
 exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="dropdown"
     >

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -2,10 +2,7 @@
 
 exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="dropdown"
     >
@@ -77,10 +74,7 @@ exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
 
 exports[`ClayDropDown renders with groups 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="dropdown"
     >
@@ -224,10 +218,7 @@ exports[`ClayDropDown renders with groups 1`] = `
 
 exports[`ClayDropDown renders with icons 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="dropdown"
     >
@@ -344,10 +335,7 @@ exports[`ClayDropDown renders with icons 1`] = `
 
 exports[`ClayDropDown renders with search input 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="dropdown"
     >

--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -14,6 +14,7 @@ import type {Undo} from 'aria-hidden';
 
 type Props = {
 	children: React.ReactElement;
+	inert?: boolean;
 	isCloseOnInteractOutside?: boolean;
 	isKeyboardDismiss?: boolean;
 	isModal?: boolean;
@@ -35,6 +36,7 @@ const overlayStack: Array<React.RefObject<Element>> = [];
  */
 export function Overlay({
 	children,
+	inert,
 	isCloseOnInteractOutside = false,
 	isKeyboardDismiss = false,
 	isModal = false,
@@ -148,7 +150,7 @@ export function Overlay({
 			// Inert is a new native feature to better handle DOM arias that are not
 			// assertive to a SR or that should ignore any user interaction.
 			// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
-			if (isModal && supportsInert()) {
+			if ((isModal || inert) && supportsInert()) {
 				unsuppressCallbackRef.current = suppressOthers(elements);
 
 				return () => {
@@ -161,7 +163,7 @@ export function Overlay({
 				return hideOthers(elements);
 			}
 		}
-	}, [isModal, isOpen]);
+	}, [isModal, inert, isOpen]);
 
 	return (
 		<ClayPortal className={menuClassName} subPortalRef={portalRef}>

--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -118,6 +118,11 @@ export function Overlay({
 			onHide('blur');
 		},
 		onInteractStart: (event) => {
+			if (unsuppressCallbackRef.current) {
+				unsuppressCallbackRef.current();
+				unsuppressCallbackRef.current = null;
+			}
+
 			if (overlayStack[overlayStack.length - 1] === menuRef && isModal) {
 				event.stopPropagation();
 				event.preventDefault();
@@ -152,16 +157,16 @@ export function Overlay({
 			// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
 			if ((isModal || inert) && supportsInert()) {
 				unsuppressCallbackRef.current = suppressOthers(elements);
-
-				return () => {
-					if (unsuppressCallbackRef.current) {
-						unsuppressCallbackRef.current();
-					}
-					unsuppressCallbackRef.current = null;
-				};
 			} else {
-				return hideOthers(elements);
+				unsuppressCallbackRef.current = hideOthers(elements);
 			}
+
+			return () => {
+				if (unsuppressCallbackRef.current) {
+					unsuppressCallbackRef.current();
+				}
+				unsuppressCallbackRef.current = null;
+			};
 		}
 	}, [isModal, inert, isOpen]);
 


### PR DESCRIPTION
Context https://liferay.slack.com/archives/C04CPMRMXAL/p1723558235946469

Well, basically, the message from Chrome about blocking focus due to the use of aria-hidden seems intermittent and only happens once, at least in the tests I've done, but I can still see the focused element when adding a watch to `document.activeElement`.

So I think this is more of a warning about good practices or avoiding problems with SR, but I think this would be an unrealistic case, perhaps since when using SR in a real case, you are normally using keyboard interaction and when you close the menu, the focus returns to the trigger that does not have aria-hidden, so this will not happen in this use case. I believe that this may be another bug in Chrome that should show this message in case of keyboard interaction or is just being shown to the developer as a warning when the console is opened.

This is my assumption, but in any case, we can change to using inert, but this causes a different interaction, for example, closing the menu by clicking on an input will no longer receive focus, just by clicking it again.

Another option would be to remove the use of aria-hidden or inert when it's a mouse interaction and add it when it's a keyboard interaction. Thoughts?