### PR TITLE
fix(@clayui/css): LPD-2001 c-prefers-expanded-text shouldn't use max-…

### DIFF
--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -834,7 +834,6 @@
 // C Prefers Expanded Text
 
 %c-prefers-expanded-text {
-	max-width: 100% !important;
 	overflow-wrap: break-word !important;
 	white-space: normal !important;
 	word-wrap: break-word !important;


### PR DESCRIPTION
…width

https://liferay.atlassian.net/browse/LPD-2001

https://github.com/liferay-platform-experience/liferay-portal/pull/689

This will only fix the stacked tab item text. We will add the functionality mentioned in https://github.com/liferay/clay/pull/5622 in another pr. I wanted a CSS only solution, but it looks like we will need to implement in it in ClayTabs since we can't tell if tabs will break to new line. The tabs will look like the screenshot when expanded text and increased spacing.

![tabs-will-look](https://github.com/user-attachments/assets/21de0a30-fc04-416e-82a7-bfb4ba72bd39)
