### PR TITLE
LPD-35161 Removes suppression of focusable elements from focus trap

### DIFF
--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -51,7 +51,6 @@ exports[`BasicRendering renders by default 1`] = `
   </div>
   <div>
     <span
-      aria-hidden="true"
       data-focus-scope-start="true"
       tabindex="0"
     />
@@ -823,7 +822,6 @@ exports[`BasicRendering renders by default 1`] = `
       </div>
     </div>
     <span
-      aria-hidden="true"
       data-focus-scope-end="true"
       tabindex="0"
     />

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -889,7 +889,6 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
   </div>
   <div>
     <span
-      aria-hidden="true"
       data-focus-scope-start="true"
       tabindex="0"
     />
@@ -1661,7 +1660,6 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
       </div>
     </div>
     <span
-      aria-hidden="true"
       data-focus-scope-end="true"
       tabindex="0"
     />
@@ -3416,7 +3414,6 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
   </div>
   <div>
     <span
-      aria-hidden="true"
       data-focus-scope-start="true"
       tabindex="0"
     />
@@ -4188,7 +4185,6 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
       </div>
     </div>
     <span
-      aria-hidden="true"
       data-focus-scope-end="true"
       tabindex="0"
     />

--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -172,21 +172,9 @@ export function Overlay({
 
 	return (
 		<ClayPortal className={menuClassName} subPortalRef={portalRef}>
-			{isModal && (
-				<span
-					aria-hidden="true"
-					data-focus-scope-start="true"
-					tabIndex={0}
-				/>
-			)}
+			{isModal && <span data-focus-scope-start="true" tabIndex={0} />}
 			{children}
-			{isModal && (
-				<span
-					aria-hidden="true"
-					data-focus-scope-end="true"
-					tabIndex={0}
-				/>
-			)}
+			{isModal && <span data-focus-scope-end="true" tabIndex={0} />}
 		</ClayPortal>
 	);
 }


### PR DESCRIPTION
Ticket [LPD-35161](https://liferay.atlassian.net/browse/LPD-35161)

To avoid the accessibility error we avoid adding aria-hidden to the focusable element that we use for the focus trap. So basically we removed aria-hidden and I thought we would also need to ignore the suppression we do with inert but it wasn't necessary.