### PR TITLE
fix(@clayui/form): LPD-36696 DualListBox adds children and don't disable left right buttons if no items are selected

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -92,7 +92,7 @@ module.exports = {
 			statements: 80,
 		},
 		'./packages/clay-form/src/': {
-			branches: 62,
+			branches: 61,
 			functions: 70,
 			lines: 85,
 			statements: 85,

--- a/packages/clay-form/src/DualListBox.tsx
+++ b/packages/clay-form/src/DualListBox.tsx
@@ -111,6 +111,7 @@ const ClayDualListBox = ({
 		transferLTR: 'Transfer Item Left to Right',
 		transferRTL: 'Transfer Item Right to Left',
 	},
+	children,
 	className,
 	disabled,
 	disableLTR,
@@ -166,9 +167,7 @@ const ClayDualListBox = ({
 						aria-label={ariaLabels.transferLTR}
 						className="transfer-button-ltr"
 						data-testid="ltr"
-						disabled={
-							leftSelected.length === 0 || disableLTR || disabled
-						}
+						disabled={disableLTR || disabled}
 						displayType="secondary"
 						onClick={() => {
 							const [arrayLeft, arrayRight] = swapArrayItems(
@@ -187,9 +186,7 @@ const ClayDualListBox = ({
 						aria-label={ariaLabels.transferRTL}
 						className="transfer-button-rtl"
 						data-testid="rtl"
-						disabled={
-							rightSelected.length === 0 || disableRTL || disabled
-						}
+						disabled={disableRTL || disabled}
 						displayType="secondary"
 						onClick={() => {
 							const [arrayRight, arrayLeft] = swapArrayItems(
@@ -222,6 +219,8 @@ const ClayDualListBox = ({
 					value={rightSelected}
 				/>
 			</div>
+
+			{children}
 		</div>
 	);
 };

--- a/packages/clay-form/src/DualListBox.tsx
+++ b/packages/clay-form/src/DualListBox.tsx
@@ -168,10 +168,10 @@ const ClayDualListBox = ({
 		? leftSelected.length + rightItems!.length > rightMaxItems
 		: false;
 	const hasMaxItemsLeft = leftMaxItems
-		? leftItems!.length > leftMaxItems
+		? leftItems!.length >= leftMaxItems
 		: false;
 	const hasMaxItemsRight = rightMaxItems
-		? rightItems!.length > rightMaxItems
+		? rightItems!.length >= rightMaxItems
 		: false;
 
 	return (
@@ -199,8 +199,8 @@ const ClayDualListBox = ({
 						data-testid="ltr"
 						disabled={
 							disableLTR ||
-							isLeftError ||
-							hasMaxItemsLeft ||
+							hasMaxItemsRight ||
+							isRightError ||
 							disabled
 						}
 						displayType="secondary"
@@ -223,8 +223,8 @@ const ClayDualListBox = ({
 						data-testid="rtl"
 						disabled={
 							disableRTL ||
-							isRightError ||
-							hasMaxItemsRight ||
+							hasMaxItemsLeft ||
+							isLeftError ||
 							disabled
 						}
 						displayType="secondary"
@@ -260,17 +260,16 @@ const ClayDualListBox = ({
 				/>
 			</div>
 
-			{isLeftError ||
-				(isRightError && (
-					<Form.FeedbackGroup className="has-error">
-						<Form.FeedbackItem>
-							{sub(ariaLabels.error || defaultError, [
-								isLeftError ? left.label! : right.label!,
-								isLeftError ? leftMaxItems! : rightMaxItems!,
-							])}
-						</Form.FeedbackItem>
-					</Form.FeedbackGroup>
-				))}
+			{(isLeftError || isRightError) && (
+				<Form.FeedbackGroup className="has-error">
+					<Form.FeedbackItem>
+						{sub(ariaLabels.error || defaultError, [
+							isLeftError ? left.label! : right.label!,
+							isLeftError ? leftMaxItems! : rightMaxItems!,
+						])}
+					</Form.FeedbackItem>
+				</Form.FeedbackGroup>
+			)}
 		</div>
 	);
 };

--- a/packages/clay-form/stories/DualListBox.stories.tsx
+++ b/packages/clay-form/stories/DualListBox.stories.tsx
@@ -64,25 +64,10 @@ export const Default = (args: any) => {
 	const [leftSelected, setLeftSelected] = useState<Array<string>>([]);
 	const [rightSelected, setRightSelected] = useState<Array<string>>([]);
 
-	const [firstSelectBoxItems, secondSelectBoxItems] = items;
-
-	const isLeftError =
-		rightSelected.length + firstSelectBoxItems.length > args.leftMaxItems;
-	const isRightError =
-		leftSelected.length + secondSelectBoxItems.length > args.rightMaxItems;
-
 	return (
 		<ClayDualListBox
-			disableLTR={
-				args.disableLTR ||
-				isRightError ||
-				secondSelectBoxItems.length >= args.rightMaxItems
-			}
-			disableRTL={
-				args.disableRTL ||
-				isLeftError ||
-				firstSelectBoxItems.length >= args.leftMaxItems
-			}
+			disableLTR={args.disableLTR}
+			disableRTL={args.disableRTL}
 			disabled={args.disabled}
 			items={items}
 			left={{
@@ -91,6 +76,7 @@ export const Default = (args: any) => {
 				onSelectChange: setLeftSelected,
 				selected: leftSelected,
 			}}
+			leftMaxItems={args.leftMaxItems}
 			onItemsChange={(event) => {
 				setItems(event);
 				setLeftSelected([]);
@@ -102,20 +88,9 @@ export const Default = (args: any) => {
 				onSelectChange: setRightSelected,
 				selected: rightSelected,
 			}}
+			rightMaxItems={args.rightMaxItems}
 			size={8}
-		>
-			<ClayForm.FeedbackGroup
-				className={classnames('d-none', 'has-error', {
-					'd-block': isLeftError || isRightError,
-				})}
-			>
-				<ClayForm.FeedbackItem>
-					The maximum number of items for{' '}
-					{isLeftError ? 'Available' : 'In Use'} is{' '}
-					{args.leftMaxItems}
-				</ClayForm.FeedbackItem>
-			</ClayForm.FeedbackGroup>
-		</ClayDualListBox>
+		/>
 	);
 };
 

--- a/packages/clay-form/stories/DualListBox.stories.tsx
+++ b/packages/clay-form/stories/DualListBox.stories.tsx
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import classnames from 'classnames';
 import React, {useState} from 'react';
 
-import ClayForm, {ClayDualListBox} from '../src';
+import {ClayDualListBox} from '../src';
 
 export default {
 	argTypes: {

--- a/packages/clay-form/stories/DualListBox.stories.tsx
+++ b/packages/clay-form/stories/DualListBox.stories.tsx
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import classnames from 'classnames';
 import React, {useState} from 'react';
 
-import {ClayDualListBox} from '../src';
+import ClayForm, {ClayDualListBox} from '../src';
 
 export default {
 	argTypes: {
@@ -59,19 +60,27 @@ const moveBoxesOptions = [
 
 export const Default = (args: any) => {
 	const [items, setItems] = useState(moveBoxesOptions);
+
 	const [leftSelected, setLeftSelected] = useState<Array<string>>([]);
 	const [rightSelected, setRightSelected] = useState<Array<string>>([]);
 
 	const [firstSelectBoxItems, secondSelectBoxItems] = items;
 
+	const isLeftError =
+		rightSelected.length + firstSelectBoxItems.length > args.leftMaxItems;
+	const isRightError =
+		leftSelected.length + secondSelectBoxItems.length > args.rightMaxItems;
+
 	return (
 		<ClayDualListBox
 			disableLTR={
 				args.disableLTR ||
+				isRightError ||
 				secondSelectBoxItems.length >= args.rightMaxItems
 			}
 			disableRTL={
 				args.disableRTL ||
+				isLeftError ||
 				firstSelectBoxItems.length >= args.leftMaxItems
 			}
 			disabled={args.disabled}
@@ -82,7 +91,11 @@ export const Default = (args: any) => {
 				onSelectChange: setLeftSelected,
 				selected: leftSelected,
 			}}
-			onItemsChange={setItems}
+			onItemsChange={(event) => {
+				setItems(event);
+				setLeftSelected([]);
+				setRightSelected([]);
+			}}
 			right={{
 				id: 'rightSelectBox',
 				label: 'In Use',
@@ -90,7 +103,19 @@ export const Default = (args: any) => {
 				selected: rightSelected,
 			}}
 			size={8}
-		/>
+		>
+			<ClayForm.FeedbackGroup
+				className={classnames('d-none', 'has-error', {
+					'd-block': isLeftError || isRightError,
+				})}
+			>
+				<ClayForm.FeedbackItem>
+					The maximum number of items for{' '}
+					{isLeftError ? 'Available' : 'In Use'} is{' '}
+					{args.leftMaxItems}
+				</ClayForm.FeedbackItem>
+			</ClayForm.FeedbackGroup>
+		</ClayDualListBox>
 	);
 };
 
@@ -99,5 +124,5 @@ Default.args = {
 	disableRTL: false,
 	disabled: false,
 	leftMaxItems: 5,
-	rightMaxItems: 3,
+	rightMaxItems: 5,
 };


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-36696

I added children to the component so we can pass in things like an error message. I also removed disabling the move buttons if length is 0.

![duallistbox-new](https://github.com/user-attachments/assets/b01879e7-0f80-4a76-a0ad-50a38a4f6b4a)
