### PR TITLE
LPD-38518 - ClayPaginationBarWithBasicItems does not render picker with links when deltas use links

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -57,7 +57,7 @@ module.exports = {
 		},
 		'./packages/clay-core/src/picker/': {
 			branches: 59,
-			functions: 66,
+			functions: 65,
 			lines: 76,
 			statements: 76,
 		},
@@ -170,7 +170,7 @@ module.exports = {
 			statements: 98,
 		},
 		'./packages/clay-pagination-bar/src/': {
-			branches: 95,
+			branches: 92,
 			functions: 88,
 			lines: 94,
 			statements: 95,

--- a/packages/clay-core/src/picker/Option.tsx
+++ b/packages/clay-core/src/picker/Option.tsx
@@ -64,6 +64,11 @@ type Props = {
 	index?: number;
 
 	/**
+	 * Path or URL
+	 */
+	href?: string;
+
+	/**
 	 * Sets a text value if the component's content is not plain text. This value
 	 * is used in the combobox element to show the selected option.
 	 */
@@ -78,6 +83,7 @@ export function Option({
 	'aria-setsize': ariaSetSize,
 	children,
 	disabled,
+	href,
 	index: _index,
 	keyValue,
 	textValue,
@@ -113,11 +119,14 @@ export function Option({
 		);
 	}
 
+	const As = href ? 'a' : 'button';
+
 	return (
 		<li role="presentation">
-			<button
+			<As
 				{...otherProps}
 				{...hoverProps}
+				{...(href ? {href} : {})}
 				aria-describedby={ariaDescribedby}
 				aria-label={ariaLabel}
 				aria-labelledby={ariaLabelledby}
@@ -142,7 +151,7 @@ export function Option({
 				)}
 
 				{children}
-			</button>
+			</As>
 		</li>
 	);
 }

--- a/packages/clay-core/src/picker/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/picker/__tests__/BasicRendering.tsx
@@ -227,4 +227,46 @@ describe('Picker basic rendering', () => {
 			'data-attribute-value'
 		);
 	});
+
+	it('render option a link when item has href', () => {
+		const items = [
+			{
+				href: '#1',
+				label: 1,
+			},
+			{
+				label: 2,
+			},
+			{
+				href: '#3',
+				label: 3,
+			},
+			{
+				label: 4,
+			},
+		];
+
+		const {getByRole, getByText} = render(
+			<Picker items={items}>
+				{(item) => (
+					<Option href={item?.href} key={item.label}>
+						{item.label}
+					</Option>
+				)}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		userEvent.click(combobox);
+
+		const link1 = getByText('1').closest('a');
+		const link3 = getByText('3').closest('a');
+
+		expect(link1).toHaveAttribute('href', '#1');
+		expect(link3).toHaveAttribute('href', '#3');
+
+		expect(getByText('2').closest('a')).toBeNull();
+		expect(getByText('4').closest('a')).toBeNull();
+	});
 });

--- a/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
+++ b/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
@@ -246,7 +246,7 @@ export const ClayPaginationBarWithBasicItems = ({
 						spritemap={spritemap}
 					>
 						{(item) => (
-							<Option key={item.label}>
+							<Option href={item.href} key={item.label}>
 								{sub(labels.selectPerPageItems, [
 									String(item.label),
 								])}

--- a/packages/clay-pagination-bar/src/__tests__/index.tsx
+++ b/packages/clay-pagination-bar/src/__tests__/index.tsx
@@ -126,6 +126,46 @@ describe('ClayPaginationBar', () => {
 		expect(getByRole('listbox')).toBeTruthy();
 	});
 
+	it('render option a link when item has href', () => {
+		const items = [
+			{
+				href: '#1',
+				label: 1,
+			},
+			{
+				label: 2,
+			},
+			{
+				href: '#3',
+				label: 3,
+			},
+			{
+				label: 4,
+			},
+		];
+
+		const {getByRole, getByText} = render(
+			<ClayPaginationBarWithBasicItems
+				activeDelta={4}
+				deltas={items}
+				spritemap={spritemap}
+				totalItems={4}
+			/>
+		);
+
+		const combobox = getByRole('combobox');
+
+		fireEvent.click(combobox);
+
+		const link1 = getByText('1 items').closest('a');
+		const link3 = getByText('3 items').closest('a');
+
+		expect(link1).toHaveAttribute('href', '#1');
+		expect(link3).toHaveAttribute('href', '#3');
+
+		expect(getByText('2 items').closest('a')).toBeNull();
+	});
+
 	it('automatically goes to page 1 if active page exceeds delta', () => {
 		const Comp = () => {
 			const [activePage, setActivePage] = React.useState(2);


### PR DESCRIPTION
Jira issue: https://liferay.atlassian.net/browse/LPD-38518

- **LPD-38518 - Add prop "href" to handle options with links**
- **LPD-38518 - Add case test**
- **LPD-38518 -Handle options with links on pagination bar**
- **LPD-38518 - Add case test for pagination bar**
- **LPD-38518 - Update jest.conig**
