### PR TITLE
feat(@clayui/css): LPD-40080 Add new sticker variants sticker-space-color-*

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -101,41 +101,45 @@ $purple-d4: #7700cc !default;
 $purple-d3: #8600e6 !default;
 $purple-d2: #9500ff !default;
 $purple-d1: #9f1aff !default;
-$purple: if($enable-lexicon-flat-colors, #af78ff, #6f42c1) !default;
+$purple: if($enable-lexicon-flat-colors, #aa33ff, #6f42c1) !default;
 $purple-l1: #bf66ff !default;
 $purple-l2: #ca80ff !default;
 $purple-l3: #d499ff !default;
 $purple-l4: #dfb3ff !default;
+$purple-l5: #f9f0ff !default;
 
 $pink-d4: #800048 !default;
 $pink-d3: #990057 !default;
 $pink-d2: #b30065 !default;
 $pink-d1: #cc0074 !default;
-$pink: if($enable-lexicon-flat-colors, #ff73c3, #e83e8c) !default;
+$pink: if($enable-lexicon-flat-colors, #e50082, #e83e8c) !default;
 $pink-l1: #ff4db2 !default;
 $pink-l2: #ff80c8 !default;
 $pink-l3: #ff99d3 !default;
 $pink-l4: #ffb3de !default;
+$pink-l5: #fff0f8 !default;
 
 $red-d4: #800000 !default;
 $red-d3: #990000 !default;
 $red-d2: #b30000 !default;
 $red-d1: #cc0000 !default;
-$red: if($enable-lexicon-flat-colors, #ff5f5f, #da1414) !default;
+$red: if($enable-lexicon-flat-colors, #e50000, #da1414) !default;
 $red-l1: #ff4d4d !default;
 $red-l2: #ff6666 !default;
 $red-l3: #ff8080 !default;
 $red-l4: #ff9999 !default;
+$red-l5: #fff0f0 !default;
 
 $orange-d4: #662700 !default;
 $orange-d3: #803100 !default;
 $orange-d2: #993b00 !default;
 $orange-d1: #b34400 !default;
-$orange: if($enable-lexicon-flat-colors, #ffb46e, #b95000) !default;
+$orange: if($enable-lexicon-flat-colors, #cc4e00, #b95000) !default;
 $orange-l1: #ff6200 !default;
 $orange-l2: #ff8133 !default;
 $orange-l3: #ffa166 !default;
 $orange-l4: #ffc099 !default;
+$orange-l5: #fff3eb !default;
 
 $yellow-d4: #997000 !default;
 $yellow-d3: #b38900 !default;
@@ -146,36 +150,40 @@ $yellow-l1: #ffc933 !default;
 $yellow-l2: #ffd666 !default;
 $yellow-l3: #ffe499 !default;
 $yellow-l4: #fff1cc !default;
+$yellow-l5: #fff8e5 !default;
 
 $green-d4: #162d06 !default;
 $green-d3: #22430a !default;
 $green-d2: #2e590d !default;
 $green-d1: #397010 !default;
-$green: if($enable-lexicon-flat-colors, #9be169, #287d3d) !default;
+$green: if($enable-lexicon-flat-colors, #458613, #287d3d) !default;
 $green-l1: #53a117 !default;
 $green-l2: #67c91d !default;
 $green-l3: #81e236 !default;
 $green-l4: #9de963 !default;
+$green-l5: #f1fce9 !default;
 
 $teal-d4: #092a25 !default;
 $teal-d3: #0d3f37 !default;
 $teal-d2: #125449 !default;
 $teal-d1: #16695b !default;
-$teal: if($enable-lexicon-flat-colors, #50d2a0, #20c997) !default;
+$teal: if($enable-lexicon-flat-colors, #1b7e6e, #20c997) !default;
 $teal-l1: #24a892 !default;
 $teal-l2: #42d7be !default;
 $teal-l3: #6ce0cc !default;
 $teal-l4: #96e9db !default;
+$teal-l5: #eafbf8 !default;
 
 $cyan-d4: #00334d !default;
 $cyan-d3: #004466 !default;
 $cyan-d2: #005580 !default;
 $cyan-d1: #006699 !default;
-$cyan: if($enable-lexicon-flat-colors, #5fc8ff, #17a2b8) !default;
+$cyan: if($enable-lexicon-flat-colors, #0077b3, #17a2b8) !default;
 $cyan-l1: #0099e6 !default;
 $cyan-l2: #33bbff !default;
 $cyan-l3: #66ccff !default;
 $cyan-l4: #99ddff !default;
+$cyan-l5: #f0faff !default;
 
 $colors: () !default;
 $colors: map-merge(

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -107,6 +107,7 @@ $purple-l1: #bf66ff !default;
 $purple-l2: #ca80ff !default;
 $purple-l3: #d499ff !default;
 $purple-l4: #dfb3ff !default;
+$purple-l5: #f9f0ff !default;
 
 $pink-d4: #800048 !default;
 $pink-d3: #990057 !default;
@@ -117,6 +118,7 @@ $pink-l1: #ff4db2 !default;
 $pink-l2: #ff80c8 !default;
 $pink-l3: #ff99d3 !default;
 $pink-l4: #ffb3de !default;
+$pink-l5: #fff0f8 !default;
 
 $red-d4: #800000 !default;
 $red-d3: #990000 !default;
@@ -127,6 +129,7 @@ $red-l1: #ff4d4d !default;
 $red-l2: #ff6666 !default;
 $red-l3: #ff8080 !default;
 $red-l4: #ff9999 !default;
+$red-l5: #fff0f0 !default;
 
 $orange-d4: #662700 !default;
 $orange-d3: #803100 !default;
@@ -137,6 +140,7 @@ $orange-l1: #ff6200 !default;
 $orange-l2: #ff8133 !default;
 $orange-l3: #ffa166 !default;
 $orange-l4: #ffc099 !default;
+$orange-l5: #fff3eb !default;
 
 $yellow-d4: #997000 !default;
 $yellow-d3: #b38900 !default;
@@ -147,6 +151,7 @@ $yellow-l1: #ffc933 !default;
 $yellow-l2: #ffd666 !default;
 $yellow-l3: #ffe499 !default;
 $yellow-l4: #fff1cc !default;
+$yellow-l5: #fff8e5 !default;
 
 $green-d4: #162d06 !default;
 $green-d3: #22430a !default;
@@ -157,6 +162,7 @@ $green-l1: #53a117 !default;
 $green-l2: #67c91d !default;
 $green-l3: #81e236 !default;
 $green-l4: #9de963 !default;
+$green-l5: #f1fce9 !default;
 
 $teal-d4: #092a25 !default;
 $teal-d3: #0d3f37 !default;
@@ -167,6 +173,7 @@ $teal-l1: #24a892 !default;
 $teal-l2: #42d7be !default;
 $teal-l3: #6ce0cc !default;
 $teal-l4: #96e9db !default;
+$teal-l5: #eafbf8 !default;
 
 $cyan-d4: #00334d !default;
 $cyan-d3: #004466 !default;
@@ -177,6 +184,7 @@ $cyan-l1: #0099e6 !default;
 $cyan-l2: #33bbff !default;
 $cyan-l3: #66ccff !default;
 $cyan-l4: #99ddff !default;
+$cyan-l5: #f0faff !default;
 
 $colors: () !default;
 $colors: map-merge(

--- a/packages/clay-css/src/scss/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/variables/_stickers.scss
@@ -402,6 +402,106 @@ $sticker-dark: map-deep-merge(
 	$sticker-dark
 );
 
+$sticker-space-color-0: () !default;
+$sticker-space-color-0: map-deep-merge(
+	(
+		background-color: $light,
+		border: 1px solid $dark,
+		color: $dark,
+	),
+	$sticker-space-color-0
+);
+
+$sticker-space-color-1: () !default;
+$sticker-space-color-1: map-deep-merge(
+	(
+		background-color: $purple-l5,
+		border: 1px solid $purple,
+		color: $purple,
+	),
+	$sticker-space-color-1
+);
+
+$sticker-space-color-2: () !default;
+$sticker-space-color-2: map-deep-merge(
+	(
+		background-color: $yellow-l5,
+		border: 1px solid $yellow-d3,
+		color: $yellow-d3,
+	),
+	$sticker-space-color-2
+);
+
+$sticker-space-color-3: () !default;
+$sticker-space-color-3: map-deep-merge(
+	(
+		background-color: $green-l5,
+		border: 1px solid $green,
+		color: $green,
+	),
+	$sticker-space-color-3
+);
+
+$sticker-space-color-4: () !default;
+$sticker-space-color-4: map-deep-merge(
+	(
+		background-color: $red-l5,
+		border: 1px solid $red,
+		color: $red,
+	),
+	$sticker-space-color-4
+);
+
+$sticker-space-color-5: () !default;
+$sticker-space-color-5: map-deep-merge(
+	(
+		background-color: $orange-l5,
+		border: 1px solid $orange,
+		color: $orange,
+	),
+	$sticker-space-color-5
+);
+
+$sticker-space-color-6: () !default;
+$sticker-space-color-6: map-deep-merge(
+	(
+		background-color: $teal-l5,
+		border: 1px solid $teal,
+		color: $teal,
+	),
+	$sticker-space-color-6
+);
+
+$sticker-space-color-7: () !default;
+$sticker-space-color-7: map-deep-merge(
+	(
+		background-color: $cyan-l5,
+		border: 1px solid $cyan,
+		color: $cyan,
+	),
+	$sticker-space-color-7
+);
+
+$sticker-space-color-8: () !default;
+$sticker-space-color-8: map-deep-merge(
+	(
+		background-color: $pink-l5,
+		border: 1px solid $pink,
+		color: $pink-d4,
+	),
+	$sticker-space-color-8
+);
+
+$sticker-space-color-9: () !default;
+$sticker-space-color-9: map-deep-merge(
+	(
+		background-color: $white,
+		border: 1px solid $dark-l2,
+		color: $dark-l2,
+	),
+	$sticker-space-color-9
+);
+
 $sticker-palette: () !default;
 $sticker-palette: map-deep-merge(
 	(
@@ -413,6 +513,16 @@ $sticker-palette: map-deep-merge(
 		danger: $sticker-danger,
 		light: $sticker-light,
 		dark: $sticker-dark,
+		'.sticker-space-color-0': $sticker-space-color-0,
+		'.sticker-space-color-1': $sticker-space-color-1,
+		'.sticker-space-color-2': $sticker-space-color-2,
+		'.sticker-space-color-3': $sticker-space-color-3,
+		'.sticker-space-color-4': $sticker-space-color-4,
+		'.sticker-space-color-5': $sticker-space-color-5,
+		'.sticker-space-color-6': $sticker-space-color-6,
+		'.sticker-space-color-7': $sticker-space-color-7,
+		'.sticker-space-color-8': $sticker-space-color-8,
+		'.sticker-space-color-9': $sticker-space-color-9,
 	),
 	$sticker-palette
 );

--- a/packages/clay-sticker/docs/index.js
+++ b/packages/clay-sticker/docs/index.js
@@ -45,6 +45,19 @@ const StickerColorsAndSizesCode = `const Component = () => {
 			<ClaySticker displayType="warning" size="sm">
 				<ClayIcon spritemap={spritemap} symbol="user" />
 			</ClaySticker>
+
+			<div className="mt-3">
+				<ClaySticker displayType="space-color-0">S</ClaySticker>
+				<ClaySticker displayType="space-color-1">M</ClaySticker>
+				<ClaySticker displayType="space-color-2">C</ClaySticker>
+				<ClaySticker displayType="space-color-3">M</ClaySticker>
+				<ClaySticker displayType="space-color-4">S</ClaySticker>
+				<ClaySticker displayType="space-color-5">S</ClaySticker>
+				<ClaySticker displayType="space-color-6">E</ClaySticker>
+				<ClaySticker displayType="space-color-7">Q</ClaySticker>
+				<ClaySticker displayType="space-color-8">D</ClaySticker>
+				<ClaySticker displayType="space-color-9">P</ClaySticker>
+			</div>
 		</>
 	);
 }
@@ -99,7 +112,18 @@ const StickerColorsAndSizesJSPCode = `<clay:sticker
 	displayType="warning"
 	icon="users"
 	size="sm"
-/>`;
+/>
+
+<clay:sticker displayType="space-color-0" label="S" />
+<clay:sticker displayType="space-color-1" label="M" />
+<clay:sticker displayType="space-color-2" label="C" />
+<clay:sticker displayType="space-color-3" label="M" />
+<clay:sticker displayType="space-color-4" label="S" />
+<clay:sticker displayType="space-color-5" label="S" />
+<clay:sticker displayType="space-color-6" label="E" />
+<clay:sticker displayType="space-color-7" label="Q" />
+<clay:sticker displayType="space-color-8" label="D" />
+<clay:sticker displayType="space-color-9" label="P" />`;
 
 export const StickerColorsAndSizes = () => {
 	const scope = {ClayIcon, ClaySticker};

--- a/packages/clay-sticker/src/index.tsx
+++ b/packages/clay-sticker/src/index.tsx
@@ -15,7 +15,17 @@ export type DisplayType =
 	| 'secondary'
 	| 'success'
 	| 'unstyled'
-	| 'warning';
+	| 'warning'
+	| 'space-color-0'
+	| 'space-color-1'
+	| 'space-color-2'
+	| 'space-color-3'
+	| 'space-color-4'
+	| 'space-color-5'
+	| 'space-color-6'
+	| 'space-color-7'
+	| 'space-color-8'
+	| 'space-color-9';
 
 type Shape = 'circle' | 'user-icon';
 

--- a/packages/clay-sticker/stories/Sticker.stories.tsx
+++ b/packages/clay-sticker/stories/Sticker.stories.tsx
@@ -51,6 +51,19 @@ export const Default = () => (
 		<ClaySticker displayType="warning">
 			<ClayIcon symbol="user" />
 		</ClaySticker>
+
+		<div className="mt-3">
+			<ClaySticker displayType="space-color-0">S</ClaySticker>
+			<ClaySticker displayType="space-color-1">M</ClaySticker>
+			<ClaySticker displayType="space-color-2">C</ClaySticker>
+			<ClaySticker displayType="space-color-3">M</ClaySticker>
+			<ClaySticker displayType="space-color-4">S</ClaySticker>
+			<ClaySticker displayType="space-color-5">S</ClaySticker>
+			<ClaySticker displayType="space-color-6">E</ClaySticker>
+			<ClaySticker displayType="space-color-7">Q</ClaySticker>
+			<ClaySticker displayType="space-color-8">D</ClaySticker>
+			<ClaySticker displayType="space-color-9">P</ClaySticker>
+		</div>
 	</div>
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-40080

This adds new sticker displayTypes `sticker-space-color-#`. I would like to shorten the name to `sticker-space-#` or something else a little more descriptive.

/cc @marcoscv-work 