### PR TITLE
feat(@clayui/css): LPD-40160 Adds menubar-primary for CMS Product Menu variant

### DIFF
--- a/packages/clay-core/src/nav/Link.tsx
+++ b/packages/clay-core/src/nav/Link.tsx
@@ -52,44 +52,6 @@ export const Link = React.forwardRef<
 		},
 		ref
 	) => {
-		if (showIcon) {
-			return (
-				<div
-					{...(otherProps as Omit<
-						IProps,
-						keyof React.AnchorHTMLAttributes<HTMLAnchorElement>
-					> &
-						React.HTMLAttributes<HTMLDivElement>)}
-					className={classNames('nav-link', className, {
-						active,
-						['collapse-icon']: showIcon,
-						collapsed,
-						disabled,
-					})}
-					ref={ref as React.Ref<HTMLDivElement>}
-				>
-					{children}
-					<span className="collapse-icon-closed">
-						<Icon
-							focusable="false"
-							role="presentation"
-							spritemap={spritemap}
-							symbol="angle-right-small"
-						/>
-					</span>
-
-					<span className="collapse-icon-open">
-						<Icon
-							focusable="false"
-							role="presentation"
-							spritemap={spritemap}
-							symbol="angle-down-small"
-						/>
-					</span>
-				</div>
-			);
-		}
-
 		return (
 			<LinkOrButton
 				{...otherProps}
@@ -104,6 +66,28 @@ export const Link = React.forwardRef<
 				ref={ref}
 			>
 				{children}
+
+				{showIcon && (
+					<>
+						<span className="collapse-icon-closed">
+							<Icon
+								focusable="false"
+								role="presentation"
+								spritemap={spritemap}
+								symbol="angle-right-small"
+							/>
+						</span>
+
+						<span className="collapse-icon-open">
+							<Icon
+								focusable="false"
+								role="presentation"
+								spritemap={spritemap}
+								symbol="angle-down-small"
+							/>
+						</span>
+					</>
+				)}
 			</LinkOrButton>
 		);
 	}

--- a/packages/clay-core/src/nav/Link.tsx
+++ b/packages/clay-core/src/nav/Link.tsx
@@ -36,7 +36,7 @@ export interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 }
 
 export const Link = React.forwardRef<
-	HTMLButtonElement | HTMLAnchorElement,
+	HTMLButtonElement | HTMLAnchorElement | HTMLDivElement,
 	IProps
 >(
 	(
@@ -55,14 +55,18 @@ export const Link = React.forwardRef<
 		if (showIcon) {
 			return (
 				<div
-					{...otherProps}
+					{...(otherProps as Omit<
+						IProps,
+						keyof React.AnchorHTMLAttributes<HTMLAnchorElement>
+					> &
+						React.HTMLAttributes<HTMLDivElement>)}
 					className={classNames('nav-link', className, {
 						active,
 						['collapse-icon']: showIcon,
 						collapsed,
 						disabled,
 					})}
-					ref={ref}
+					ref={ref as React.Ref<HTMLDivElement>}
 				>
 					{children}
 					<span className="collapse-icon-closed">

--- a/packages/clay-core/src/nav/Link.tsx
+++ b/packages/clay-core/src/nav/Link.tsx
@@ -52,6 +52,40 @@ export const Link = React.forwardRef<
 		},
 		ref
 	) => {
+		if (showIcon) {
+			return (
+				<div
+					{...otherProps}
+					className={classNames('nav-link', className, {
+						active,
+						['collapse-icon']: showIcon,
+						collapsed,
+						disabled,
+					})}
+					ref={ref}
+				>
+					{children}
+					<span className="collapse-icon-closed">
+						<Icon
+							focusable="false"
+							role="presentation"
+							spritemap={spritemap}
+							symbol="angle-right-small"
+						/>
+					</span>
+
+					<span className="collapse-icon-open">
+						<Icon
+							focusable="false"
+							role="presentation"
+							spritemap={spritemap}
+							symbol="angle-down-small"
+						/>
+					</span>
+				</div>
+			);
+		}
+
 		return (
 			<LinkOrButton
 				{...otherProps}
@@ -66,28 +100,6 @@ export const Link = React.forwardRef<
 				ref={ref}
 			>
 				{children}
-
-				{showIcon && (
-					<>
-						<span className="collapse-icon-closed">
-							<Icon
-								focusable="false"
-								role="presentation"
-								spritemap={spritemap}
-								symbol="caret-right"
-							/>
-						</span>
-
-						<span className="collapse-icon-open">
-							<Icon
-								focusable="false"
-								role="presentation"
-								spritemap={spritemap}
-								symbol="caret-bottom"
-							/>
-						</span>
-					</>
-				)}
 			</LinkOrButton>
 		);
 	}

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -3,13 +3,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {ClayButtonWithIcon} from '@clayui/button';
 import {useProvider} from '@clayui/provider';
 import {Keys, setElementFullHeight, useId} from '@clayui/shared';
 import React, {useContext, useMemo, useRef, useState} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
-import classNames from 'classnames';
-import {ClayButtonWithIcon} from '@clayui/button';
 import {Collection} from '../collection';
 import {Nav} from '../nav';
 import {useVertical} from './context';

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -81,7 +81,7 @@ const ParentContext = React.createContext<React.RefObject<
 	HTMLButtonElement | HTMLAnchorElement
 > | null>(null);
 
-export function Item<T extends object>({
+export function Item<T extends Record<string, any>>({
 	active: depreactedActive,
 	children,
 	href,

--- a/packages/clay-core/src/vertical-nav/Item.tsx
+++ b/packages/clay-core/src/vertical-nav/Item.tsx
@@ -8,6 +8,8 @@ import {Keys, setElementFullHeight, useId} from '@clayui/shared';
 import React, {useContext, useMemo, useRef, useState} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
+import classNames from 'classnames';
+import {ClayButtonWithIcon} from '@clayui/button';
 import {Collection} from '../collection';
 import {Nav} from '../nav';
 import {useVertical} from './context';
@@ -40,6 +42,14 @@ interface IProps<T> extends React.HTMLAttributes<HTMLLIElement> {
 	 * @ignore
 	 */
 	keyValue?: React.Key;
+
+	/**
+	 * Properties to pass to the menubar action
+	 */
+	menubarAction?: {
+		ariaLabel: string;
+		title: string;
+	};
 
 	/**
 	 * Internal property.
@@ -89,6 +99,7 @@ export function Item<T extends Record<string, any>>({
 	initialExpanded,
 	items,
 	keyValue,
+	menubarAction,
 	onClick,
 	textValue: _textValue,
 	...otherProps
@@ -137,6 +148,7 @@ export function Item<T extends Record<string, any>>({
 				aria-controls={items ? ariaControlsId : undefined}
 				aria-current={active ? ariaCurrent ?? undefined : undefined}
 				aria-expanded={items ? isExpanded : undefined}
+				className={menubarAction ? 'menubar-action-1' : ''}
 				collapsed={!isExpanded}
 				href={href}
 				onClick={(event) => {
@@ -203,6 +215,18 @@ export function Item<T extends Record<string, any>>({
 			>
 				{children}
 			</Nav.Link>
+
+			{menubarAction && (
+				<ClayButtonWithIcon
+					aria-label={menubarAction.ariaLabel}
+					className="menubar-action"
+					displayType="secondary"
+					monospaced
+					size="xs"
+					symbol="plus"
+					title={menubarAction.title}
+				/>
+			)}
 
 			{items && (
 				<CSSTransition

--- a/packages/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/packages/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -34,16 +34,6 @@ const Trigger = ({
 	</Button>
 );
 
-const Menubar = ({collection, value}) => {
-	return (
-		<Nav aria-orientation="vertical" nested role="menubar">
-			<VerticalNavContext.Provider value={value}>
-				<Collection collection={collection} />
-			</VerticalNavContext.Provider>
-		</Nav>
-	);
-};
-
 type Props<T extends Record<string, any> | string> = {
 	/**
 	 * Flag to define which item has the active state/current page.
@@ -254,22 +244,30 @@ function VerticalNav<T extends Record<string, any> | string>({
 		return depthActive(items as Array<Record<string, any>>);
 	}, [active, items]);
 
-	const menubarValue = {
-		activeKey:
-			active && collection.hasItem(active)
-				? active
-				: hasDepthActive
-				? null
-				: undefined,
-		ariaCurrent: ariaCurrent ? 'page' : null,
-		childrenRoot: childrenRootRef,
-		close,
-		expandedKeys,
-		firstKey: collection.getFirstItem().key,
-		open,
-		spritemap,
-		toggle,
-	};
+	const content = (
+		<Nav aria-orientation="vertical" nested role="menubar">
+			<VerticalNavContext.Provider
+				value={{
+					activeKey:
+						active && collection.hasItem(active)
+							? active
+							: hasDepthActive
+							? null
+							: undefined,
+					ariaCurrent: ariaCurrent ? 'page' : null,
+					childrenRoot: childrenRootRef,
+					close,
+					expandedKeys,
+					firstKey: collection.getFirstItem().key,
+					open,
+					spritemap,
+					toggle,
+				}}
+			>
+				<Collection collection={collection} />
+			</VerticalNavContext.Provider>
+		</Nav>
+	);
 
 	return (
 		<nav
@@ -303,16 +301,12 @@ function VerticalNav<T extends Record<string, any> | string>({
 						})}
 						ref={containerRef}
 					>
-						<Menubar collection={collection} value={menubarValue} />
+						{content}
 					</div>
 				</>
 			)}
 
-			{displayType === 'primary' && (
-				<>
-					<Menubar collection={collection} value={menubarValue} />
-				</>
-			)}
+			{displayType === 'primary' && content}
 		</nav>
 	);
 }

--- a/packages/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/packages/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -34,6 +34,16 @@ const Trigger = ({
 	</Button>
 );
 
+const Menubar = ({collection, value}) => {
+	return (
+		<Nav aria-orientation="vertical" nested role="menubar">
+			<VerticalNavContext.Provider value={value}>
+				<Collection collection={collection} />
+			</VerticalNavContext.Provider>
+		</Nav>
+	);
+};
+
 type Props<T extends Record<string, any> | string> = {
 	/**
 	 * Flag to define which item has the active state/current page.
@@ -53,6 +63,11 @@ type Props<T extends Record<string, any> | string> = {
 	 * The component contents.
 	 */
 	children?: React.ReactNode | ChildrenFunction<T, null>;
+
+	/**
+	 * Determines the Vertical Nav variant to use.
+	 */
+	displayType?: null | 'primary';
 
 	/**
 	 * Flag to activate the Decorator variation.
@@ -137,6 +152,7 @@ function VerticalNav<T extends Record<string, any> | string>({
 	activation = 'manual',
 	children,
 	decorated,
+	displayType,
 	defaultExpandedKeys = new Set(),
 	expandedKeys: externalExpandedKeys,
 	itemAriaCurrent: ariaCurrent = true,
@@ -238,57 +254,65 @@ function VerticalNav<T extends Record<string, any> | string>({
 		return depthActive(items as Array<Record<string, any>>);
 	}, [active, items]);
 
+	const menubarValue = {
+		activeKey:
+			active && collection.hasItem(active)
+				? active
+				: hasDepthActive
+				? null
+				: undefined,
+		ariaCurrent: ariaCurrent ? 'page' : null,
+		childrenRoot: childrenRootRef,
+		close,
+		expandedKeys,
+		firstKey: collection.getFirstItem().key,
+		open,
+		spritemap,
+		toggle,
+	};
+
 	return (
 		<nav
 			className={classNames('menubar menubar-transparent', {
 				['menubar-decorated']: decorated,
+				['menubar-primary']: displayType === 'primary',
 				['menubar-vertical-expand-lg']: large,
-				['menubar-vertical-expand-md']: !large,
+				['menubar-vertical-expand-md']:
+					!large && displayType !== 'primary',
 			})}
 		>
-			<CustomTrigger onClick={() => setIsOpen(!isOpen)}>
-				<span className="inline-item inline-item-before">
-					{triggerLabel}
-				</span>
+			{displayType !== 'primary' && (
+				<>
+					<CustomTrigger onClick={() => setIsOpen(!isOpen)}>
+						<span className="inline-item inline-item-before">
+							{triggerLabel}
+						</span>
 
-				<Icon
-					focusable="false"
-					role="presentation"
-					spritemap={spritemap}
-					symbol="caret-bottom"
-				/>
-			</CustomTrigger>
+						<Icon
+							focusable="false"
+							role="presentation"
+							spritemap={spritemap}
+							symbol="caret-bottom"
+						/>
+					</CustomTrigger>
 
-			<div
-				{...navigationProps}
-				className={classNames('collapse menubar-collapse', {
-					show: isOpen,
-				})}
-				ref={containerRef}
-			>
-				<Nav aria-orientation="vertical" nested role="menubar">
-					<VerticalNavContext.Provider
-						value={{
-							activeKey:
-								active && collection.hasItem(active)
-									? active
-									: hasDepthActive
-									? null
-									: undefined,
-							ariaCurrent: ariaCurrent ? 'page' : null,
-							childrenRoot: childrenRootRef,
-							close,
-							expandedKeys,
-							firstKey: collection.getFirstItem().key,
-							open,
-							spritemap,
-							toggle,
-						}}
+					<div
+						{...navigationProps}
+						className={classNames('collapse menubar-collapse', {
+							show: isOpen,
+						})}
+						ref={containerRef}
 					>
-						<Collection<T> collection={collection} />
-					</VerticalNavContext.Provider>
-				</Nav>
-			</div>
+						<Menubar collection={collection} value={menubarValue} />
+					</div>
+				</>
+			)}
+
+			{displayType === 'primary' && (
+				<>
+					<Menubar collection={collection} value={menubarValue} />
+				</>
+			)}
 		</nav>
 	);
 }

--- a/packages/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/packages/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -155,7 +155,7 @@ function VerticalNav<T extends Record<string, any> | string>({
 }: Props<T>) {
 	const [isOpen, setIsOpen] = useState(false);
 
-	const containerRef = useRef<HTMLDivElement | null>(null);
+	const containerRef = useRef<HTMLUListElement | null>(null);
 
 	const [expandedKeys, setExpandedKeys] = useControlledState({
 		defaultName: 'defaultExpandedKeys',
@@ -245,7 +245,13 @@ function VerticalNav<T extends Record<string, any> | string>({
 	}, [active, items]);
 
 	const content = (
-		<Nav aria-orientation="vertical" nested role="menubar">
+		<Nav
+			{...navigationProps}
+			aria-orientation="vertical"
+			nested
+			ref={containerRef}
+			role="menubar"
+		>
 			<VerticalNavContext.Provider
 				value={{
 					activeKey:
@@ -295,11 +301,9 @@ function VerticalNav<T extends Record<string, any> | string>({
 					</CustomTrigger>
 
 					<div
-						{...navigationProps}
 						className={classNames('collapse menubar-collapse', {
 							show: isOpen,
 						})}
-						ref={containerRef}
 					>
 						{content}
 					</div>

--- a/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -36,11 +36,12 @@ exports[`VerticalNav basic rendering render dynamic content 1`] = `
           class="nav-item"
           role="none"
         >
-          <div
+          <button
             aria-controls="clay-id-6"
             aria-expanded="false"
-            class="nav-link collapse-icon collapsed"
+            class="nav-link collapse-icon collapsed btn btn-unstyled"
             role="menuitem"
+            type="button"
           >
             Home
             <span
@@ -69,7 +70,7 @@ exports[`VerticalNav basic rendering render dynamic content 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </li>
         <li
           class="nav-item"

--- a/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -36,24 +36,23 @@ exports[`VerticalNav basic rendering render dynamic content 1`] = `
           class="nav-item"
           role="none"
         >
-          <button
+          <div
             aria-controls="clay-id-6"
             aria-expanded="false"
-            class="nav-link collapse-icon collapsed btn btn-unstyled"
+            class="nav-link collapse-icon collapsed"
             role="menuitem"
-            type="button"
           >
             Home
             <span
               class="collapse-icon-closed"
             >
               <svg
-                class="lexicon-icon lexicon-icon-caret-right"
+                class="lexicon-icon lexicon-icon-angle-right-small"
                 focusable="false"
                 role="presentation"
               >
                 <use
-                  href="#caret-right"
+                  href="#angle-right-small"
                 />
               </svg>
             </span>
@@ -61,16 +60,16 @@ exports[`VerticalNav basic rendering render dynamic content 1`] = `
               class="collapse-icon-open"
             >
               <svg
-                class="lexicon-icon lexicon-icon-caret-bottom"
+                class="lexicon-icon lexicon-icon-angle-down-small"
                 focusable="false"
                 role="presentation"
               >
                 <use
-                  href="#caret-bottom"
+                  href="#angle-down-small"
                 />
               </svg>
             </span>
-          </button>
+          </div>
         </li>
         <li
           class="nav-item"

--- a/packages/clay-core/stories/VerticalNav.stories.tsx
+++ b/packages/clay-core/stories/VerticalNav.stories.tsx
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import Button, {ClayButtonWithIcon} from '@clayui/button';
+import Button from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import ClaySticker from '@clayui/sticker';
 import React, {useState} from 'react';
 
 import {VerticalNav} from '../src';
@@ -498,7 +499,7 @@ type ProductMenuItem = {
 		displayType: string;
 		label: string;
 	};
-	plusButton?: {
+	menubarAction?: {
 		ariaLabel: string;
 		title: string;
 	};
@@ -517,6 +518,7 @@ const items_cms_product_menu = [
 		label: 'Analytics',
 	},
 	{
+		initialExpanded: true,
 		itemClass: 'mt-3',
 		items: [
 			{
@@ -544,6 +546,7 @@ const items_cms_product_menu = [
 		label: 'Shared With Me',
 	},
 	{
+		initialExpanded: true,
 		itemClass: 'mt-3',
 		items: [
 			{
@@ -570,6 +573,7 @@ const items_cms_product_menu = [
 		label: 'Admin',
 	},
 	{
+		initialExpanded: true,
 		itemClass: 'mt-3',
 		items: [
 			{
@@ -584,7 +588,7 @@ const items_cms_product_menu = [
 				href: '#campaigns',
 				label: 'Campaigns',
 				sticker: {
-					displaytype: 'primary',
+					displayType: 'primary',
 					label: 'C',
 				},
 			},
@@ -595,7 +599,7 @@ const items_cms_product_menu = [
 			},
 		],
 		label: 'Spaces',
-		plusButton: {
+		menubarAction: {
 			ariaLabel: 'New Space',
 			title: 'New Space',
 		},
@@ -618,30 +622,31 @@ export const Primary = () => {
 			{(item) => (
 				<VerticalNav.Item
 					href={item.href}
+					initialExpanded={item.initialExpanded}
 					items={item.items}
 					key={item.label}
+					menubarAction={item.menubarAction}
+					textValue={item.label}
 				>
 					<div className="autofit-row">
+						{item.sticker && (
+							<ClaySticker
+								displayType={item.sticker.displayType}
+								size="sm"
+							>
+								{item.sticker.label}
+							</ClaySticker>
+						)}
+
 						{item.icon && (
 							<div className="autofit-col">
 								<ClayIcon symbol={item.icon} />
 							</div>
 						)}
+
 						<div className="autofit-col autofit-col-expand">
 							{item.label}
 						</div>
-						{item.plusButton && (
-							<div className="autofit-col">
-								<ClayButtonWithIcon
-									aria-label={item.plusButton.ariaLabel}
-									displayType="secondary"
-									monospaced
-									size="xs"
-									symbol="plus"
-									title={item.plusButton.title}
-								/>
-							</div>
-						)}
 					</div>
 				</VerticalNav.Item>
 			)}

--- a/packages/clay-core/stories/VerticalNav.stories.tsx
+++ b/packages/clay-core/stories/VerticalNav.stories.tsx
@@ -3,12 +3,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import Button from '@clayui/button';
-import React, {useState} from 'react';
-
-import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import Button, {ClayButtonWithIcon} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
+import React, {useState} from 'react';
 
 import {VerticalNav} from '../src';
 

--- a/packages/clay-core/stories/VerticalNav.stories.tsx
+++ b/packages/clay-core/stories/VerticalNav.stories.tsx
@@ -490,6 +490,24 @@ export const ControlledExpandedKeys = () => {
 	);
 };
 
+type ProductMenuItem = {
+	id: string;
+	href?: string;
+	label: string;
+	active?: boolean;
+	icon?: string;
+	itemClass?: string;
+	sticker?: {
+		displayType: string;
+		label: string;
+	};
+	plusButton?: {
+		ariaLabel: string;
+		title: string;
+	};
+	items?: Array<ProductMenuItem>;
+};
+
 const items_cms_product_menu = [
 	{
 		href: '#home',
@@ -591,7 +609,7 @@ const items_cms_product_menu = [
 		itemClass: 'mt-3',
 		label: 'Recycle Bin',
 	},
-] as Array<Item>;
+] as Array<ProductMenuItem>;
 
 export const Primary = () => {
 	return (

--- a/packages/clay-core/stories/VerticalNav.stories.tsx
+++ b/packages/clay-core/stories/VerticalNav.stories.tsx
@@ -6,6 +6,10 @@
 import Button from '@clayui/button';
 import React, {useState} from 'react';
 
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
+
 import {VerticalNav} from '../src';
 
 type Item = {
@@ -483,5 +487,149 @@ export const ControlledExpandedKeys = () => {
 				)}
 			</VerticalNav>
 		</>
+	);
+};
+
+const items_cms_product_menu = [
+	{
+		href: '#home',
+		icon: 'home',
+		label: 'Home',
+	},
+	{
+		href: '#analytics',
+		icon: 'analytics',
+		label: 'Analytics',
+	},
+	{
+		itemClass: 'mt-3',
+		items: [
+			{
+				href: '#all',
+				icon: 'sheets',
+				label: 'All',
+			},
+			{
+				href: '#content',
+				icon: 'catalog',
+				label: 'Content',
+			},
+			{
+				href: '#files',
+				icon: 'documents-and-media',
+				label: 'Files',
+			},
+		],
+		label: 'Assets',
+	},
+	{
+		href: '#shared-with-me',
+		icon: 'users',
+		itemClass: 'mt-3',
+		label: 'Shared With Me',
+	},
+	{
+		itemClass: 'mt-3',
+		items: [
+			{
+				href: '#structures',
+				icon: 'edit-layout',
+				label: 'Structures',
+			},
+			{
+				href: '#collections',
+				icon: 'books',
+				label: 'Collections',
+			},
+			{
+				href: '#categorization',
+				icon: 'vocabulary',
+				label: 'Categorization',
+			},
+			{
+				href: '#workflow',
+				icon: 'workflow',
+				label: 'Workflow',
+			},
+		],
+		label: 'Admin',
+	},
+	{
+		itemClass: 'mt-3',
+		items: [
+			{
+				href: '#marketing',
+				label: 'Marketing',
+				sticker: {
+					displayType: 'danger',
+					label: 'M',
+				},
+			},
+			{
+				href: '#campaigns',
+				label: 'Campaigns',
+				sticker: {
+					displaytype: 'primary',
+					label: 'C',
+				},
+			},
+			{
+				href: '#all-spaces',
+				icon: 'box-container',
+				label: 'All Spaces',
+			},
+		],
+		label: 'Spaces',
+		plusButton: {
+			ariaLabel: 'New Space',
+			title: 'New Space',
+		},
+	},
+	{
+		href: '#recycle-bin',
+		icon: 'trash',
+		itemClass: 'mt-3',
+		label: 'Recycle Bin',
+	},
+] as Array<Item>;
+
+export const Primary = () => {
+	return (
+		<VerticalNav
+			active="Home"
+			displayType="primary"
+			items={items_cms_product_menu}
+		>
+			{(item) => (
+				<VerticalNav.Item
+					href={item.href}
+					items={item.items}
+					key={item.label}
+				>
+					<div className="autofit-row">
+						{item.icon && (
+							<div className="autofit-col">
+								<ClayIcon symbol={item.icon} />
+							</div>
+						)}
+						<div className="autofit-col autofit-col-expand">
+							{item.label}
+						</div>
+						{item.plusButton && (
+							<div className="autofit-col">
+								<ClayButtonWithIcon
+									aria-label={item.plusButton.ariaLabel}
+									displayType="secondary"
+									monospaced
+									size="xs"
+									symbol="plus"
+									title={item.plusButton.title}
+								/>
+							</div>
+						)}
+					</div>
+				</VerticalNav.Item>
+			)}
+		</VerticalNav>
 	);
 };

--- a/packages/clay-css/src/scss/cadmin/components/_menubar.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_menubar.scss
@@ -8,6 +8,14 @@
 	display: none;
 }
 
+.menubar-primary {
+	@include clay-menubar-vertical-variant($cadmin-menubar-primary);
+
+	.nav .nav .nav > li > .nav-link {
+		margin-left: 16px;
+	}
+}
+
 // Menubar Vertical MD
 
 .menubar-vertical-expand-md {

--- a/packages/clay-css/src/scss/cadmin/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_menubar.scss
@@ -1,3 +1,126 @@
+$cadmin-menubar-primary: () !default;
+$cadmin-menubar-primary: map-deep-merge(
+	(
+		nav-item: (
+			position: relative,
+		),
+		nav-link: (
+			border-radius: 0,
+			color: $cadmin-gray-900,
+			line-height: 24px,
+			transition: #{color 0.15s ease-in-out,
+			background-color 0.15s ease-in-out,
+			border-color 0.15s ease-in-out,
+			box-shadow 0.15s ease-in-out},
+			before: (
+				bottom: 0,
+				content: '',
+				display: block,
+				left: 0,
+				position: absolute,
+				top: 0,
+				transition: $cadmin-transition-base,
+			),
+			hover: (
+				background-color: $cadmin-primary-l3,
+				color: $cadmin-gray-900,
+				letter-spacing: 0,
+				before: (
+					background: $cadmin-secondary-l0,
+					width: 2px,
+				),
+			),
+			focus: (
+				background-color: c-unset,
+				box-shadow: none,
+				color: $cadmin-gray-900,
+				outline: 0,
+				after: (
+					bottom: 0,
+					box-shadow: $cadmin-component-focus-inset-box-shadow,
+					content: '',
+					display: block,
+					left: 0,
+					pointer-events: none,
+					position: absolute,
+					right: 0,
+					top: 0,
+				),
+			),
+			active-class: (
+				background-color: $cadmin-primary-l3,
+				color: $cadmin-gray-900,
+				font-weight: $cadmin-font-weight-semi-bold,
+				before: (
+					background-color: $cadmin-primary,
+					width: 6px,
+				),
+				focus: (
+					before: (
+						display: none,
+					),
+				),
+			),
+			disabled: (
+				background-color: transparent,
+				box-shadow: none,
+				font-weight: $cadmin-font-weight-normal,
+				letter-spacing: 0.016rem,
+				before: (
+					content: none,
+				),
+				after: (
+					content: none,
+				),
+			),
+			show: (
+				background-color: c-unset,
+				box-shadow: c-unset,
+				color: $cadmin-gray-900,
+				before: (
+					background-color: transparent,
+					width: 0,
+				),
+				hover: (
+					before: (
+						background-color: $cadmin-secondary-l0,
+						width: 2px,
+					),
+				),
+			),
+			autofit-row: (
+				align-items: center,
+				margin-left: -4px,
+				margin-right: -4px,
+				autofit-col: (
+					padding-left: 4px,
+					padding-right: 4px,
+				),
+			),
+			collapse-icon: (
+				font-size: 12px,
+				font-weight: $cadmin-font-weight-semi-bold,
+				text-transform: uppercase,
+				collapse-icon-closed: (
+					top: calc(22px - (1em / 2)),
+				),
+				collapse-icon-open: (
+					top: calc(22px - (1em / 2)),
+				),
+			),
+		),
+		menubar-actions-1: (
+			padding-right: 64px,
+		),
+		menubar-action: (
+			position: absolute,
+			top: 10px,
+			right: 32px,
+		),
+	),
+	$cadmin-menubar-primary
+);
+
 // Menubar Vertical MD
 
 $cadmin-menubar-vertical-expand-md: () !default;

--- a/packages/clay-css/src/scss/components/_icons.scss
+++ b/packages/clay-css/src/scss/components/_icons.scss
@@ -29,7 +29,8 @@
 // Collapse Icon
 
 a.collapse-icon,
-button.collapse-icon {
+button.collapse-icon,
+.collapse-icon[tabindex] {
 	padding-left: $collapse-icon-padding-left;
 	padding-right: $collapse-icon-padding-right;
 

--- a/packages/clay-css/src/scss/components/_menubar.scss
+++ b/packages/clay-css/src/scss/components/_menubar.scss
@@ -8,6 +8,14 @@
 	display: none;
 }
 
+.menubar-primary {
+	@include clay-menubar-vertical-variant($menubar-primary);
+
+	.nav .nav .nav > li > .nav-link {
+		margin-left: 1rem;
+	}
+}
+
 // Menubar Vertical MD
 
 .menubar-vertical-expand-md {

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -938,6 +938,40 @@
 				}
 			}
 
+			&.collapse-icon {
+				$_collapse-icon: setter(map-get($map, collapse-icon), ());
+
+				@include clay-css($_collapse-icon);
+
+				.collapse-icon-closed {
+					@include clay-css(
+						map-get($_collapse-icon, collapse-icon-closed)
+					);
+				}
+
+				.collapse-icon-open {
+					@include clay-css(
+						map-get($_collapse-icon, collapse-icon-open)
+					);
+				}
+			}
+
+			.autofit-row {
+				$_autofit-row: setter(map-get($map, autofit-row), ());
+
+				@include clay-css($_autofit-row);
+
+				.autofit-col {
+					@include clay-css(map-get($_autofit-row, autofit-col));
+				}
+
+				.autofit-col-expand {
+					@include clay-css(
+						map-get($_autofit-row, autofit-col-expand)
+					);
+				}
+			}
+
 			@if (map-get($c-inner, enabled)) {
 				> .c-inner {
 					@include clay-css($c-inner);

--- a/packages/clay-css/src/scss/mixins/_menubar.scss
+++ b/packages/clay-css/src/scss/mixins/_menubar.scss
@@ -931,6 +931,10 @@
 			}
 		}
 
+		.nav-item {
+			@include clay-css(map-get($map, nav-item));
+		}
+
 		.nav-link {
 			$_nav-link: setter(map-get($map, nav-link), ());
 			$_nav-link: map-deep-merge($link, $_nav-link);
@@ -940,6 +944,14 @@
 			@include media-breakpoint-down($breakpoint-down) {
 				@include clay-link($link-mobile);
 			}
+		}
+
+		.menubar-actions-1 {
+			@include clay-css(map-get($map, menubar-actions-1));
+		}
+
+		.menubar-action {
+			@include clay-css(map-get($map, menubar-action));
 		}
 
 		$_media-breakpoint-down: map-get($map, media-breakpoint-down);

--- a/packages/clay-css/src/scss/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/variables/_menubar.scss
@@ -1,6 +1,9 @@
 $menubar-primary: () !default;
 $menubar-primary: map-deep-merge(
 	(
+		nav-item: (
+			position: relative,
+		),
 		nav-link: (
 			border-radius: 0,
 			color: $gray-900,
@@ -105,6 +108,14 @@ $menubar-primary: map-deep-merge(
 					top: calc(22px - (1em / 2)),
 				),
 			),
+		),
+		menubar-actions-1: (
+			padding-right: 4rem,
+		),
+		menubar-action: (
+			position: absolute,
+			top: 0.625rem,
+			right: 2rem,
 		),
 	),
 	$menubar-primary

--- a/packages/clay-css/src/scss/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/variables/_menubar.scss
@@ -1,3 +1,115 @@
+$menubar-primary: () !default;
+$menubar-primary: map-deep-merge(
+	(
+		nav-link: (
+			border-radius: 0,
+			color: $gray-900,
+			line-height: 24px,
+			transition: #{color 0.15s ease-in-out,
+			background-color 0.15s ease-in-out,
+			border-color 0.15s ease-in-out,
+			box-shadow 0.15s ease-in-out},
+			before: (
+				bottom: 0,
+				content: '',
+				display: block,
+				left: 0,
+				position: absolute,
+				top: 0,
+				transition: $transition-base,
+			),
+			hover: (
+				background-color: $primary-l3,
+				color: $gray-900,
+				letter-spacing: 0,
+				before: (
+					background: $secondary-l0,
+					width: 0.125rem,
+				),
+			),
+			focus: (
+				background-color: c-unset,
+				box-shadow: none,
+				color: $gray-900,
+				outline: 0,
+				after: (
+					bottom: 0,
+					box-shadow: $component-focus-inset-box-shadow,
+					content: '',
+					display: block,
+					left: 0,
+					pointer-events: none,
+					position: absolute,
+					right: 0,
+					top: 0,
+				),
+			),
+			active-class: (
+				background-color: $primary-l3,
+				color: $gray-900,
+				font-weight: $font-weight-semi-bold,
+				before: (
+					background-color: $primary,
+					width: 0.375rem,
+				),
+				focus: (
+					before: (
+						display: none,
+					),
+				),
+			),
+			disabled: (
+				background-color: transparent,
+				box-shadow: none,
+				font-weight: $font-weight-normal,
+				letter-spacing: 0.016rem,
+				before: (
+					content: none,
+				),
+				after: (
+					content: none,
+				),
+			),
+			show: (
+				background-color: c-unset,
+				box-shadow: c-unset,
+				color: $gray-900,
+				before: (
+					background-color: transparent,
+					width: 0,
+				),
+				hover: (
+					before: (
+						background-color: $secondary-l0,
+						width: 0.125rem,
+					),
+				),
+			),
+			autofit-row: (
+				align-items: center,
+				margin-left: -0.25rem,
+				margin-right: -0.25rem,
+				autofit-col: (
+					padding-left: 0.25rem,
+					padding-right: 0.25rem,
+				),
+			),
+			collapse-icon: (
+				font-size: 0.75rem,
+				font-weight: $font-weight-semi-bold,
+				text-transform: uppercase,
+				collapse-icon-closed: (
+					top: calc(22px - (1em / 2)),
+				),
+				collapse-icon-open: (
+					top: calc(22px - (1em / 2)),
+				),
+			),
+		),
+	),
+	$menubar-primary
+);
+
 // Menubar Vertical MD
 
 $menubar-vertical-expand-md: () !default;

--- a/packages/clay-css/src/scss/variables/_navs.scss
+++ b/packages/clay-css/src/scss/variables/_navs.scss
@@ -11,12 +11,14 @@ $nav-link-disabled-cursor: $disabled-cursor !default;
 $nav-link: () !default;
 $nav-link: map-deep-merge(
 	(
+		cursor: pointer,
 		display: block,
 		padding-bottom: $nav-link-padding-y,
 		padding-left: $nav-link-padding-x,
 		padding-right: $nav-link-padding-x,
 		padding-top: $nav-link-padding-y,
 		position: relative,
+		user-select: none,
 		hover: (
 			text-decoration: none,
 		),

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -7,6 +7,8 @@ import {Nav, VerticalNav} from '@clayui/core';
 import React from 'react';
 import warning from 'warning';
 
+export type DisplayType = null | 'primary';
+
 interface IItem extends React.ComponentProps<typeof Nav.Item> {
 	/**
 	 * Flag to indicate if item is active.
@@ -64,6 +66,11 @@ export interface IProps extends React.ComponentProps<typeof VerticalNav> {
 	activeLabel?: string;
 
 	/**
+	 * Determines the Vertical Nav variant to use.
+	 */
+	displayType?: DisplayType;
+
+	/**
 	 * Flag to activate the Decorator variation.
 	 */
 	decorated?: boolean;
@@ -102,6 +109,7 @@ function ClayVerticalNav(props: IProps): JSX.Element & {
 function ClayVerticalNav({
 	activeLabel,
 	children,
+	displayType,
 	triggerLabel = 'Menu',
 	...otherProps
 }: IProps) {
@@ -110,7 +118,7 @@ function ClayVerticalNav({
 		'ClayVerticalNav: The `activeLabel` API has been deprecated in favor of `triggerLabel` and will be removed in the next major release.'
 	);
 
-	if (children) {
+	if (children && !displayType) {
 		return (
 			<VerticalNav
 				{...otherProps}

--- a/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -36,24 +36,23 @@ exports[`ClayVerticalNav renders 1`] = `
           class="nav-item"
           role="none"
         >
-          <button
+          <div
             aria-controls="clay-id-2"
             aria-expanded="true"
-            class="nav-link collapse-icon btn btn-unstyled"
+            class="nav-link collapse-icon"
             role="menuitem"
-            type="button"
           >
             Home
             <span
               class="collapse-icon-closed"
             >
               <svg
-                class="lexicon-icon lexicon-icon-caret-right"
+                class="lexicon-icon lexicon-icon-angle-right-small"
                 focusable="false"
                 role="presentation"
               >
                 <use
-                  href="/path/to#caret-right"
+                  href="/path/to#angle-right-small"
                 />
               </svg>
             </span>
@@ -61,16 +60,16 @@ exports[`ClayVerticalNav renders 1`] = `
               class="collapse-icon-open"
             >
               <svg
-                class="lexicon-icon lexicon-icon-caret-bottom"
+                class="lexicon-icon lexicon-icon-angle-down-small"
                 focusable="false"
                 role="presentation"
               >
                 <use
-                  href="/path/to#caret-bottom"
+                  href="/path/to#angle-down-small"
                 />
               </svg>
             </span>
-          </button>
+          </div>
           <ul
             class="nav nav-stacked"
             id="clay-id-2"

--- a/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -36,11 +36,12 @@ exports[`ClayVerticalNav renders 1`] = `
           class="nav-item"
           role="none"
         >
-          <div
+          <button
             aria-controls="clay-id-2"
             aria-expanded="true"
-            class="nav-link collapse-icon"
+            class="nav-link collapse-icon btn btn-unstyled"
             role="menuitem"
+            type="button"
           >
             Home
             <span
@@ -69,7 +70,7 @@ exports[`ClayVerticalNav renders 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
           <ul
             class="nav nav-stacked"
             id="clay-id-2"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-40160

![vertical-bar-primary](https://github.com/user-attachments/assets/84c6d47c-8351-4756-ad80-a5991415145a)

I'm sending this as a draft because we have a problem with the accordion headers. They can only be `button` and in some of the headers we have nested plus buttons. Having a `button` nested in a `button` violates:

> [Phrasing content](https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2), but there must be no [interactive content](https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2) descendant and no descendant with the [tabindex](https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex) attribute specified.

from the w3c spec. I need some help figuring out which component we should place `<div role="button">` to make our markup valid.