### PR TITLE
fix(@clayui/core): fixes bug when updating the state at render time and the number of table columns when the state changes

### DIFF
--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -7,7 +7,7 @@ import Button from '@clayui/button';
 import {ClayToggle as Toggle} from '@clayui/form';
 import Icon from '@clayui/icon';
 import Layout from '@clayui/layout';
-import React, {useMemo} from 'react';
+import React, {useEffect, useLayoutEffect} from 'react';
 
 import {ChildrenFunction, Collection, useCollection} from '../collection';
 import {Item, Menu} from '../drop-down';
@@ -35,6 +35,9 @@ const Header = React.forwardRef<HTMLLIElement, HeaderProps>(
 		);
 	}
 );
+
+const useIsomorphicEffect =
+	typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 type Props<T> = {
 	/**
@@ -68,12 +71,12 @@ function HeadInner<T extends Record<string, any>>(
 		visibleKeys: new Set(visibleColumns.keys()),
 	});
 
-	useMemo(() => {
+	useIsomorphicEffect(() => {
 		if (visibleColumns.size === 0) {
 			onVisibleColumnsChange(collection.getItems(), 0);
 		}
 		onHeadCellsChange(collection.getSize());
-	}, []);
+	}, [collection.getSize()]);
 
 	return (
 		<thead {...otherProps} ref={ref}>

--- a/packages/clay-core/src/table/Row.tsx
+++ b/packages/clay-core/src/table/Row.tsx
@@ -160,11 +160,9 @@ function RowInner<T extends Record<string, any>>(
 
 		return [
 			...Array.from(visibleColumns.values()),
-			...(columnsVisibility && count > visibleColumns.size
-				? [count - 1]
-				: []),
+			...(columnsVisibility && count > headCellsCount ? [count - 1] : []),
 		];
-	}, [columnsVisibility, items?.length, visibleColumns]);
+	}, [columnsVisibility, items?.length, visibleColumns, headCellsCount]);
 
 	const collection = useCollection({
 		children,


### PR DESCRIPTION
From https://github.com/liferay-platform-experience/liferay-portal/pull/865

Well, this PR only makes a small internal adjustment to recalculate the number of columns when the data changes. This is welcome because we can have applications that can change the data while the user interacts, not necessarily linked to column visibility, for example, a table editor.

The bug originated because of column visibility, but I don't believe this is a bug, but because of the way it is done in FDS, which should not change the data that is passed to the Table. It is recommended to always leave the data intact because we deal with this internally.