### PR TITLE
fix(@clayui.css): LPD-44793 toggle-switch-sm label text breaks to new…

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_toggle-switch.scss
@@ -479,7 +479,7 @@ $cadmin-toggle-switch-sizes: map-deep-merge(
 		toggle-switch-sm: (
 			simple-toggle-switch: (
 				toggle-switch-label: (
-					max-width: calc(100% - 38px),
+					max-width: calc(100% - 34px),
 				),
 			),
 			toggle-switch-check: (
@@ -500,9 +500,8 @@ $cadmin-toggle-switch-sizes: map-deep-merge(
 					),
 					toggle-switch-handle: (
 						min-width: 30px,
-						max-width: 30px,
 						after: (
-							margin-left: 38px,
+							margin-left: 34px,
 						),
 					),
 					toggle-switch-icon: (

--- a/packages/clay-css/src/scss/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/variables/_toggle-switch.scss
@@ -497,7 +497,7 @@ $toggle-switch-sizes: map-deep-merge(
 		toggle-switch-sm: (
 			simple-toggle-switch: (
 				toggle-switch-label: (
-					max-width: calc(100% - 38px),
+					max-width: calc(100% - 34px),
 				),
 			),
 			toggle-switch-check: (
@@ -515,9 +515,8 @@ $toggle-switch-sizes: map-deep-merge(
 					),
 					toggle-switch-handle: (
 						min-width: 30px,
-						max-width: 30px,
 						after: (
-							margin-left: 38px,
+							margin-left: 34px,
 						),
 					),
 					toggle-switch-icon: (


### PR DESCRIPTION
… line too early

https://liferay.atlassian.net/browse/LPD-44793
![toggle-switch-sm](https://github.com/user-attachments/assets/26bcf884-961c-415d-bf67-380888b05dbf)
