### PR TITLE
LPD-46396 - Clay Vertical Navigation should include a prop that allows an aria-label to be added to the nav element.

### DIFF
--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -40,7 +40,8 @@
 		"fuzzy": "^0.1.3",
 		"react-dnd": "^11.1.1",
 		"react-dnd-html5-backend": "^11.1.1",
-		"react-transition-group": "^4.4.1"
+		"react-transition-group": "^4.4.1",
+		"warning": "^4.0.3"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/packages/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -11,7 +11,8 @@ import {
 	useNavigation,
 } from '@clayui/shared';
 import classNames from 'classnames';
-import React, {useCallback, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import warning from 'warning';
 
 import {Collection, useCollection} from '../collection';
 import {Nav} from '../nav';
@@ -48,6 +49,11 @@ type Props<T extends Record<string, any> | string> = {
 	 * - automatic - moves the focus to the menuitem and activates the menu.
 	 */
 	activation?: 'manual' | 'automatic';
+
+	/**
+	 * Flag to define aria-label.
+	 */
+	'aria-label': string;
 
 	/**
 	 * The component contents.
@@ -140,6 +146,7 @@ function VerticalNav<T extends Record<string, any> | string>(
 function VerticalNav<T extends Record<string, any> | string>({
 	active,
 	activation = 'manual',
+	'aria-label': ariaLabel,
 	children,
 	decorated,
 	displayType,
@@ -275,8 +282,16 @@ function VerticalNav<T extends Record<string, any> | string>({
 		</Nav>
 	);
 
+	useEffect(() => {
+		warning(
+			ariaLabel,
+			"[VerticalNav]: Missing required 'aria-label' attribute. Please provide a value to ensure accessibility."
+		);
+	}, [ariaLabel]);
+
 	return (
 		<nav
+			aria-label={ariaLabel}
 			className={classNames('menubar menubar-transparent', {
 				['menubar-decorated']: decorated,
 				['menubar-primary']: displayType === 'primary',

--- a/packages/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
@@ -13,7 +13,7 @@ describe('VerticalNav basic rendering', () => {
 
 	it('render static content', () => {
 		const {container} = render(
-			<VerticalNav>
+			<VerticalNav aria-label="vertical navbar">
 				<VerticalNav.Item active key="home">
 					Home
 				</VerticalNav.Item>
@@ -28,6 +28,7 @@ describe('VerticalNav basic rendering', () => {
 	it('render dynamic content', () => {
 		const {container} = render(
 			<VerticalNav
+				aria-label="vertical navbar"
 				items={[
 					{
 						id: 1,

--- a/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/vertical-nav/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -3,6 +3,7 @@
 exports[`VerticalNav basic rendering render dynamic content 1`] = `
 <div>
   <nav
+    aria-label="vertical navbar"
     class="menubar menubar-transparent menubar-vertical-expand-md"
   >
     <button
@@ -107,6 +108,7 @@ exports[`VerticalNav basic rendering render dynamic content 1`] = `
 exports[`VerticalNav basic rendering render static content 1`] = `
 <div>
   <nav
+    aria-label="vertical navbar"
     class="menubar menubar-transparent menubar-vertical-expand-md"
   >
     <button

--- a/packages/clay-core/stories/Accessibility.stories.tsx
+++ b/packages/clay-core/stories/Accessibility.stories.tsx
@@ -98,6 +98,7 @@ export const UnderlinedLinks = () => (
 			VerticalNav
 		</Heading>
 		<VerticalNav
+			aria-label="vertical navbar"
 			items={[
 				{
 					items: [
@@ -316,6 +317,7 @@ export const TextSpacing = () => (
 			VerticalNav
 		</Heading>
 		<VerticalNav
+			aria-label="vertical navbar"
 			items={[
 				{
 					items: [

--- a/packages/clay-core/stories/VerticalNav.stories.tsx
+++ b/packages/clay-core/stories/VerticalNav.stories.tsx
@@ -441,7 +441,7 @@ export default {
 };
 
 export const Default = () => (
-	<VerticalNav active="6" items={items}>
+	<VerticalNav active="6" aria-label="vertical navbar" items={items}>
 		{(item) => (
 			<VerticalNav.Item href={item.href} items={item.items} key={item.id}>
 				{item.label}
@@ -474,6 +474,7 @@ export const ControlledExpandedKeys = () => {
 
 			<VerticalNav
 				active={active}
+				aria-label="vertical navbar"
 				expandedKeys={expandedKeys}
 				items={items_long}
 				onExpandedChange={setExpandedKeys}
@@ -616,6 +617,7 @@ export const Primary = () => {
 	return (
 		<VerticalNav
 			active="Home"
+			aria-label="vertical navbar"
 			displayType="primary"
 			items={items_cms_product_menu}
 		>

--- a/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -3,6 +3,7 @@
 exports[`ClayVerticalNav renders 1`] = `
 <div>
   <nav
+    aria-label="vertical navbar"
     class="menubar menubar-transparent menubar-vertical-expand-md"
   >
     <button

--- a/packages/clay-nav/src/__tests__/index.tsx
+++ b/packages/clay-nav/src/__tests__/index.tsx
@@ -64,7 +64,11 @@ describe('ClayVerticalNav', () => {
 
 	it('renders', () => {
 		const {container} = render(
-			<ClayVerticalNav items={items} spritemap="/path/to" />
+			<ClayVerticalNav
+				aria-label="vertical navbar"
+				items={items}
+				spritemap="/path/to"
+			/>
 		);
 
 		expect(container).toMatchSnapshot();
@@ -72,7 +76,11 @@ describe('ClayVerticalNav', () => {
 
 	it('expands items when clicked', () => {
 		const {container, getByText} = render(
-			<ClayVerticalNav items={items} spritemap="/path/to" />
+			<ClayVerticalNav
+				aria-label="vertical navbar"
+				items={items}
+				spritemap="/path/to"
+			/>
 		);
 
 		expect(
@@ -88,7 +96,11 @@ describe('ClayVerticalNav', () => {
 
 	it('expand items by pressing the right arrow key', () => {
 		const {getByText} = render(
-			<ClayVerticalNav items={ITEMS} spritemap="/path/to" />
+			<ClayVerticalNav
+				aria-label="vertical navbar"
+				items={ITEMS}
+				spritemap="/path/to"
+			/>
 		);
 
 		const projects = getByText('Projects');
@@ -105,7 +117,11 @@ describe('ClayVerticalNav', () => {
 
 	it('collapse items by pressing the left arrow key', () => {
 		const {getByText} = render(
-			<ClayVerticalNav items={ITEMS} spritemap="/path/to" />
+			<ClayVerticalNav
+				aria-label="vertical navbar"
+				items={ITEMS}
+				spritemap="/path/to"
+			/>
 		);
 
 		const projects = getByText('Projects');
@@ -126,7 +142,11 @@ describe('ClayVerticalNav', () => {
 
 	it('moves focus to first item if item is expanded', () => {
 		const {getByText} = render(
-			<ClayVerticalNav items={ITEMS} spritemap="/path/to" />
+			<ClayVerticalNav
+				aria-label="vertical navbar"
+				items={ITEMS}
+				spritemap="/path/to"
+			/>
 		);
 
 		const projects = getByText('Projects');
@@ -149,7 +169,11 @@ describe('ClayVerticalNav', () => {
 
 	it('move focus to parent if focus is on child when pressing left arrow key', () => {
 		const {getByText} = render(
-			<ClayVerticalNav items={ITEMS} spritemap="/path/to" />
+			<ClayVerticalNav
+				aria-label="vertical navbar"
+				items={ITEMS}
+				spritemap="/path/to"
+			/>
 		);
 
 		const projects = getByText('Projects');

--- a/packages/clay-nav/stories/Nav.stories.tsx
+++ b/packages/clay-nav/stories/Nav.stories.tsx
@@ -70,7 +70,11 @@ export const Default = () => (
 );
 
 export const VerticalNav = (args: any) => (
-	<ClayVerticalNav items={items} large={args.large} />
+	<ClayVerticalNav
+		aria-label="vertical navbar"
+		items={items}
+		large={args.large}
+	/>
 );
 
 VerticalNav.args = {
@@ -79,6 +83,7 @@ VerticalNav.args = {
 
 export const CustomTrigger = () => (
 	<ClayVerticalNav
+		aria-label="vertical navbar"
 		items={items}
 		trigger={(props) => (
 			<ClayVerticalNav.Trigger {...props}>
@@ -92,4 +97,6 @@ export const CustomTrigger = () => (
 	/>
 );
 
-export const WithDecorator = () => <ClayVerticalNav decorated items={items} />;
+export const WithDecorator = () => (
+	<ClayVerticalNav aria-label="vertical navbar" decorated items={items} />
+);


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-46005

## Motivation
The prop aria-label can be passed to the vertical navigation.

## Proposed Solution
Added a prop called `ariaLabel` and an `useEffect` to display the console error when this prop is not passed

## Steps to Verify
1. Go to Clay Vertical Navigation
2. Open Devtools
3. Check if tag `<nav>` has an aria-label property
4. When the propis not passed, there should be a warning logged to the console when in a development build

## Screenshots/videos (if applies)
![image](https://github.com/user-attachments/assets/42447340-9322-45bd-9f38-8668bf2b9425)
![image](https://github.com/user-attachments/assets/98971e08-f64f-440d-994a-368f8f155c1a)

