### PR TITLE
fix(@clayui/date-picker): LPD-46943 The Date Picker component shows time using the wrong format

### DIFF
--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -346,8 +346,8 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 
 				if (startDate.toString() !== 'Invalid Date') {
 					const hours = use12Hours
-						? formatDate(startDate, 'HH')
-						: formatDate(startDate, 'hh');
+						? formatDate(startDate, 'hh')
+						: formatDate(startDate, 'HH');
 
 					const minutes = formatDate(startDate, 'mm');
 


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-46943

## Motivation
Passing `2025-01-19 04:00 PM` as value with use12Hours, the time picker shows 16:00 PM

## Proposed Solution
The hour format should be reversed, `hh` for 12 hours and `HH` for 24h

## Steps to Verify
1. Go to [Clay > Date Picker component > Time](https://deploy-preview-5923--next-clayui.netlify.app/docs/components/date-picker.html#time)
2. Update value from `null` to  `2025-01-19 04:00 PM`
3. Add `use12Hours` prop
4. Open the dropdown by clicking on the calendar icon and see the value matching.

## Screenshots/videos 
![image](https://github.com/user-attachments/assets/8635238b-f661-43aa-9dfa-abb220f2bd8f)
