### PR TITLE
fix(@clayui/shared): Only run hide code if menus match in Overlay

### DIFF
--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -118,14 +118,16 @@ export function Overlay({
 			onHide('blur');
 		},
 		onInteractStart: (event) => {
-			if (unsuppressCallbackRef.current) {
-				unsuppressCallbackRef.current();
-				unsuppressCallbackRef.current = null;
-			}
+			if (overlayStack[overlayStack.length - 1] === menuRef) {
+				if (unsuppressCallbackRef.current) {
+					unsuppressCallbackRef.current();
+					unsuppressCallbackRef.current = null;
+				}
 
-			if (overlayStack[overlayStack.length - 1] === menuRef && isModal) {
-				event.stopPropagation();
-				event.preventDefault();
+				if (isModal) {
+					event.stopPropagation();
+					event.preventDefault();
+				}
 			}
 		},
 		ref: portalRef ?? menuRef,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-48227

@matuzalemsteles not related to this pr, but should we be using `inert` for all our dropdown menus and popups?