### PR TITLE
fix(@clayui/shared): LPD-48347 Close overlay on left click only

### DIFF
--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -114,8 +114,11 @@ export function Overlay({
 
 	useInteractOutside({
 		isDisabled: isOpen ? !isCloseOnInteractOutside : true,
-		onInteract: () => {
-			onHide('blur');
+		onInteract: (event) => {
+			// @ts-ignore
+			if (event.button === 0) {
+				onHide('blur');
+			}
 		},
 		onInteractStart: (event) => {
 			if (overlayStack[overlayStack.length - 1] === menuRef) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-48347

![dropdown-overlay](https://github.com/user-attachments/assets/b350a5e4-6de2-4212-9427-3f8e5e89cfa6)
