### PR TITLE
fix(@clayui/core): fixes build bug in applications

### DIFF
--- a/packages/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/packages/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -39,7 +39,7 @@ type Props<T extends Record<string, any> | string> = {
 	/**
 	 * Flag to define aria-label.
 	 */
-	'aria-label': string;
+	'aria-label'?: string;
 
 	/**
 	 * The component contents.


### PR DESCRIPTION
Since we introduced a new API and made it required, this would be a major change because we would have to update all applications that use the component to define the `aria-label`, so the ideal would be to make the API optional. Since we have a warning message, this will notify developers to pay attention to this and configure it according to each use case.