### PR TITLE
docs(@clayui/empty-state): LPD-49337 fixes bug when not showing empty state images

### DIFF
--- a/packages/clay-empty-state/docs/empty-state.mdx
+++ b/packages/clay-empty-state/docs/empty-state.mdx
@@ -51,8 +51,8 @@ export default function App() {
 				<EmptyState
 					description="You don't have more notifications to review"
 					imgProps={{alt: 'Alternative Text', title: 'Hello World!'}}
-					imgSrc="/images/success_state.svg"
-					imgSrcReducedMotion="/images/success_state_reduced_motion.svg"
+					imgSrc="https://clayui.com/images/success_state.svg"
+					imgSrcReducedMotion="https://clayui.com/images/success_state_reduced_motion.svg"
 					title="Hurray"
 				/>
 			</div>
@@ -88,8 +88,8 @@ export default function App() {
 				<EmptyState
 					description="You don't have more notifications to review"
 					imgProps={{alt: 'Alternative Text', title: 'Hello World!'}}
-					imgSrc="/images/success_state.svg"
-					imgSrcReducedMotion="/images/success_state_reduced_motion.svg"
+					imgSrc="https://clayui.com/images/success_state.svg"
+					imgSrcReducedMotion="https://clayui.com/images/success_state_reduced_motion.svg"
 					title="Hurray"
 				/>
 			</div>


### PR DESCRIPTION
Ticket [LPD-49337](https://liferay.atlassian.net/browse/LPD-49337)

I thought about adding the images to codesandbox but this requires more configuration and can make things more slow because it will load the image in all examples, so since we already host the image on our website it is easier to pass the URL to our website, best practice is to continue with this now.