### PR TITLE
fix(@clayui/css): custom-control-outside shouldn't be clickable beyon…

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
@@ -538,7 +538,6 @@ $cadmin-custom-control-outside: () !default;
 $cadmin-custom-control-outside: map-deep-merge(
 	(
 		label: (
-			display: block,
 			padding-left:
 				calc(
 					#{$cadmin-custom-control-indicator-size} + #{$cadmin-custom-control-description-padding-left}

--- a/packages/clay-css/src/scss/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/variables/_custom-forms.scss
@@ -536,7 +536,6 @@ $custom-control-outside: () !default;
 $custom-control-outside: map-deep-merge(
 	(
 		label: (
-			display: block,
 			padding-left:
 				calc(
 					#{$custom-control-indicator-size} + #{$custom-control-description-padding-left}

--- a/packages/clay-form/BREAKING.md
+++ b/packages/clay-form/BREAKING.md
@@ -1,3 +1,4 @@
 # List of Breaking Changes for 4.x
 
 -   `onChange` will return only the value instead of the event.
+-   Remove the CSS class `custom-control-outside` from checkboxes and radio inputs.


### PR DESCRIPTION
…d the text

https://liferay.atlassian.net/browse/LPD-50093

I wanted to remove `custom-control-outside` from our checkboxes, but there might be users targeting it with a CSS selector. What do you think?