### PR TITLE
feat(@clayui/dropdown): LPD-50132 Adapt tests

### DIFF
--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -10,6 +10,17 @@ import React, {useContext} from 'react';
 
 import {DropDownContext} from './DropDownContext';
 
+const SYMBOL_DISPLAY_TYPES = [
+	'danger',
+	'info',
+	'primary',
+	'secondary',
+	'success',
+	'warning',
+] as const;
+
+export type SymbolDisplayType = typeof SYMBOL_DISPLAY_TYPES[number];
+
 export interface IProps
 	extends React.HTMLAttributes<
 		HTMLSpanElement | HTMLButtonElement | HTMLAnchorElement
@@ -53,6 +64,11 @@ export interface IProps
 	symbolLeft?: string;
 
 	/**
+	 * Display type of the icon symbol if there is one on the left side.
+	 */
+	symbolLeftDisplayType?: SymbolDisplayType;
+
+	/**
 	 * Flag that indicates if there is an icon symbol on the right side.
 	 */
 	symbolRight?: string;
@@ -74,6 +90,7 @@ const Item = React.forwardRef<HTMLLIElement, IProps>(
 			spritemap,
 			style,
 			symbolLeft,
+			symbolLeftDisplayType,
 			symbolRight,
 			tabIndex,
 			...otherProps
@@ -82,6 +99,9 @@ const Item = React.forwardRef<HTMLLIElement, IProps>(
 	) => {
 		const clickableElement = onClick ? 'button' : 'span';
 		const ItemElement = href ? ClayLink : clickableElement;
+
+		const displayTypeIsValid = (displayType: SymbolDisplayType) =>
+			SYMBOL_DISPLAY_TYPES.includes(displayType);
 
 		const {close, closeOnClick, tabFocus} = useContext(DropDownContext);
 
@@ -126,6 +146,12 @@ const Item = React.forwardRef<HTMLLIElement, IProps>(
 					{symbolLeft && (
 						<span className="dropdown-item-indicator-start">
 							<ClayIcon
+								className={
+									symbolLeftDisplayType &&
+									displayTypeIsValid(symbolLeftDisplayType)
+										? `text-${symbolLeftDisplayType}`
+										: undefined
+								}
 								spritemap={spritemap}
 								symbol={symbolLeft}
 							/>

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -326,6 +326,29 @@ exports[`ClayDropDown renders with icons 1`] = `
               </span>
             </span>
           </li>
+          <li
+            role="presentation"
+          >
+            <span
+              class="dropdown-item"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="dropdown-item-indicator-start"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-trash text-primary"
+                  role="presentation"
+                >
+                  <use
+                    href="/foo/bar#trash"
+                  />
+                </svg>
+              </span>
+              Left
+            </span>
+          </li>
         </ul>
       </div>
     </div>

--- a/packages/clay-drop-down/src/__tests__/index.tsx
+++ b/packages/clay-drop-down/src/__tests__/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayDropDown, {ClayDropDownWithItems} from '..';
+import ClayDropDown, {ClayDropDownWithItems, SymbolDisplayType} from '..';
 import {cleanup, fireEvent, getAllByRole, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -201,18 +201,29 @@ describe('ClayDropDown', () => {
 	});
 
 	it('renders with icons', () => {
+		type Item = {
+			label: string;
+			left?: string;
+			leftDisplayType?: SymbolDisplayType;
+			right?: string;
+		};
+
+		const items: Array<Item> = [
+			{label: 'Left', left: 'trash'},
+			{label: 'Right', right: 'check'},
+			{label: 'Both', left: 'trash', right: 'check'},
+			{label: 'Left', left: 'trash', leftDisplayType: 'primary'},
+		];
+
 		const {container} = render(
 			<DropDownWithState hasLeftSymbols hasRightSymbols>
 				<ClayDropDown.ItemList>
-					{[
-						{label: 'Left', left: 'trash'},
-						{label: 'Right', right: 'check'},
-						{label: 'Both', left: 'trash', right: 'check'},
-					].map((item, i) => (
+					{items.map((item, i) => (
 						<ClayDropDown.Item
 							key={i}
 							spritemap="/foo/bar"
 							symbolLeft={item.left}
+							symbolLeftDisplayType={item.leftDisplayType}
 							symbolRight={item.right}
 						>
 							{item.label}

--- a/packages/clay-drop-down/src/index.tsx
+++ b/packages/clay-drop-down/src/index.tsx
@@ -6,7 +6,14 @@
 import DropDown from './DropDown';
 import {ClayDropDownWithDrilldown} from './DropDownWithDrilldown';
 import {ClayDropDownWithItems} from './DropDownWithItems';
+import {SymbolDisplayType} from './Item';
 import {Align} from './Menu';
 
-export {Align, DropDown, ClayDropDownWithItems, ClayDropDownWithDrilldown};
+export {
+	Align,
+	DropDown,
+	ClayDropDownWithItems,
+	ClayDropDownWithDrilldown,
+	SymbolDisplayType,
+};
 export default DropDown;

--- a/packages/clay-drop-down/stories/DropDown.stories.tsx
+++ b/packages/clay-drop-down/stories/DropDown.stories.tsx
@@ -4,6 +4,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import {SymbolDisplayType} from '@clayui/drop-down';
 import {ClayCheckbox, ClayInput, ClayRadio} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
 import React, {useRef, useState} from 'react';
@@ -330,32 +331,45 @@ export const CaptionAndHelp = () => (
 	</ClayDropDown>
 );
 
-export const ItemsWithIcons = () => (
-	<ClayDropDown
-		alignmentPosition={Align.BottomLeft}
-		hasLeftSymbols
-		hasRightSymbols
-		trigger={<ClayButton>Click Me</ClayButton>}
-		triggerIcon="caret-bottom"
-	>
-		<ClayDropDown.ItemList>
-			{[
-				{label: 'Left', left: 'trash'},
-				{label: 'Right', right: 'check'},
-				{label: 'Both', left: 'trash', right: 'check'},
-			].map((item, i) => (
-				<ClayDropDown.Item
-					key={i}
-					onClick={() => {}}
-					symbolLeft={item.left}
-					symbolRight={item.right}
-				>
-					{item.label}
-				</ClayDropDown.Item>
-			))}
-		</ClayDropDown.ItemList>
-	</ClayDropDown>
-);
+export const ItemsWithIcons = () => {
+	type Item = {
+		label: string;
+		left?: string;
+		leftDisplayType?: SymbolDisplayType;
+		right?: string;
+	};
+
+	const items: Array<Item> = [
+		{label: 'Left', left: 'trash'},
+		{label: 'Right', right: 'check'},
+		{label: 'Both', left: 'trash', right: 'check'},
+		{label: 'Left', left: 'trash', leftDisplayType: 'primary'},
+	];
+
+	return (
+		<ClayDropDown
+			alignmentPosition={Align.BottomLeft}
+			hasLeftSymbols
+			hasRightSymbols
+			trigger={<ClayButton>Click Me</ClayButton>}
+			triggerIcon="caret-bottom"
+		>
+			<ClayDropDown.ItemList>
+				{items.map((item, i) => (
+					<ClayDropDown.Item
+						key={i}
+						onClick={() => {}}
+						symbolLeft={item.left}
+						symbolLeftDisplayType={item.leftDisplayType}
+						symbolRight={item.right}
+					>
+						{item.label}
+					</ClayDropDown.Item>
+				))}
+			</ClayDropDown.ItemList>
+		</ClayDropDown>
+	);
+};
 
 export const CustomOffset = () => (
 	<ClayDropDown


### PR DESCRIPTION
Hi guys!

According to this CMS story [LPD-48264](https://liferay.atlassian.net/browse/LPD-48264), we need the left icons of the dropdown items to support different display types, as shown in the following image:

<img width="190" alt="Screenshot 2025-03-03 at 10 25 13" src="https://github.com/user-attachments/assets/2a0063fd-43fa-4a3a-9dd2-0bedebd20783" />

After several discussions with the design teams (cc @marcoscv-work), it was decided that this should be contributed to Clay for standardization.

For that reason, I’m sending this pull request where I’ve added a new prop for the display type of the left icon, `symbolLeftDisplayType`. 

Let me know what you think! 😊 Thanks in advance!