### PR TITLE
fix(@clayui/css): LPD-47339 loading-animation-squares should look lik…

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
@@ -880,5 +880,16 @@
 
 	html#{$cadmin-selector} .c-prefers-reduced-motion .cadmin {
 		@include clay-css($cadmin-c-prefers-reduced-motion);
+
+		.loading-animation-squares {
+			@extend %loading-animation !optional;
+
+			@include clay-map-to-css(
+				map-get(
+					$cadmin-c-prefers-reduced-motion,
+					'.loading-animation-squares'
+				)
+			);
+		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
@@ -830,6 +830,22 @@ $cadmin-c-prefers-reduced-motion: map-merge(
 	(
 		scroll-behavior: auto,
 		transition: clay-enable-transitions(none),
+		'.loading-animation-squares': (
+			'&::before': (
+				background-color: transparent,
+				display: block,
+				font-size: inherit,
+				opacity: inherit,
+				transform: none,
+			),
+			'&::after': (
+				font-size: inherit,
+				left: auto,
+				position: relative,
+				top: auto,
+				transform: none,
+			),
+		),
 	),
 	$cadmin-c-prefers-reduced-motion
 );

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -855,4 +855,12 @@
 
 .c-prefers-reduced-motion {
 	@include clay-css($c-prefers-reduced-motion);
+
+	.loading-animation-squares {
+		@extend %loading-animation !optional;
+
+		@include clay-map-to-css(
+			map-get($c-prefers-reduced-motion, '.loading-animation-squares')
+		);
+	}
 }

--- a/packages/clay-css/src/scss/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/variables/_utilities.scss
@@ -798,6 +798,22 @@ $c-prefers-reduced-motion: map-merge(
 	(
 		scroll-behavior: auto,
 		transition: clay-enable-transitions(none),
+		'.loading-animation-squares': (
+			'&::before': (
+				background-color: transparent,
+				display: block,
+				font-size: inherit,
+				opacity: inherit,
+				transform: none,
+			),
+			'&::after': (
+				font-size: inherit,
+				left: auto,
+				position: relative,
+				top: auto,
+				transform: none,
+			),
+		),
 	),
 	$c-prefers-reduced-motion
 );


### PR DESCRIPTION
…e loading-animation when c-prefers-reduced-motion is on

https://liferay.atlassian.net/browse/LPD-47339
![loading-animation-squares](https://github.com/user-attachments/assets/72998dd2-b2a6-4f31-972b-4c8bae01b24c)
