### PR TITLE
feat(@clayui/drop-down): LPD-47559 Cascading Menu should turn into dr…

### DIFF
--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -55,6 +55,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	defaultActiveMenu?: string;
 
 	/**
+	 * Flag to indicate if menu is displaying a clay-icon on the left.
+	 */
+	hasLeftSymbols?: boolean;
+
+	/**
 	 * The unique identifier of the menu that should be active on mount.
 	 * @deprecated since v3.51.0 - use `defaultActiveMenu` instead.
 	 */
@@ -129,6 +134,7 @@ export const ClayDropDownWithDrilldown = ({
 	containerElement,
 	defaultActive = false,
 	defaultActiveMenu,
+	hasLeftSymbols,
 	initialActiveMenu,
 	menuElementAttrs,
 	menuHeight,
@@ -204,6 +210,7 @@ export const ClayDropDownWithDrilldown = ({
 			alignmentPosition={alignmentPosition}
 			className={className}
 			containerElement={containerElement}
+			hasLeftSymbols={hasLeftSymbols}
 			hasRightSymbols
 			menuElementAttrs={{
 				...menuElementAttrs,

--- a/packages/clay-drop-down/src/drilldown/Menu.tsx
+++ b/packages/clay-drop-down/src/drilldown/Menu.tsx
@@ -24,12 +24,14 @@ export interface IItem extends React.ComponentProps<typeof LinkOrButton> {
 	title?: string;
 	href?: string;
 	symbol?: string;
+	symbolRight?: string;
 	type?: TType;
 }
 
 export interface IProps {
 	active?: boolean;
 	direction?: 'prev' | 'next';
+	hasLeftSymbols?: boolean;
 	header?: string;
 	items: Array<IItem>;
 	messages: Messages;
@@ -103,6 +105,8 @@ const DrilldownMenu = ({
 									className,
 									onClick,
 									symbol,
+									symbolLeft,
+									symbolRight,
 									title,
 									type,
 									...other
@@ -144,9 +148,25 @@ const DrilldownMenu = ({
 												</span>
 											)}
 
-											<span className="dropdown-item-indicator-text-end">
-												{title}
-											</span>
+											{symbolLeft && (
+												<span className="dropdown-item-indicator-start">
+													<ClayIcon
+														spritemap={spritemap}
+														symbol={symbolLeft}
+													/>
+												</span>
+											)}
+
+											<span>{title}</span>
+
+											{symbolRight && (
+												<span className="dropdown-item-indicator-end">
+													<ClayIcon
+														spritemap={spritemap}
+														symbol={symbolRight}
+													/>
+												</span>
+											)}
 
 											{child && (
 												<span


### PR DESCRIPTION
…illdown in smaller screens

https://liferay.atlassian.net/browse/LPD-47559

I was running into errors returning drilldown when resizing. This PR renders Drilldown if the window width is < 768px and cascade at larger sizes. I also couldn't figure out how to add `dropdown-menu-indicator-start` on `dropdown-menu` based on if an item had an icon on the left side in Drilldown.

![cascadetodrilldown](https://github.com/user-attachments/assets/6fcaf2dd-16ca-4f53-b178-7c6268d77025)
