### PR TITLE
LPD-50827 New Variant of Clay Modal

### DIFF
--- a/packages/clay-css/src/scss/components/_modals.scss
+++ b/packages/clay-css/src/scss/components/_modals.scss
@@ -472,3 +472,10 @@
 	top: -9999px;
 	width: 50px;
 }
+
+.modal-header-clean {
+	position: absolute;
+	right: 0;
+	z-index: 9;
+	border: 0;
+}

--- a/packages/clay-modal/src/Context.ts
+++ b/packages/clay-modal/src/Context.ts
@@ -11,6 +11,12 @@ export interface IContext {
 	ariaLabelledby?: string;
 
 	/**
+	 * Flag indicating if the modal should be the clean variant
+	 * with the title hidden
+	 */
+	clean?: boolean;
+
+	/**
 	 * Callback called to close the modal.
 	 */
 	onClose: () => void;

--- a/packages/clay-modal/src/Header.tsx
+++ b/packages/clay-modal/src/Header.tsx
@@ -22,6 +22,12 @@ export const ItemGroup = ({
 
 export interface IItemProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
+	 * Flag indicating if the modal should be the clean variant
+	 * with the title hidden
+	 */
+	clean?: boolean;
+
+	/**
 	 * Flag for indicating if item should autofitting the width
 	 */
 	shrink?: boolean;
@@ -120,12 +126,13 @@ const ICON_MAP = {
 
 const HighLevel = ({
 	children,
+	clean,
 	onClose,
 	spritemap,
 	status,
 }: IContext & {children?: React.ReactNode}) => (
 	<>
-		<Title>
+		<Title className={classNames({'sr-only': clean})}>
 			{status && (
 				<TitleIndicator>
 					<ClayIcon spritemap={spritemap} symbol={ICON_MAP[status]} />
@@ -157,19 +164,34 @@ const ClayModalHeader = ({
 
 export interface IHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
+	 * Flag indicating if the modal should be the clean variant
+	 * with the title hidden
+	 */
+	clean?: boolean;
+
+	/**
 	 * Flag for indicating if you want to use the Header its children being the title.
 	 * Set to `false` if you want to use this as a low-level component.
 	 */
 	withTitle?: boolean;
 }
 
-const Header = ({children, withTitle = true, ...otherProps}: IHeaderProps) => {
+const Header = ({
+	children,
+	clean = false,
+	withTitle = true,
+	...otherProps
+}: IHeaderProps) => {
 	const {onClose, spritemap, status} = React.useContext(Context);
 
 	return (
-		<ClayModalHeader {...otherProps}>
+		<ClayModalHeader
+			className={classNames({'modal-header-clean': clean})}
+			{...otherProps}
+		>
 			{withTitle && (
 				<HighLevel
+					clean={clean}
 					onClose={onClose}
 					spritemap={spritemap}
 					status={status}

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -33,6 +33,12 @@ interface IProps
 	center?: boolean;
 
 	/**
+	 * Flag indicating if the modal should be the clean variant
+	 * with the title hidden
+	 */
+	clean?: boolean;
+
+	/**
 	 * Container element to render modal into.
 	 */
 	containerElementRef?: React.RefObject<Element>;
@@ -83,6 +89,7 @@ const Modal = ({
 	center,
 	children,
 	className,
+	clean,
 	containerElementRef,
 	containerProps = {},
 	disableAutoClose = false,
@@ -198,6 +205,7 @@ const Modal = ({
 						<Context.Provider
 							value={{
 								ariaLabelledby,
+								clean,
 								onClose: () =>
 									observer.dispatch(ObserverType.Close),
 								spritemap,

--- a/packages/clay-modal/src/Provider.tsx
+++ b/packages/clay-modal/src/Provider.tsx
@@ -35,6 +35,12 @@ type TState = {
 	center?: boolean;
 
 	/**
+	 * Flag indicating if the modal should be the clean variant
+	 * with the title hidden
+	 */
+	clean?: boolean;
+
+	/**
 	 * Render the action buttons on the footer following the order of `ClayModal.Footer`:
 	 * - first
 	 * - middle
@@ -102,7 +108,16 @@ const ModalProvider = ({children, spritemap}: IProps) => {
 	const {observer, onClose} = useModal({
 		onClose: () => dispatch({type: Action.Close}),
 	});
-	const {body, center, footer = [], header, size, status, url} = otherState;
+	const {
+		body,
+		center,
+		clean,
+		footer = [],
+		header,
+		size,
+		status,
+		url,
+	} = otherState;
 	const [first, middle, last] = footer;
 	const state = {
 		...otherState,
@@ -119,7 +134,11 @@ const ModalProvider = ({children, spritemap}: IProps) => {
 					spritemap={spritemap}
 					status={status}
 				>
-					{header && <ClayModal.Header>{header}</ClayModal.Header>}
+					{header && (
+						<ClayModal.Header clean={clean}>
+							{header}
+						</ClayModal.Header>
+					)}
 					<ClayModal.Body url={url}>{body}</ClayModal.Body>
 					{!!footer.length && (
 						<ClayModal.Footer

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -358,6 +358,65 @@ exports[`ClayModal renders with center 1`] = `
 </body>
 `;
 
+exports[`ClayModal renders with clean variant 1`] = `
+<body
+  class="modal-open"
+>
+  <div>
+    <div
+      aria-hidden="true"
+      class="modal-backdrop fade show"
+      data-suppressed="true"
+    />
+    <div
+      class="fade modal d-block show"
+    >
+      <div
+        class="modal-dialog"
+      >
+        <div
+          aria-labelledby="clay-modal-label-9"
+          aria-modal="true"
+          class="modal-content"
+          role="dialog"
+          tabindex="-1"
+        >
+          <div
+            class="modal-header modal-header-clean"
+          >
+            <h1
+              class="modal-title sr-only"
+              id="clay-modal-label-9"
+              tabindex="-1"
+            >
+              Foo
+            </h1>
+            <button
+              aria-label="close"
+              class="close btn btn-unstyled"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times"
+                role="presentation"
+              >
+                <use
+                  href="icons.svg#times"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    data-suppressed="true"
+  />
+</body>
+`;
+
 exports[`ClayModal renders with size 1`] = `
 <body
   class="modal-open"

--- a/packages/clay-modal/src/__tests__/index.tsx
+++ b/packages/clay-modal/src/__tests__/index.tsx
@@ -218,4 +218,24 @@ describe('ClayModal', () => {
 
 		expect(document.body).toMatchSnapshot();
 	});
+
+	it('renders with clean variant', () => {
+		const ModalWithCleanVariant = () => {
+			const {observer} = useModal({onClose: () => {}});
+
+			return (
+				<ClayModal observer={observer} spritemap={spritemap}>
+					<ClayModal.Header clean>Foo</ClayModal.Header>
+				</ClayModal>
+			);
+		};
+
+		render(<ModalWithCleanVariant />);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(document.body).toMatchSnapshot();
+	});
 });

--- a/packages/clay-modal/stories/Modal.stories.tsx
+++ b/packages/clay-modal/stories/Modal.stories.tsx
@@ -39,7 +39,9 @@ export const Default = (args: any) => {
 					size={args.size}
 					status={args.status}
 				>
-					<ClayModal.Header>{args.title}</ClayModal.Header>
+					<ClayModal.Header clean={args.clean}>
+						{args.title}
+					</ClayModal.Header>
 					<ClayModal.Body
 						iFrameProps={{
 							'aria-label': 'Hello World',
@@ -95,6 +97,7 @@ export const Default = (args: any) => {
 Default.args = {
 	autoClose: false,
 	center: false,
+	clean: false,
 	scrollable: false,
 	size: 'lg',
 	status: undefined,


### PR DESCRIPTION
## Motivation
Due to [this](https://liferay.atlassian.net/browse/LPD-47547) story we are contributing a new Variant of Clay Modal to be used in the CMS and with Marketplace in DXP. 

## Changes
To do so, I have added the “clean” attribute that hides the title and changes the styles to not show the header and keep the close button in place. Also it adds a "sr-only" to the title.

Once we have this, to obtain the modal that we want to use in both cases, we would only have to place the image, the title and the desired text in the body manually.