### PR TITLE
feat(@clayui/css): LPD-51097 card-page-item's should be 100%, 50%, 25…

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_cards.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_cards.scss
@@ -470,7 +470,7 @@
 // Card Page
 
 .card-page {
-	@extend %clay-custom-grid-wrapper !optional;
+	@include clay-map-to-css($cadmin-card-page);
 
 	&.card-page-equal-height {
 		.card-page-item,
@@ -499,15 +499,15 @@
 }
 
 .card-page-item-directory {
-	@include clay-custom-grid-columns($cadmin-card-page-item-directory);
+	@include clay-map-to-css($cadmin-card-page-item-directory);
 }
 
 .card-page-item-asset {
-	@include clay-custom-grid-columns($cadmin-card-page-item-asset);
+	@include clay-map-to-css($cadmin-card-page-item-asset);
 }
 
 .card-page-item-user {
-	@include clay-custom-grid-columns($cadmin-card-page-item-user);
+	@include clay-map-to-css($cadmin-card-page-item-user);
 }
 
 // Card Interactive

--- a/packages/clay-css/src/scss/cadmin/components/_grid.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_grid.scss
@@ -234,6 +234,7 @@
 	}
 
 	%clay-custom-grid-wrapper {
+		container-type: inline-size;
 		display: flex;
 		flex-wrap: wrap;
 		list-style: none;

--- a/packages/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -598,34 +598,39 @@ $cadmin-user-card: map-deep-merge(
 	$cadmin-user-card
 );
 
-// Card Page Item Asset
+$cadmin-card-page: () !default;
+$cadmin-card-page: map-deep-merge(
+	(
+		container-name: c-card-page,
+		container-type: inline-size,
+		extend: '%clay-custom-grid-wrapper',
+	),
+	$cadmin-card-page
+);
 
-// base: min-width 0, sm min-width: 576px, md: min-width: 768px,
-// lg: min-width: 992px
+// Card Page Item Asset
 
 $cadmin-card-page-item-asset: () !default;
 $cadmin-card-page-item-asset: map-deep-merge(
 	(
-		base: (
-			breakpoint: 0,
-			min-width: 193px,
-			padding-left: $cadmin-grid-gutter-width * 0.5,
-			padding-right: $cadmin-grid-gutter-width * 0.5,
-		),
-		sm: (
-			breakpoint: map-get($cadmin-grid-breakpoints, sm),
+		flex-basis: 100%,
+		max-width: 100%,
+		padding-left: $cadmin-grid-gutter-width * 0.5,
+		padding-right: $cadmin-grid-gutter-width * 0.5,
+		'@container #{map-get($cadmin-card-page, container-name)} (min-width: #{map-get($cadmin-container-max-widths, sm)})':
+		(
 			flex-basis: 50%,
 			max-width: 50%,
 		),
-		md: (
-			breakpoint: map-get($cadmin-grid-breakpoints, md),
-			flex-basis: 33.3333%,
-			max-width: 33.3333%,
-		),
-		lg: (
-			breakpoint: map-get($cadmin-grid-breakpoints, lg),
+		'@container #{map-get($cadmin-card-page, container-name)} (min-width: #{map-get($cadmin-container-max-widths, lg)})':
+		(
 			flex-basis: 25%,
 			max-width: 25%,
+		),
+		'@container #{map-get($cadmin-card-page, container-name)} (min-width: #{map-get($cadmin-container-max-widths, xxl)})':
+		(
+			flex-basis: 20%,
+			max-width: 20%,
 		),
 	),
 	$cadmin-card-page-item-asset
@@ -637,26 +642,7 @@ $cadmin-card-page-item-asset: map-deep-merge(
 
 $cadmin-card-page-item-user: () !default;
 $cadmin-card-page-item-user: map-deep-merge(
-	(
-		base: (
-			breakpoint: 0,
-			flex-basis: 50%,
-			max-width: 50%,
-			padding-left: $cadmin-grid-gutter-width * 0.5,
-			padding-right: $cadmin-grid-gutter-width * 0.5,
-		),
-		sm: (
-			breakpoint: map-get($cadmin-grid-breakpoints, sm),
-			flex-basis: 33.33333%,
-			max-width: 33.33333%,
-			min-width: 200px,
-		),
-		lg: (
-			breakpoint: map-get($cadmin-grid-breakpoints, lg),
-			flex-basis: 20%,
-			max-width: 20%,
-		),
-	),
+	$cadmin-card-page-item-asset,
 	$cadmin-card-page-item-user
 );
 

--- a/packages/clay-css/src/scss/components/_cards.scss
+++ b/packages/clay-css/src/scss/components/_cards.scss
@@ -535,7 +535,7 @@
 // Card Page
 
 .card-page {
-	@extend %clay-custom-grid-wrapper !optional;
+	@include clay-map-to-css($card-page);
 
 	&.card-page-equal-height {
 		.card-page-item,
@@ -564,15 +564,15 @@
 }
 
 .card-page-item-directory {
-	@include clay-custom-grid-columns($card-page-item-directory);
+	@include clay-map-to-css($card-page-item-directory);
 }
 
 .card-page-item-asset {
-	@include clay-custom-grid-columns($card-page-item-asset);
+	@include clay-map-to-css($card-page-item-asset);
 }
 
 .card-page-item-user {
-	@include clay-custom-grid-columns($card-page-item-user);
+	@include clay-map-to-css($card-page-item-user);
 }
 
 // Card Interactive

--- a/packages/clay-css/src/scss/components/_grid.scss
+++ b/packages/clay-css/src/scss/components/_grid.scss
@@ -201,6 +201,7 @@
 	}
 
 	%clay-custom-grid-wrapper {
+		container-type: inline-size;
 		display: flex;
 		flex-wrap: wrap;
 		list-style: none;

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -436,6 +436,14 @@
 					@media #{clay-str-replace('#{$selector}', '@media ', '')} {
 						@include clay-map-to-css($value);
 					}
+				} @else if (starts-with($selector, '@container ')) {
+					@at-root {
+						@container #{clay-str-replace('#{$selector}', '@container ', '')} {
+							& {
+								@include clay-map-to-css($value);
+							}
+						}
+					}
 				} @else {
 					#{$selector} {
 						@include clay-map-to-css($value);

--- a/packages/clay-css/src/scss/mixins/_grid.scss
+++ b/packages/clay-css/src/scss/mixins/_grid.scss
@@ -128,6 +128,8 @@
 	}
 }
 
+/// @deprecated as of v3.130.0
+
 @mixin clay-custom-grid-columns($map) {
 	@if (type-of($map) == 'map') {
 		$custom-grid-props: map-merge(

--- a/packages/clay-css/src/scss/variables/_cards.scss
+++ b/packages/clay-css/src/scss/variables/_cards.scss
@@ -862,6 +862,16 @@ $user-card: map-deep-merge(
 	$user-card
 );
 
+$card-page: () !default;
+$card-page: map-deep-merge(
+	(
+		container-name: c-card-page,
+		container-type: inline-size,
+		extend: '%clay-custom-grid-wrapper',
+	),
+	$card-page
+);
+
 // Card Page Item Asset
 
 // base: min-width 0, sm min-width: 576px, md: min-width: 768px,
@@ -870,26 +880,24 @@ $user-card: map-deep-merge(
 $card-page-item-asset: () !default;
 $card-page-item-asset: map-deep-merge(
 	(
-		base: (
-			breakpoint: 0,
-			min-width: 193px,
-			padding-left: $grid-gutter-width * 0.5,
-			padding-right: $grid-gutter-width * 0.5,
-		),
-		sm: (
-			breakpoint: map-get($grid-breakpoints, sm),
+		flex-basis: 100%,
+		max-width: 100%,
+		padding-left: $grid-gutter-width * 0.5,
+		padding-right: $grid-gutter-width * 0.5,
+		'@container #{map-get($card-page, container-name)} (min-width: #{map-get($container-max-widths, sm)})':
+		(
 			flex-basis: 50%,
 			max-width: 50%,
 		),
-		md: (
-			breakpoint: map-get($grid-breakpoints, md),
-			flex-basis: 33.3333%,
-			max-width: 33.3333%,
-		),
-		lg: (
-			breakpoint: map-get($grid-breakpoints, lg),
+		'@container #{map-get($card-page, container-name)} (min-width: #{map-get($container-max-widths, lg)})':
+		(
 			flex-basis: 25%,
 			max-width: 25%,
+		),
+		'@container #{map-get($card-page, container-name)} (min-width: #{map-get($container-max-widths, xxl)})':
+		(
+			flex-basis: 20%,
+			max-width: 20%,
 		),
 	),
 	$card-page-item-asset
@@ -901,26 +909,7 @@ $card-page-item-asset: map-deep-merge(
 
 $card-page-item-user: () !default;
 $card-page-item-user: map-deep-merge(
-	(
-		base: (
-			breakpoint: 0,
-			flex-basis: 50%,
-			max-width: 50%,
-			padding-left: $grid-gutter-width * 0.5,
-			padding-right: $grid-gutter-width * 0.5,
-		),
-		sm: (
-			breakpoint: map-get($grid-breakpoints, sm),
-			flex-basis: 33.33333%,
-			max-width: 33.33333%,
-			min-width: 200px,
-		),
-		lg: (
-			breakpoint: map-get($grid-breakpoints, lg),
-			flex-basis: 20%,
-			max-width: 20%,
-		),
-	),
+	$card-page-item-asset,
 	$card-page-item-user
 );
 


### PR DESCRIPTION
…%, or 20% depending on container size

BREAKING CHANGE: .card-page-item-asset, .card-page-item-directory, and .card-page-item-user no longer uses the mixin clay-custom-grid-columns

https://liferay.atlassian.net/browse/LPD-51097