### PR TITLE
LPD-51873 Include a visible label on Clay Picker input fields

### DIFF
--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -66,6 +66,7 @@ const ClayDatePickerDateNavigation = ({
 			<div className="date-picker-nav">
 				<div className="date-picker-nav-item input-date-picker-month">
 					<Select
+						aria-label={ariaLabels.selectMonth}
 						disabled={disabled}
 						name="month"
 						onChange={(event) =>
@@ -84,6 +85,7 @@ const ClayDatePickerDateNavigation = ({
 				<div className="date-picker-nav-item input-date-picker-year">
 					<Picker
 						UNSAFE_behavior="secondary"
+						aria-label={ariaLabels.selectYear}
 						className="form-control-sm"
 						data-testid="year-select"
 						disabled={disabled}

--- a/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
+++ b/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
@@ -110,7 +110,11 @@ describe('BasicRendering', () => {
 					buttonDot: 'Select current date',
 					buttonNextMonth: 'Select the next month',
 					buttonPreviousMonth: 'Select the previous month',
+					chooseDate:
+						'Use the calendar to choose a Date. Current selection {0}',
 					input: 'input-test',
+					selectMonth: 'Select a month',
+					selectYear: 'Select a year',
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				defaultValue="2019-04-10"
@@ -138,7 +142,11 @@ describe('BasicRendering', () => {
 					buttonDot: 'Select current date',
 					buttonNextMonth: 'Select the next month',
 					buttonPreviousMonth: 'Select the previous month',
+					chooseDate:
+						'Use the calendar to choose a Date. Current selection {0}',
 					input: 'input-test',
+					selectMonth: 'Select a month',
+					selectYear: 'Select a year',
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				onChange={() => {}}
@@ -167,7 +175,11 @@ describe('BasicRendering', () => {
 					buttonDot: 'Select current date',
 					buttonNextMonth: 'Select the next month',
 					buttonPreviousMonth: 'Select the previous month',
+					chooseDate:
+						'Use the calendar to choose a Date. Current selection {0}',
 					input: 'input-test',
+					selectMonth: 'Select a month',
+					selectYear: 'Select a year',
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				onChange={() => {}}
@@ -199,7 +211,11 @@ describe('BasicRendering', () => {
 					buttonDot: 'Select current date',
 					buttonNextMonth: 'Select the next month',
 					buttonPreviousMonth: 'Select the previous month',
+					chooseDate:
+						'Use the calendar to choose a Date. Current selection {0}',
 					input: 'input-test',
+					selectMonth: 'Select a month',
+					selectYear: 'Select a year',
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				defaultValue="2019-04-10 - 2019-04-15"
@@ -229,7 +245,11 @@ describe('BasicRendering', () => {
 					buttonDot: 'Select current date',
 					buttonNextMonth: 'Select the next month',
 					buttonPreviousMonth: 'Select the previous month',
+					chooseDate:
+						'Use the calendar to choose a Date. Current selection {0}',
 					input: 'input-test',
+					selectMonth: 'Select a month',
+					selectYear: 'Select a year',
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				onChange={() => {}}
@@ -265,7 +285,11 @@ describe('BasicRendering', () => {
 					buttonDot: 'Select current date',
 					buttonNextMonth: 'Select the next month',
 					buttonPreviousMonth: 'Select the previous month',
+					chooseDate:
+						'Use the calendar to choose a Date. Current selection {0}',
 					input: 'input-test',
+					selectMonth: 'Select a month',
+					selectYear: 'Select a year',
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				defaultValue="2019-04-10 05:00"

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -21,7 +21,10 @@ const ariaLabels = {
 	buttonDot: 'Select current date',
 	buttonNextMonth: 'Select the next month',
 	buttonPreviousMonth: 'Select the previous month',
+	chooseDate: 'Use the calendar to choose a Date. Current selection {0}',
 	input: 'input-test',
+	selectMonth: 'Select a month',
+	selectYear: 'Select a year',
 };
 
 const DatePickerWithState = ({

--- a/packages/clay-date-picker/src/__tests__/Internationalization.tsx
+++ b/packages/clay-date-picker/src/__tests__/Internationalization.tsx
@@ -16,7 +16,10 @@ const ariaLabels = {
 	buttonDot: 'Select current date',
 	buttonNextMonth: 'Select the next month',
 	buttonPreviousMonth: 'Select the previous month',
+	chooseDate: 'Use the calendar to choose a Date. Current selection {0}',
 	input: 'input-test',
+	selectMonth: 'Select a month',
+	selectYear: 'Select a year',
 };
 
 const DatePickerWithState = ({

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -33,6 +33,7 @@ exports[`BasicRendering renders by default 1`] = `
               aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
+              title="Open Calendar Picker"
               type="button"
             >
               <svg
@@ -65,7 +66,7 @@ exports[`BasicRendering renders by default 1`] = `
         role="dialog"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -79,6 +80,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -149,6 +151,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -866,6 +869,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
+              title="Open Calendar Picker"
               type="button"
             >
               <svg
@@ -900,7 +904,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -914,6 +918,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -984,6 +989,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -1733,6 +1739,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
+              title="Open Calendar Picker"
               type="button"
             >
               <svg
@@ -1767,7 +1774,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -1781,6 +1788,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -1851,6 +1859,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -2712,6 +2721,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
+              title="Open Calendar Picker"
               type="button"
             >
               <svg
@@ -2746,7 +2756,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -2760,6 +2770,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -2830,6 +2841,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -71,7 +71,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="July 2019"
+          aria-label="Use the calendar to choose a Date. Current selection July 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -85,6 +85,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -155,6 +156,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -903,7 +905,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -917,6 +919,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -987,6 +990,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -1738,7 +1742,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -1752,6 +1756,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -1822,6 +1827,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -2576,7 +2582,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2018"
+          aria-label="Use the calendar to choose a Date. Current selection April 2018"
           class="date-picker-calendar"
           role="group"
         >
@@ -2590,6 +2596,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -2660,6 +2667,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -3428,7 +3436,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -3442,6 +3450,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -3512,6 +3521,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -4263,7 +4273,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -4277,6 +4287,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -4347,6 +4358,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -71,7 +71,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -85,6 +85,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -155,6 +156,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -908,7 +910,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -922,6 +924,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -992,6 +995,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -1745,7 +1749,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -1759,6 +1763,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -1829,6 +1834,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -2582,7 +2588,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -2596,6 +2602,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -2666,6 +2673,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -3419,7 +3427,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -3433,6 +3441,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -3503,6 +3512,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -4256,7 +4266,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -4270,6 +4280,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -4340,6 +4351,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -5197,7 +5209,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -5211,6 +5223,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -5281,6 +5294,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >
@@ -6034,7 +6048,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-label="April 2019"
+          aria-label="Use the calendar to choose a Date. Current selection April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -6048,6 +6062,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-nav-item input-date-picker-month"
               >
                 <select
+                  aria-label="Select a month"
                   class="form-control form-control-sm"
                   data-testid="month-select"
                   name="month"
@@ -6118,6 +6133,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-nav-item input-date-picker-year"
               >
                 <select
+                  aria-label="Select a year"
                   class="form-control form-control-select form-control-select-secondary form-control-sm"
                   data-testid="year-select"
                 >

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -10,6 +10,7 @@ import Icon from '@clayui/icon';
 import {
 	FocusScope,
 	InternalDispatch,
+	sub,
 	useControlledState,
 	useId,
 } from '@clayui/shared';
@@ -241,7 +242,12 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 				buttonDot: 'Select current date',
 				buttonNextMonth: 'Select the next month',
 				buttonPreviousMonth: 'Select the previous month',
+				chooseDate:
+					'Use the calendar to choose a Date. Current selection {0}',
 				dialog: 'Choose date',
+				openCalendar: 'Open Calendar Picker',
+				selectMonth: 'Select a month',
+				selectYear: 'Select a year',
 			},
 			dateFormat = 'yyyy-MM-dd',
 			defaultExpanded,
@@ -673,6 +679,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 										displayType="unstyled"
 										onClick={handleCalendarButtonClicked}
 										ref={chooseDateRef}
+										title={ariaLabels.openCalendar}
 									>
 										<Icon
 											spritemap={spritemap}
@@ -698,10 +705,12 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 							triggerRef={chooseDateRef}
 						>
 							<div
-								aria-label={formatDate(
-									currentMonth,
-									'MMMM yyyy'
-								)}
+								aria-label={
+									ariaLabels.chooseDate &&
+									sub(ariaLabels.chooseDate, [
+										formatDate(currentMonth, 'MMMM yyyy'),
+									])
+								}
 								className="date-picker-calendar"
 								role="group"
 							>

--- a/packages/clay-date-picker/src/types.ts
+++ b/packages/clay-date-picker/src/types.ts
@@ -18,8 +18,12 @@ export interface IAriaLabels {
 	buttonDot: string;
 	buttonNextMonth: string;
 	buttonPreviousMonth: string;
-	input?: string;
+	chooseDate?: string;
 	dialog?: string;
+	input?: string;
+	openCalendar?: string;
+	selectMonth: string;
+	selectYear: string;
 }
 
 export interface IYears {

--- a/packages/clay-date-picker/stories/DatePicker.stories.tsx
+++ b/packages/clay-date-picker/stories/DatePicker.stories.tsx
@@ -27,8 +27,13 @@ const ClayDatePickerWithState = (props: {[key: string]: any}) => {
 					buttonDot: 'Go to today',
 					buttonNextMonth: 'Next month',
 					buttonPreviousMonth: 'Previous month',
+					chooseDate:
+						'Use the calendar to choose a Date. Current selection {0}',
 					dialog: 'Choose Date',
 					input: value.toLocaleString(),
+					openCalendar: 'Open Calendar Picker',
+					selectMonth: 'Select a month',
+					selectYear: 'Select a year',
 				}}
 				onChange={setValue}
 				value={value}
@@ -169,7 +174,11 @@ export const DynamicYears = () => {
 				buttonDot: 'Go to today',
 				buttonNextMonth: 'Next month',
 				buttonPreviousMonth: 'Previous month',
+				chooseDate:
+					'Use the calendar to choose a Date. Current selection {0}',
 				input: value.toLocaleString(),
+				selectMonth: 'Select a month',
+				selectYear: 'Select a year',
 			}}
 			onChange={(value) => {
 				if (value) {


### PR DESCRIPTION
- **fix(@clayui/date-picker): LPD-51873 improve accessibility and update types**
- **fix(@clayui/date-picker): LPD-51873 Update stories**
- **fix(@clayui/date-picker): LPD-51873 Update tests and snapshots**


Ticket: https://liferay.atlassian.net/browse/LPD-51873

## Motivation
 Improve the accessibility of the date picker by making it more usable for screen reader users

## Proposed Solution

- Add `aria-label` on input fields
- Better description once the dropdown to select a date is open

## Screenshots/videos (if applies)

https://github.com/user-attachments/assets/c18f837c-7083-485b-88cb-582a5af2703d
