### PR TITLE
feat(@clayui/css): LPD-52388 Add *px spacer utilities to match Lexicon spacers

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -329,6 +329,12 @@ $spacers: map-deep-merge(
 		8: $spacer * 7.5,
 		9: $spacer * 9,
 		10: $spacer * 10,
+		'2px': $spacer * 0.125,
+		'12px': $spacer * 0.75,
+		'20px': $spacer * 1.25,
+		'40px': $spacer * 2.5,
+		'56px': $spacer * 3.5,
+		'64px': $spacer * 4,
 	),
 	$spacers
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -371,6 +371,12 @@ $cadmin-spacers: map-deep-merge(
 		8: $cadmin-spacer * 7.5,
 		9: $cadmin-spacer * 9,
 		10: $cadmin-spacer * 10,
+		'2px': $cadmin-spacer * 0.125,
+		'12px': $cadmin-spacer * 0.75,
+		'20px': $cadmin-spacer * 1.25,
+		'40px': $cadmin-spacer * 2.5,
+		'56px': $cadmin-spacer * 3.5,
+		'64px': $cadmin-spacer * 4,
 	),
 	$cadmin-spacers
 );

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -312,6 +312,12 @@ $spacers: map-deep-merge(
 		6: $spacer * 4.5,
 		7: $spacer * 6,
 		8: $spacer * 7.5,
+		'2px': $spacer * 0.125,
+		'12px': $spacer * 0.75,
+		'20px': $spacer * 1.25,
+		'40px': $spacer * 2.5,
+		'56px': $spacer * 3.5,
+		'64px': $spacer * 4,
 	),
 	$spacers
 );

--- a/www/docs/css/c-spacing.mdx
+++ b/www/docs/css/c-spacing.mdx
@@ -40,11 +40,17 @@ CSS: `@media(min-width: 576px) { margin-top: 1rem; }`. _(576px can change depend
 `3` is the value of the spacing you want to assign in the example. By default the spaces are:
 
 -   `0` - **0rem** - _0px_
+-   `2px` - **0.125rem** _2px_
 -   `1` - **0.25rem** - _4px_
 -   `2` - **0.5rem** - _8px_
+-   `12px` - **0.75** - _12px_
 -   `3` - **1rem** - _16px_
+-   `20px` - **1.25rem** - _20px_
 -   `4` - **1.5rem** - _24px_
+-   `40px` - **2.5rem** - _40px_
 -   `5` - **3rem** - _48px_
+-   `56px` - **3.5rem** - _56px_
+-   `64px` - **4rem** - _64px_
 -   `6` - **4.5rem** - _72px_
 -   `7` - **6rem** - _96px_
 -   `8` - **7.5rem** - _120px_
@@ -54,9 +60,14 @@ These spaces can be negative if we use `n` before the value, that means:
 
 -   `n1` | **-0.25rem** | _-4px_
 -   `n2` | **-0.5rem** | _-8px_
+-   `n12px` | \*\*-0.75rem | \_12px\_\_
 -   `n3` | **-1rem** | _-16px_
+-   `n20px` | \*\*-1.25rem | \_20px\_\_
 -   `n4` | **-1.5rem** | _-24px_
+-   `n40px` | \*\*-2.5rem | \_40px\_\_
 -   `n5` | **-3rem** | _-48px_
+-   `n56px` | \*\*-3.5rem | \_56px\_\_
+-   `n64px` | \*\*-4rem | \_64px\_\_
 -   `n6` | **-4.5rem** | _-72px_
 -   `n7` | **-6rem** | _-96px_
 -   `n8` | **-7.5rem** | _-120px_


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52388

I debated whether we should try and namespace the spacers like:
```
    0: 0,
    0-5: $spacer * 0.125,
    1: $spacer * 0.25,
    2: $spacer * 0.5,
    2-5: $spacer * 0.75,
    3: $spacer,
    3-5: $spacer * 1.25,
    4: $spacer * 1.5,
    4-5: $spacer * 2.5,
    5: $spacer * 3,
    5-5: $spacer * 3.5,
    5-75: $spacer * 4,
    6: $spacer * 4.5,
    7: $spacer * 6,
    8: $spacer * 7.5,
```
but it didn't make sense to me. It's difficult to remember and inserting more sizes increases the confusion.