### PR TITLE
docs(@clayui/icon-selector): LPD-46157 Update docs to fetch the icon correctly

### DIFF
--- a/packages/clay-core/docs/icon-selector.mdx
+++ b/packages/clay-core/docs/icon-selector.mdx
@@ -20,7 +20,7 @@ import React from 'react';
 
 import '@clayui/css/lib/css/atlas.css';
 
-const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+const spritemap = '/icons.svg';
 
 export default function App() {
 	return (


### PR DESCRIPTION
Icon Selector documentation was not fetching the icons correctly.
![image](https://github.com/user-attachments/assets/2dc3ddf3-763e-4231-a613-ae4fa7a74281)
