### PR TITLE
feat(@clayui/drop-down): adds target prop to high-level components

### DIFF
--- a/packages/clay-drop-down/src/Items.tsx
+++ b/packages/clay-drop-down/src/Items.tsx
@@ -95,6 +95,7 @@ const Item = ({
 
 	return (
 		<DropDown.Item
+			{...props}
 			onClick={(event) => {
 				if (onForward && child && label) {
 					event.preventDefault();
@@ -115,7 +116,6 @@ const Item = ({
 				}
 			}}
 			spritemap={spritemap}
-			{...props}
 		>
 			{label}
 
@@ -406,18 +406,19 @@ export type Item = {
 	 * The unique id that references the next menu.
 	 */
 	child?: string;
+	title?: string;
+	items?: Array<Item>;
 
 	/**
 	 * @deprecated since v3.129.0 - use `title` instead.
 	 */
-	title?: string;
-	items?: Array<Item>;
 	label?: string;
 	name?: string;
 	onChange?: Function;
 	onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 	symbolLeft?: string;
 	symbolRight?: string;
+	target?: string;
 	type?:
 		| 'checkbox'
 		| 'contextual'


### PR DESCRIPTION
Ticket [LPD-52748](https://liferay.atlassian.net/browse/LPD-52748)

Well it is safe to add an `otherProps` to the DropDownWithItems component along with the Drilldown that now both share the same components internally but I kept the idea of ​​just adding the `target` type in the API to avoid increasing the surface and increase this as the needs arise to avoid having a high number of props support that can eventually become a problem because we cannot change.