### PR TITLE
fix(@clayui/css): LPD-53627 Modals scope splash image to modal-banner-img instead of aspect-ratio

### DIFF
--- a/packages/clay-css/src/scss/variables/_modals.scss
+++ b/packages/clay-css/src/scss/variables/_modals.scss
@@ -138,7 +138,7 @@ $modal-body: map-deep-merge(
 			overflow: auto,
 			padding: $modal-inner-padding,
 		),
-		'.aspect-ratio': (
+		'.modal-banner-img': (
 			margin-left: math-sign($modal-inner-padding),
 			margin-right: math-sign($modal-inner-padding),
 			top: math-sign($modal-inner-padding),

--- a/packages/clay-modal/stories/Modal.stories.tsx
+++ b/packages/clay-modal/stories/Modal.stories.tsx
@@ -371,7 +371,7 @@ export const CardStyleModal = (args: any) => {
 						>
 							<ClayIcon symbol="times" />
 						</ClayButton>
-						<div className="aspect-ratio aspect-ratio-16-to-9 bg-primary-l3">
+						<div className="aspect-ratio aspect-ratio-16-to-9 bg-primary-l3 modal-banner-img">
 							<div className="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid">
 								<img
 									alt="An image of adding modules to a page"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-53627