### PR TITLE
feat(@clayui/core): adds SidePanel implementation

### DIFF
--- a/packages/clay-core/docs/side-panel.mdx
+++ b/packages/clay-core/docs/side-panel.mdx
@@ -1,0 +1,161 @@
+---
+title: 'SidePanel'
+description: 'Side Panels are vertical containers used to display additional information that supports the main content area or to edit specific content within the page.'
+packageNpm: '@clayui/core'
+packageStatus: 'Beta'
+packageUse: "import {SidePanel} from '@clayui/core';"
+storybookPath: 'design-system-components-sidepanel'
+packageTypes:
+    [
+        'clay-core/src/side-panel/SidePanel.tsx',
+        'clay-core/src/side-panel/Header.tsx',
+        'clay-core/src/side-panel/Title.tsx',
+        'clay-core/src/side-panel/Body.tsx',
+        'clay-core/src/side-panel/Footer.tsx',
+    ]
+---
+
+## Example
+
+```jsx preview
+import {SidePanel, Provider} from '@clayui/core';
+import Button from '@clayui/button';
+import React from 'react';
+
+import '@clayui/css/lib/css/atlas.css';
+
+export default function App() {
+	const [open, setOpen] = React.useState(false);
+
+	return (
+		<Provider spritemap="/public/icons.svg">
+			<div className="p-4">
+				<Button
+					aria-controls="sidepanel-example"
+					aria-pressed={open}
+					onClick={() => setOpen(!open)}
+				>
+					Open
+				</Button>
+
+				<SidePanel
+					id="sidepanel-example"
+					onOpenChange={setOpen}
+					open={open}
+				>
+					<SidePanel.Header>
+						<SidePanel.Title>Title</SidePanel.Title>
+					</SidePanel.Header>
+					<SidePanel.Body>Body</SidePanel.Body>
+					<SidePanel.Footer>
+						<Button.Group spaced>
+							<Button>Primary</Button>
+							<Button displayType="secondary">Secondary</Button>
+						</Button.Group>
+					</SidePanel.Footer>
+				</SidePanel>
+			</div>
+		</Provider>
+	);
+}
+```
+
+## Introduction
+
+The Side Panel component provides a more easy and quick way for the users to consult or edit information without the need for deeper navigation.
+
+Side Panels can anchor to the left or right side of the screen. They can be collapsible or triggered by a button or a link. When activated, the Side Panel opens and the content of the page is readjusted. You can navigate through the Side Panel content using both mouse and keyboard.
+
+## Anatomy
+
+```jsx
+import {SidePanel} from '@clayui/core';
+
+<SidePanel>
+	<SidePanel.Header>
+		<SidePanel.Title />
+	</SidePanel.Header>
+	<SidePanel.Body />
+	<SidePanel.Footer />
+</SidePanel>;
+```
+
+## Content
+
+The SidePanel component follows a compositional API with subcomponents: Header, Title, Body, and Footer. Refer to the design specifications to configure each part according to your use case.
+
+### Header
+
+he `<SidePanel.Header />` subcomponent always renders the close button by default but leaves the left side of the header open for developer customization.
+
+The `<SidePanel.Title />` must always be used as a direct child of Header. It automatically configures accessibility attributes—such as setting the appropriate `aria-labelledby` relationship between the title and the panel.
+
+```jsx
+<SidePanel.Header>
+	<SidePanel.Title>Title</SidePanel.Title>
+</SidePanel.Header>
+```
+
+### Body and Footer
+
+The `<SidePanel.Body />` and `<SidePanel.Footer />` components are flexible containers that can render any content. However, you should follow design system guidelines and recommendations to ensure consistent layout and behavior across the application.
+
+## Open panel
+
+The SidePanel component requires the open state to be controlled, even though it defaults to an uncontrolled behavior.
+
+Opening the SidePanel can be triggered from any button or link in the DOM, so it’s your responsibility to ensure the trigger element meets accessibility standards. This includes adding appropriate attributes such as `aria-controls` and `aria-pressed` to the button:
+
+```jsx
+import {SidePanel} from '@clayui/core';
+import Button from '@clayui/button';
+
+export default App() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+       	aria-controls="sidepanel-example"
+       	aria-pressed={open}
+       	onClick={() => setOpen(!open)}
+      >
+       	Open
+      </Button>
+
+      <SidePanel id="sidepanel-example" onOpenChange={setOpen} open={open} />
+    </>
+  )
+}
+```
+
+Make sure the `id` used in `aria-controls` matches the `id` of the `<SidePanel />` component to maintain a proper relationship between the trigger and the panel.
+
+## Direction
+
+Positioning the SidePanel on the right or left side is possible by setting the `direction` property.
+
+```jsx
+<SidePanel direction="left" />
+```
+
+## Accesibility
+
+The SidePanel component handles most accessibility rules OOTB, but in some cases, you may need to configure specific properties based on your use case.
+
+By default, SidePanel renders using the `<aside>` tag, but this may not be appropriate for all scenarios:
+
+-   ✅ Use <aside> when it’s suitable for collapsible sidebars:
+    -   Secondary navigation or filtering options (e.g., product filters on an e-commerce site).
+    -   Widgets or supplementary content (e.g., related articles in a blog).
+    -   Contextual or complementary information (e.g., author bios, ads, promotions).
+-   ⚠️ Avoid using <aside> when:
+    -   The content is critical for primary navigation (e.g., a main menu).
+    -   The sidebar includes primary user actions (e.g., key forms).
+    -   The sidebar is the main focus of the page (in this case, consider using <nav> or <section> instead).
+
+Once you determine the correct semantic tag for your use case, you can configure which HTML element the component should render by setting the `as` prop. For example:
+
+```jsx
+<SidePanel as="nav" />
+```

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -40,6 +40,7 @@
 		"aria-hidden": "^1.2.2",
 		"classnames": "^2.2.6",
 		"fuzzy": "^0.1.3",
+		"motion": "^12.12.1",
 		"react-dnd": "^11.1.1",
 		"react-dnd-html5-backend": "^11.1.1",
 		"react-transition-group": "^4.4.1",

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -26,6 +26,7 @@ export {FocusTrap} from './focus-trap';
 export {Nav} from './nav';
 export {Body, Cell, Head, Row, Table} from './table';
 export {LanguagePicker} from './language-picker';
+export {SidePanel} from './side-panel';
 
 // Experimental components
 export * as __EXPERIMENTAL_MENU from './drop-down';

--- a/packages/clay-core/src/side-panel/Body.tsx
+++ b/packages/clay-core/src/side-panel/Body.tsx
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+type Props = {
+	/**
+	 * Children content to render a content.
+	 */
+	children: React.ReactNode;
+};
+
+export function Body({children}: Props) {
+	return <div className="sidebar-body">{children}</div>;
+}

--- a/packages/clay-core/src/side-panel/Footer.tsx
+++ b/packages/clay-core/src/side-panel/Footer.tsx
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+type Props = {
+	/**
+	 * Children content to render a content.
+	 */
+	children: React.ReactNode;
+};
+
+export function Footer({children}: Props) {
+	return <div className="sidebar-footer">{children}</div>;
+}

--- a/packages/clay-core/src/side-panel/Header.tsx
+++ b/packages/clay-core/src/side-panel/Header.tsx
@@ -36,3 +36,13 @@ export function Header({children}: Props) {
 		</div>
 	);
 }
+
+export function Title({children}: React.HTMLAttributes<HTMLDivElement>) {
+	const {titleId} = useSidePanel();
+
+	return (
+		<span className="component-title" id={titleId}>
+			{children}
+		</span>
+	);
+}

--- a/packages/clay-core/src/side-panel/Header.tsx
+++ b/packages/clay-core/src/side-panel/Header.tsx
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Icon from '@clayui/icon';
+import React from 'react';
+
+import {useSidePanel} from './context';
+
+type Props = {
+	/**
+	 * Children content to render a content.
+	 */
+	children: React.ReactNode;
+};
+
+export function Header({children}: Props) {
+	const {onOpenChange} = useSidePanel();
+
+	return (
+		<div className="sidebar-header">
+			<div className="autofit-row sidebar-section">
+				<div className="autofit-col autofit-col-expand">{children}</div>
+				<div className="autofit-col">
+					<button
+						aria-label="Close"
+						className="close"
+						onClick={() => onOpenChange(false)}
+						type="button"
+					>
+						<Icon symbol="times" />
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/clay-core/src/side-panel/SidePanel.tsx
+++ b/packages/clay-core/src/side-panel/SidePanel.tsx
@@ -150,25 +150,31 @@ export function SidePanel({
 			document.addEventListener('keydown', onKeyDown, true);
 
 			return () => {
-				// Remove Side Panel content from DOM focus management
-				ref.current?.setAttribute('inert', '');
-
 				document.removeEventListener('keydown', onKeyDown, true);
 			};
+		} else {
+			// Remove Side Panel content from DOM focus management
+			ref.current?.setAttribute('inert', '');
 		}
 	}, [open]);
 
 	useLayoutEffect(() => {
 		const performSlideout = (position: string | number) => {
 			if (ref.current) {
-				animate(
-					ref.current,
-					{[direction]: position},
-					{
-						duration: 0.3,
-						ease: 'easeInOut',
-					}
-				);
+				// Only use animate in the browser environment
+				if ('animate' in ref.current) {
+					animate(
+						ref.current,
+						{[direction]: position},
+						{
+							duration: 0.3,
+							ease: 'easeInOut',
+						}
+					);
+				} else {
+					// @ts-ignore
+					(ref.current as HTMLDivElement).style[direction] = position;
+				}
 			}
 		};
 

--- a/packages/clay-core/src/side-panel/SidePanel.tsx
+++ b/packages/clay-core/src/side-panel/SidePanel.tsx
@@ -8,6 +8,9 @@ import classnames from 'classnames';
 import {animate} from 'motion/mini';
 import React, {useEffect, useLayoutEffect, useRef} from 'react';
 
+import {Body} from './Body';
+import {Footer} from './Footer';
+import {Header, Title} from './Header';
 import {SidePanelContext} from './context';
 
 type ControlledState = {
@@ -219,3 +222,8 @@ export function SidePanel({
 		</div>
 	);
 }
+
+SidePanel.Header = Header;
+SidePanel.Title = Title;
+SidePanel.Body = Body;
+SidePanel.Footer = Footer;

--- a/packages/clay-core/src/side-panel/SidePanel.tsx
+++ b/packages/clay-core/src/side-panel/SidePanel.tsx
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {Keys, useControlledState} from '@clayui/shared';
+import classnames from 'classnames';
+import React, {useEffect, useLayoutEffect, useRef, useState} from 'react';
+
+import {SidePanelContext} from './context';
+
+type ControlledState = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+};
+
+type UncontrolledState = {
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
+};
+
+export type Props = {
+	/**
+	 * The global `aria-describedby` attribute identifies the element that
+	 * describes the component.
+	 */
+	'aria-describedby'?: string;
+
+	/**
+	 * The `aria-label` attribute defines a string value that labels an interactive
+	 * element.
+	 */
+	'aria-label'?: string;
+
+	/**
+	 * The `aria-labelledby` attribute identifies the element (or elements) that
+	 * labels the element it is applied to.
+	 */
+	'aria-labelledby'?: string;
+
+	/**
+	 * Custom component.
+	 * `aside` - Secondary menus or filters, complementary information...
+	 * (e.g product filters in an e-commerce site, related articles in a blog...).
+	 * `nav` or `section` - If the ontent is essential for navigation, sidebar
+	 * contains primary actions like important forms or sidebar is the
+	 * only important content.
+	 */
+	as?: 'aside' | 'nav' | 'section';
+
+	/**
+	 * Sets the CSS className for the component.
+	 */
+	className?: string;
+
+	/**
+	 * Children content to render a content.
+	 */
+	children: React.ReactNode;
+
+	/**
+	 * Property to set the default value (uncontrolled).
+	 */
+	defaultOpen?: boolean;
+
+	/**
+	 * Direction the panel will render.
+	 */
+	direction?: 'left' | 'right';
+
+	/**
+	 * Flag to determine which style the SidePanel will display.
+	 */
+	displayType?: 'light' | 'dark';
+
+	/**
+	 * The id of the component.
+	 */
+	id?: string;
+
+	/**
+	 * Element reference to open the SidePanel.
+	 * NOTE: SidePanel automatically identifies the trigger but it may not
+	 * work in some cases when the element disappears from the DOM.
+	 */
+	triggerRef?: React.RefObject<HTMLElement>;
+} & (UncontrolledState | ControlledState);
+
+export function SidePanel({
+	as: As = 'aside',
+	children,
+	className,
+	defaultOpen,
+	direction = 'right',
+	displayType = 'light',
+	onOpenChange,
+	open: externalOpen,
+	triggerRef,
+	...otherProps
+}: Props) {
+	const ref = useRef<HTMLElement | null>(null);
+
+	const [open, setOpen] = useControlledState({
+		defaultName: 'defaultOpen',
+		defaultValue: defaultOpen,
+		handleName: 'onOpenChange',
+		name: 'open',
+		onChange: onOpenChange,
+		value: externalOpen,
+	});
+
+	const [transition, setTransition] = useState(false);
+
+	useEffect(() => {
+		if (open) {
+			// Saves the last element that has focus before moving to the sidepanel to
+			// regain focus when closing the sidepanel.
+			const element =
+				(document.activeElement as HTMLElement | null) ||
+				triggerRef?.current ||
+				null;
+
+			return () => {
+				element?.focus();
+			};
+		}
+	}, [open]);
+
+	useEffect(() => {
+		if (open) {
+			const onKeyDown = (event: KeyboardEvent) => {
+				if (event.key === Keys.Esc) {
+					event.stopImmediatePropagation();
+					event.preventDefault();
+
+					setOpen(false);
+				}
+			};
+
+			// Move focus to sidepanel when opening
+			ref.current?.focus();
+
+			document.addEventListener('keydown', onKeyDown, true);
+
+			return () => {
+				document.removeEventListener('keydown', onKeyDown, true);
+			};
+		}
+	}, [open]);
+
+	useLayoutEffect(() => {
+		setTransition(true);
+
+		return () => {
+			setTransition(false);
+		};
+	}, [open]);
+
+	return (
+		<div
+			className={classnames('c-slideout c-slideout-fixed', {
+				'c-slideout-end': direction === 'right',
+				'c-slideout-shown': !transition && open,
+				'c-slideout-start': direction === 'left',
+			})}
+		>
+			<As
+				className={classnames('sidebar c-slideout-active', className, {
+					'c-slideout-show': open,
+					'c-slideout-transition': transition,
+					'c-slideout-transition-in': transition && open,
+					'c-slideout-transition-out': transition && !open,
+					'sidebar-dark': displayType === 'dark',
+					'sidebar-light': displayType === 'light',
+				})}
+				onTransitionEnd={() => setTransition(false)}
+				ref={ref}
+				tabIndex={-1}
+				{...otherProps}
+			>
+				<SidePanelContext.Provider
+					value={{onOpenChange: setOpen, open}}
+				>
+					{children}
+				</SidePanelContext.Provider>
+			</As>
+		</div>
+	);
+}

--- a/packages/clay-core/src/side-panel/SidePanel.tsx
+++ b/packages/clay-core/src/side-panel/SidePanel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {Keys, useControlledState} from '@clayui/shared';
+import {Keys, useControlledState, useId} from '@clayui/shared';
 import classnames from 'classnames';
 import {animate} from 'motion/mini';
 import React, {useEffect, useLayoutEffect, useRef} from 'react';
@@ -88,6 +88,8 @@ export type Props = {
 } & (UncontrolledState | ControlledState);
 
 export function SidePanel({
+	'aria-label': ariaLabel,
+	'aria-labelledby': ariaLabelledby,
 	as: As = 'aside',
 	children,
 	className,
@@ -176,6 +178,8 @@ export function SidePanel({
 		}
 	}, [open]);
 
+	const titleId = useId();
+
 	return (
 		<div
 			className={classnames(
@@ -188,6 +192,10 @@ export function SidePanel({
 		>
 			<As
 				{...otherProps}
+				aria-label={ariaLabel}
+				aria-labelledby={
+					!ariaLabelledby && !ariaLabel ? titleId : ariaLabelledby
+				}
 				className={classnames(
 					'sidebar c-slideout-active c-slideout-show',
 					className,
@@ -203,7 +211,7 @@ export function SidePanel({
 				tabIndex={-1}
 			>
 				<SidePanelContext.Provider
-					value={{onOpenChange: setOpen, open}}
+					value={{onOpenChange: setOpen, open, titleId}}
 				>
 					{children}
 				</SidePanelContext.Provider>

--- a/packages/clay-core/src/side-panel/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/side-panel/__tests__/BasicRendering.tsx
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {Provider} from '@clayui/provider';
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import {SidePanel} from '../SidePanel';
+
+describe('SidePanel basic rendering', () => {
+	afterEach(cleanup);
+
+	it('render basic content', () => {
+		const {container} = render(
+			<Provider spritemap="icons.svg">
+				<SidePanel id="sidepanel">
+					<SidePanel.Header>
+						<SidePanel.Title>Title</SidePanel.Title>
+					</SidePanel.Header>
+					<SidePanel.Body>Body</SidePanel.Body>
+					<SidePanel.Footer>Footer</SidePanel.Footer>
+				</SidePanel>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render component with open state', () => {
+		const {container} = render(
+			<Provider spritemap="icons.svg">
+				<SidePanel defaultOpen id="sidepanel">
+					<SidePanel.Header>
+						<SidePanel.Title>Title</SidePanel.Title>
+					</SidePanel.Header>
+					<SidePanel.Body>Body</SidePanel.Body>
+					<SidePanel.Footer>Footer</SidePanel.Footer>
+				</SidePanel>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render with custom aria-label', () => {
+		const {container} = render(
+			<Provider spritemap="icons.svg">
+				<SidePanel aria-label="Custom Title" id="sidepanel">
+					<SidePanel.Header>
+						<SidePanel.Title>Title</SidePanel.Title>
+					</SidePanel.Header>
+					<SidePanel.Body>Body</SidePanel.Body>
+					<SidePanel.Footer>Footer</SidePanel.Footer>
+				</SidePanel>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+});

--- a/packages/clay-core/src/side-panel/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/side-panel/__tests__/IncrementalInteractions.tsx
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Button from '@clayui/button';
+import {Provider} from '@clayui/provider';
+import {cleanup, render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, {useState} from 'react';
+
+import {SidePanel} from '../SidePanel';
+
+function Example({defaultOpen = false}: {defaultOpen?: boolean}) {
+	const [open, setOpen] = useState(defaultOpen);
+
+	return (
+		<Provider spritemap="icons.svg">
+			<Button
+				aria-controls="sidepanel"
+				aria-pressed={open}
+				onClick={() => setOpen(!open)}
+			>
+				Open
+			</Button>
+
+			<SidePanel id="sidepanel" onOpenChange={setOpen} open={open}>
+				<SidePanel.Header>
+					<SidePanel.Title>Title</SidePanel.Title>
+				</SidePanel.Header>
+				<SidePanel.Body>Body</SidePanel.Body>
+				<SidePanel.Footer>Footer</SidePanel.Footer>
+			</SidePanel>
+		</Provider>
+	);
+}
+
+describe('SidePanel incremental interactions', () => {
+	afterEach(cleanup);
+
+	it('when opening move focus to the root element', () => {
+		const {getAllByRole, getByRole} = render(<Example />);
+
+		const [button] = getAllByRole('button');
+		const panel = getByRole('complementary');
+
+		userEvent.tab();
+
+		expect(button).toHaveFocus();
+		expect(panel).toHaveAttribute('inert');
+
+		userEvent.click(button!);
+
+		expect(panel).toHaveFocus();
+		expect(panel).not.toHaveAttribute('inert');
+	});
+
+	it('clicking the close button closes the side panel and moves the focus to the trigger', () => {
+		const {getAllByRole, getByRole} = render(<Example />);
+
+		const [button, close] = getAllByRole('button');
+		const panel = getByRole('complementary');
+
+		userEvent.tab();
+
+		expect(button).toHaveFocus();
+		expect(panel).toHaveAttribute('inert');
+
+		userEvent.click(button!);
+
+		expect(panel).toHaveFocus();
+		expect(panel).not.toHaveAttribute('inert');
+
+		userEvent.click(close!);
+
+		expect(button).toHaveFocus();
+		expect(panel).toHaveAttribute('inert');
+	});
+
+	it('pressing ESC closes and moves focus to the trigger', () => {
+		const {getAllByRole, getByRole} = render(<Example />);
+
+		const [button] = getAllByRole('button');
+		const panel = getByRole('complementary');
+
+		userEvent.tab();
+
+		expect(button).toHaveFocus();
+		expect(panel).toHaveAttribute('inert');
+
+		userEvent.click(button!);
+
+		expect(panel).toHaveFocus();
+		expect(panel).not.toHaveAttribute('inert');
+
+		userEvent.keyboard('[Escape]');
+
+		expect(button).toHaveFocus();
+		expect(panel).toHaveAttribute('inert');
+	});
+});

--- a/packages/clay-core/src/side-panel/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/side-panel/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -1,0 +1,192 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SidePanel basic rendering render basic content 1`] = `
+<div>
+  <div
+    class="c-slideout c-slideout-fixed c-slideout-shown c-slideout-end"
+  >
+    <aside
+      aria-labelledby="clay-id-1"
+      class="sidebar c-slideout-active c-slideout-show sidebar-light"
+      id="sidepanel"
+      inert=""
+      style="right: -360px;"
+      tabindex="-1"
+    >
+      <div
+        class="sidebar-header"
+      >
+        <div
+          class="autofit-row sidebar-section"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <span
+              class="component-title"
+              id="clay-id-1"
+            >
+              Title
+            </span>
+          </div>
+          <div
+            class="autofit-col"
+          >
+            <button
+              aria-label="Close"
+              class="close"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times"
+                role="presentation"
+              >
+                <use
+                  href="icons.svg#times"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sidebar-body"
+      >
+        Body
+      </div>
+      <div
+        class="sidebar-footer"
+      >
+        Footer
+      </div>
+    </aside>
+  </div>
+</div>
+`;
+
+exports[`SidePanel basic rendering render component with open state 1`] = `
+<div>
+  <div
+    class="c-slideout c-slideout-fixed c-slideout-shown c-slideout-end"
+  >
+    <aside
+      aria-labelledby="clay-id-2"
+      class="sidebar c-slideout-active c-slideout-show sidebar-light"
+      id="sidepanel"
+      style="right: 0px;"
+      tabindex="-1"
+    >
+      <div
+        class="sidebar-header"
+      >
+        <div
+          class="autofit-row sidebar-section"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <span
+              class="component-title"
+              id="clay-id-2"
+            >
+              Title
+            </span>
+          </div>
+          <div
+            class="autofit-col"
+          >
+            <button
+              aria-label="Close"
+              class="close"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times"
+                role="presentation"
+              >
+                <use
+                  href="icons.svg#times"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sidebar-body"
+      >
+        Body
+      </div>
+      <div
+        class="sidebar-footer"
+      >
+        Footer
+      </div>
+    </aside>
+  </div>
+</div>
+`;
+
+exports[`SidePanel basic rendering render with custom aria-label 1`] = `
+<div>
+  <div
+    class="c-slideout c-slideout-fixed c-slideout-shown c-slideout-end"
+  >
+    <aside
+      aria-label="Custom Title"
+      class="sidebar c-slideout-active c-slideout-show sidebar-light"
+      id="sidepanel"
+      inert=""
+      style="right: -360px;"
+      tabindex="-1"
+    >
+      <div
+        class="sidebar-header"
+      >
+        <div
+          class="autofit-row sidebar-section"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <span
+              class="component-title"
+              id="clay-id-3"
+            >
+              Title
+            </span>
+          </div>
+          <div
+            class="autofit-col"
+          >
+            <button
+              aria-label="Close"
+              class="close"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times"
+                role="presentation"
+              >
+                <use
+                  href="icons.svg#times"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sidebar-body"
+      >
+        Body
+      </div>
+      <div
+        class="sidebar-footer"
+      >
+        Footer
+      </div>
+    </aside>
+  </div>
+</div>
+`;

--- a/packages/clay-core/src/side-panel/context.ts
+++ b/packages/clay-core/src/side-panel/context.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {createContext, useContext} from 'react';
+
+type Context = {
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+};
+
+export const SidePanelContext = createContext<Context | null>(null);
+
+export function useSidePanel() {
+	const context = useContext(SidePanelContext);
+
+	if (context === null) {
+		throw new Error('useSidePanel must be used within SidePanel.');
+	}
+
+	return context;
+}

--- a/packages/clay-core/src/side-panel/context.ts
+++ b/packages/clay-core/src/side-panel/context.ts
@@ -8,6 +8,7 @@ import {createContext, useContext} from 'react';
 type Context = {
 	onOpenChange: (open: boolean) => void;
 	open: boolean;
+	titleId: string;
 };
 
 export const SidePanelContext = createContext<Context | null>(null);

--- a/packages/clay-core/src/side-panel/index.ts
+++ b/packages/clay-core/src/side-panel/index.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export {SidePanel} from './SidePanel';
+export {Body} from './Body';
+export {Footer} from './Footer';
+export {Header} from './Header';
+export type {Props as SidePanelProps} from './SidePanel';

--- a/packages/clay-core/src/side-panel/index.ts
+++ b/packages/clay-core/src/side-panel/index.ts
@@ -6,5 +6,5 @@
 export {SidePanel} from './SidePanel';
 export {Body} from './Body';
 export {Footer} from './Footer';
-export {Header} from './Header';
+export {Header, Title} from './Header';
 export type {Props as SidePanelProps} from './SidePanel';

--- a/packages/clay-core/src/side-panel/index.ts
+++ b/packages/clay-core/src/side-panel/index.ts
@@ -4,7 +4,4 @@
  */
 
 export {SidePanel} from './SidePanel';
-export {Body} from './Body';
-export {Footer} from './Footer';
-export {Header, Title} from './Header';
 export type {Props as SidePanelProps} from './SidePanel';

--- a/packages/clay-core/stories/SidePanel.stories.tsx
+++ b/packages/clay-core/stories/SidePanel.stories.tsx
@@ -7,7 +7,7 @@ import Button from '@clayui/button';
 import {useId} from '@clayui/shared';
 import React, {useState} from 'react';
 
-import {Body, Footer, Header, SidePanel} from '../src/side-panel';
+import {Body, Footer, Header, SidePanel, Title} from '../src/side-panel';
 
 export default {
 	title: 'Design System/Components/SidePanel',
@@ -29,7 +29,7 @@ export const Default = () => {
 
 			<SidePanel id={sidePanelId} onOpenChange={setOpen} open={open}>
 				<Header>
-					<div className="component-title">Default Header</div>
+					<Title>Title</Title>
 				</Header>
 				<Body>Body</Body>
 				<Footer>

--- a/packages/clay-core/stories/SidePanel.stories.tsx
+++ b/packages/clay-core/stories/SidePanel.stories.tsx
@@ -7,7 +7,7 @@ import Button from '@clayui/button';
 import {useId} from '@clayui/shared';
 import React, {useState} from 'react';
 
-import {Body, Footer, Header, SidePanel, Title} from '../src/side-panel';
+import {SidePanel} from '../src/side-panel';
 
 export default {
 	title: 'Design System/Components/SidePanel',
@@ -28,16 +28,16 @@ export const Default = () => {
 			</Button>
 
 			<SidePanel id={sidePanelId} onOpenChange={setOpen} open={open}>
-				<Header>
-					<Title>Title</Title>
-				</Header>
-				<Body>Body</Body>
-				<Footer>
+				<SidePanel.Header>
+					<SidePanel.Title>Title</SidePanel.Title>
+				</SidePanel.Header>
+				<SidePanel.Body>Body</SidePanel.Body>
+				<SidePanel.Footer>
 					<Button.Group spaced>
 						<Button>Primary</Button>
 						<Button displayType="secondary">Secondary</Button>
 					</Button.Group>
-				</Footer>
+				</SidePanel.Footer>
 			</SidePanel>
 		</>
 	);

--- a/packages/clay-core/stories/SidePanel.stories.tsx
+++ b/packages/clay-core/stories/SidePanel.stories.tsx
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Button from '@clayui/button';
+import {useId} from '@clayui/shared';
+import React, {useState} from 'react';
+
+import {Body, Footer, Header, SidePanel} from '../src/side-panel';
+
+export default {
+	title: 'Design System/Components/SidePanel',
+};
+
+export const Default = () => {
+	const [open, setOpen] = useState(false);
+	const sidePanelId = useId();
+
+	return (
+		<>
+			<Button
+				aria-controls={sidePanelId}
+				aria-pressed={open}
+				onClick={() => setOpen(!open)}
+			>
+				Open
+			</Button>
+
+			<SidePanel id={sidePanelId} onOpenChange={setOpen} open={open}>
+				<Header>
+					<div className="component-title">Default Header</div>
+				</Header>
+				<Body>Body</Body>
+				<Footer>
+					<Button.Group spaced>
+						<Button>Primary</Button>
+						<Button displayType="secondary">Secondary</Button>
+					</Button.Group>
+				</Footer>
+			</SidePanel>
+		</>
+	);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7282,9 +7282,9 @@ core-js-compat@^3.16.0, core-js-compat@^3.16.2, core-js-compat@^3.8.1:
     semver "7.0.0"
 
 core-js-pure@^3.8.1:
-  version "3.41.0"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.41.0.tgz#349fecad168d60807a31e83c99d73d786fe80811"
-  integrity sha512-71Gzp96T9YPk63aUvE5Q5qP+DryB4ZloUZPSOebGM88VNw8VNfvdA7z6kGA8iGOTEzAomsRidp4jXSmUIJsL+Q==
+  version "3.42.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.42.0.tgz#e86c45a7f3bdcb608823e872f73d1ad9ddf0531d"
+  integrity sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==
 
 core-js@^2.4.0, core-js@^2.6.10, core-js@^2.6.5:
   version "2.6.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,19 +2384,17 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@pmmmwh/react-refresh-webpack-plugin@0.5.1", "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.1.tgz#7e98d6f22c360e1dd00909f5fa9d0f6ecc263292"
-  integrity sha512-ccap6o7+y5L8cnvkZ9h8UXCGyy2DqtwCD+/N3Yru6lxMvcdkPKtdx13qd7sAC9s5qZktOmWf9lfUjsGOvSdYhg==
+"@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.16.tgz#36795b3d5a967032a769977780f2dcc01f4e9c4a"
+  integrity sha512-kLQc9xz6QIqd2oIYyXRUiAp79kGpFBm3fEM9ahfG1HI0WI5gdZ2OVHWdmZYnwODt7ISck+QuQ6sBPrtvUBML7Q==
   dependencies:
-    ansi-html-community "^0.0.8"
-    common-path-prefix "^3.0.0"
-    core-js-pure "^3.8.1"
+    ansi-html "^0.0.9"
+    core-js-pure "^3.23.3"
     error-stack-parser "^2.0.6"
-    find-up "^5.0.0"
     html-entities "^2.1.0"
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
+    loader-utils "^2.0.4"
+    schema-utils "^4.2.0"
     source-map "^0.7.3"
 
 "@react-dnd/asap@^4.0.0":
@@ -4062,6 +4060,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/lodash@^4.14.167":
   version "4.14.184"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.184.tgz#23f96cd2a21a28e106dc24d825d4aa966de7a9fe"
@@ -4915,10 +4918,24 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
+ajv-keywords@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
+  integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
 
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
@@ -4929,6 +4946,16 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.9.0:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ajv@^8.0.1, ajv@^8.6.3:
   version "8.6.3"
@@ -4986,10 +5013,15 @@ ansi-gray@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-html-community@0.0.8, ansi-html-community@^0.0.8:
+ansi-html-community@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
+
+ansi-html@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.9.tgz#6512d02342ae2cc68131952644a129cb734cd3f0"
+  integrity sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==
 
 ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"
@@ -5820,7 +5852,7 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@^3.0.5, bluebird@^3.3.5, bluebird@^3.5.5:
+bluebird@^3.3.5, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6977,7 +7009,7 @@ command-exists@^1.2.6:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
-commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@^2.8.1, commander@^2.9.0:
+commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -7021,11 +7053,6 @@ common-ancestor-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
   integrity sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==
-
-common-path-prefix@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz#7d007a7e07c58c4b4d5f433131a19141b29f11e0"
-  integrity sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -7094,14 +7121,6 @@ config-chain@1.1.12:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
   integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
-  dependencies:
-    ini "^1.3.4"
-    proto-list "~1.2.1"
-
-config-chain@~1.1.5:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
-  integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
   dependencies:
     ini "^1.3.4"
     proto-list "~1.2.1"
@@ -7281,7 +7300,7 @@ core-js-compat@^3.16.0, core-js-compat@^3.16.2, core-js-compat@^3.8.1:
     browserslist "^4.17.5"
     semver "7.0.0"
 
-core-js-pure@^3.8.1:
+core-js-pure@^3.23.3:
   version "3.42.0"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.42.0.tgz#e86c45a7f3bdcb608823e872f73d1ad9ddf0531d"
   integrity sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==
@@ -8795,7 +8814,7 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-duplexer@^0.1.1, duplexer@^0.1.2, duplexer@~0.1.1:
+duplexer@^0.1.1, duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
@@ -8830,17 +8849,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
-
-editorconfig@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
-  integrity sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==
-  dependencies:
-    bluebird "^3.0.5"
-    commander "^2.9.0"
-    lru-cache "^3.2.0"
-    semver "^5.1.0"
-    sigmund "^1.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -9431,19 +9439,6 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-stream@3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
-  integrity sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==
-  dependencies:
-    duplexer "~0.1.1"
-    from "~0"
-    map-stream "~0.1.0"
-    pause-stream "0.0.11"
-    split "0.3"
-    stream-combiner "~0.0.4"
-    through "~2.3.1"
-
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -9756,6 +9751,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-uri@^3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.6.tgz#88f130b77cfaea2378d56bf970dea21257a68748"
+  integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
 fastparse@^1.1.2:
   version "1.1.2"
@@ -10163,6 +10163,15 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+framer-motion@^12.12.1:
+  version "12.12.1"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-12.12.1.tgz#b756079cc050be7fa6ae0d093ab0903fd3f15ca1"
+  integrity sha512-PFw4/GCREHI2suK/NlPSUxd+x6Rkp80uQsfCRFSOQNrm5pZif7eGtmG1VaD/UF1fW9tRBy5AaS77StatB3OJDg==
+  dependencies:
+    motion-dom "^12.12.1"
+    motion-utils "^12.12.1"
+    tslib "^2.4.0"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -10175,11 +10184,6 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
-
-from@~0:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
-  integrity sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -10829,10 +10833,15 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@4.2.10, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@4.2.10, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+graceful-fs@^4.2.11:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 grapheme-breaker@^0.3.2:
   version "0.3.2"
@@ -13088,16 +13097,6 @@ jora@^1.0.0-beta.5:
   resolved "https://registry.yarnpkg.com/jora/-/jora-1.0.0-beta.5.tgz#55b2c4d86078af1bc74da401e88b67be42b0bddd"
   integrity sha512-hPJKQyF0eiCqQOwfgIuQa+8wIn+WcEcjjyeOchuiXEUnt6zbV0tHKsUqRRwJY47ZtBiGcJQNr/BGuYW1Sfwbvg==
 
-js-beautify@1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.7.5.tgz#69d9651ef60dbb649f65527b53674950138a7919"
-  integrity sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==
-  dependencies:
-    config-chain "~1.1.5"
-    editorconfig "^0.13.2"
-    mkdirp "~0.5.0"
-    nopt "~3.0.1"
-
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -13648,6 +13647,15 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
+loader-utils@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -14068,13 +14076,6 @@ lru-cache@^2.5.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
   integrity sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=
 
-lru-cache@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
-  integrity sha512-91gyOKTc2k66UG6kHiH4h3S2eltcPwE1STVfMYC/NG+nZwf8IIuiamfmpGZjpbbxzSyEJaLC0tNSmhjlQUTJow==
-  dependencies:
-    pseudomap "^1.0.1"
-
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -14207,11 +14208,6 @@ map-or-similar@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/map-or-similar/-/map-or-similar-1.5.0.tgz#6de2653174adfb5d9edc33c69d3e92a1b76faf08"
   integrity sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=
-
-map-stream@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
-  integrity sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -14760,7 +14756,7 @@ mkdirp-infer-owner@^2.0.0:
     infer-owner "^1.0.4"
     mkdirp "^1.0.3"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -14776,6 +14772,26 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+motion-dom@^12.12.1:
+  version "12.12.1"
+  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.12.1.tgz#12f50c778ca295de337e28f3b4937da86e9098ea"
+  integrity sha512-GXq/uUbZBEiFFE+K1Z/sxdPdadMdfJ/jmBALDfIuHGi0NmtealLOfH9FqT+6aNPgVx8ilq0DtYmyQlo6Uj9LKQ==
+  dependencies:
+    motion-utils "^12.12.1"
+
+motion-utils@^12.12.1:
+  version "12.12.1"
+  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.12.1.tgz#63e28751325cb9d1cd684f3c273a570022b0010e"
+  integrity sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==
+
+motion@^12.12.1:
+  version "12.12.1"
+  resolved "https://registry.yarnpkg.com/motion/-/motion-12.12.1.tgz#d0a329fd10130961f365c7a10ea8adb12f0ffcba"
+  integrity sha512-vN/3p++Ix0lVt9NH0ZqPrAy8QRTkff27t5z3z5+4BJ3cXPxtOia2EBZS4snM+JUTfl7J0JXP/5ERqu9GT/8IgA==
+  dependencies:
+    framer-motion "^12.12.1"
+    tslib "^2.4.0"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -15074,7 +15090,7 @@ node-status-codes@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
   integrity sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=
 
-nopt@^3.0.0, nopt@~3.0.1:
+nopt@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==
@@ -16223,13 +16239,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pause-stream@0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
-  integrity sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==
-  dependencies:
-    through "~2.3"
-
 pbkdf2@^3.0.3:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
@@ -17297,11 +17306,6 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
-
-pseudomap@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
@@ -18694,6 +18698,16 @@ schema-utils@^3.0.0, schema-utils@^3.1.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+schema-utils@^4.2.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.2.tgz#0c10878bf4a73fd2b1dfd14b9462b26788c806ae"
+  integrity sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.9.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.1.0"
+
 scss-comment-parser@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/scss-comment-parser/-/scss-comment-parser-0.8.4.tgz#8e82c3fcf7fdbbb7f172f8955e2aa88b685f86d8"
@@ -18720,7 +18734,7 @@ semver-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
   integrity sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -18919,11 +18933,6 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
-
-sigmund@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
-  integrity sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==
 
 signal-exit@3.0.7, signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
@@ -19180,13 +19189,6 @@ split2@^3.0.0:
   dependencies:
     readable-stream "^3.0.0"
 
-split@0.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
-  integrity sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==
-  dependencies:
-    through "2"
-
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
@@ -19351,13 +19353,6 @@ stream-combiner2@^1.1.1:
   dependencies:
     duplexer2 "~0.1.0"
     readable-stream "^2.0.2"
-
-stream-combiner@~0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
-  integrity sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==
-  dependencies:
-    duplexer "~0.1.1"
 
 stream-each@^1.1.0:
   version "1.2.3"
@@ -20095,7 +20090,7 @@ through2@^4.0.0:
   dependencies:
     readable-stream "3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3, through@~2.3.1:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==


### PR DESCRIPTION
Ticket [LPD-48055](https://liferay.atlassian.net/browse/LPD-48055)

This is an initial implementation of the SidePanel without CSS implementation and the markup may also change but talking to Patrick ideally we will reuse the `.sidebar` and `.c-slideout` classes but there should be adjustments to meet the ticket requirements, the CSS part has a separate ticket for that.

This initial implementation contains the component structure and the necessary states, also the trigger focus recovery in an OOTB way.

There are some cases to implement still like when the title is rendered in the header under the covers we can add the `aria-labelledby` to the sidepanel OOTB when an `aria-label` is not defined in the root component. I also need to adjust the SidePanel animation when opening, @pat270 you can check that I'm not sure if the order is right here.