### PR TITLE
feat(@clayui/form): add props for enabling reorder buttons on both sides

### DIFF
--- a/packages/clay-form/src/DualListBox.tsx
+++ b/packages/clay-form/src/DualListBox.tsx
@@ -34,6 +34,11 @@ function swapArrayItems(
 
 type BoxProps = {
 	/**
+	 * Flag to disable the reorder buttons
+	 */
+	disableReorder?: boolean;
+
+	/**
 	 * Id of the selectbox to be used with the label
 	 */
 	id?: string;
@@ -189,6 +194,7 @@ const DualListBox = ({
 						onItemsChange([newLeftItems, rightItems!])
 					}
 					onSelectChange={handleLeftSelectedChange}
+					showArrows={!left.disableReorder}
 					size={size}
 					value={leftSelected}
 				/>
@@ -254,7 +260,7 @@ const DualListBox = ({
 						onItemsChange([leftItems!, newRightItems])
 					}
 					onSelectChange={handleRightSelectedChange}
-					showArrows
+					showArrows={!right.disableReorder}
 					size={size}
 					spritemap={spritemap}
 					value={rightSelected}

--- a/packages/clay-form/src/__tests__/__snapshots__/DualListBox.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/DualListBox.tsx.snap
@@ -46,6 +46,45 @@ exports[`Rendering renders ClayDualListBox 1`] = `
           <div
             class="clay-reorder-underlay form-control"
           />
+          <div
+            class="clay-reorder-footer"
+          >
+            <div
+              class="reorder-order-buttons btn-group"
+              role="group"
+            >
+              <button
+                aria-label="Reorder Up"
+                class="reorder-button reorder-button-up btn btn-monospaced btn-sm btn-secondary"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-top"
+                  role="presentation"
+                >
+                  <use
+                    href="#caret-top"
+                  />
+                </svg>
+              </button>
+              <button
+                aria-label="Reorder Down"
+                class="reorder-button reorder-button-down btn btn-monospaced btn-sm btn-secondary"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-bottom"
+                  role="presentation"
+                >
+                  <use
+                    href="#caret-bottom"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <div


### PR DESCRIPTION
Currently we only allow for reordering on the right box, and we also can't disable it. These changes allow for enable/disable the reorder buttons and also has it for both left and right boxes.