### PR TITLE
feat(@clayui/core): LPD-58729 - Allow attaching onClick handlers to table cell

### DIFF
--- a/packages/clay-core/src/table/Cell.tsx
+++ b/packages/clay-core/src/table/Cell.tsx
@@ -111,6 +111,7 @@ export const Cell = React.forwardRef(
 			expanded,
 			index,
 			keyValue,
+			onClick,
 			sortable,
 			textAlign,
 			textValue,
@@ -227,12 +228,14 @@ export const Cell = React.forwardRef(
 						: `string,${keyValue}`
 				}
 				onClick={(event) => {
-					if (!isSortable) {
-						return;
+					if (isSortable) {
+						event.preventDefault();
+						doSort();
 					}
 
-					event.preventDefault();
-					doSort();
+					if (onClick) {
+						onClick(event);
+					}
 				}}
 				onKeyDown={(event) => {
 					if (event.key === Keys.Enter) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58729

Current @clayui/core Table Cell expects `onClick` events only for header cells to trigger column sorting, preventing any other custom `onClick` event from running.

With the proposed change, we keep the current behavior while allowing users to attach custom `onClick` events to any other table cell.
 