### PR TITLE
feat(@clayui/autocomplete): LPD-54854 Allow adding new items to the autocomplete dropdown

### DIFF
--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -114,16 +114,23 @@ export interface IProps<T>
 	 * Messages for autocomplete.
 	 */
 	messages?: {
+		allowsCustomValue?: string;
 		listCount?: string;
 		listCountPlural?: string;
 		loading: string;
 		notFound: string;
+		setAsHTML?: boolean;
 	};
 
 	/**
 	 * Callback for when the active state changes (controlled).
 	 */
 	onActiveChange?: InternalDispatch<boolean>;
+
+	/**
+	 * Callback called when an item is added to the autocomplete list.
+	 */
+	onAddNewItem?: () => void;
 
 	/**
 	 * Callback called when input value changes (controlled).
@@ -189,10 +196,12 @@ function hasItem<T extends Item>(
 const ESCAPE_REGEXP = /[.*+?^${}()|[\]\\]/g;
 
 const defaultMessages = {
+	allowsCustomValue: 'Add {0}',
 	listCount: '{0} option available.',
 	listCountPlural: '{0} options available.',
 	loading: 'Loading...',
 	notFound: 'No results found',
+	setAsHTML: false,
 };
 
 function AutocompleteInner<T extends Item>(
@@ -214,6 +223,7 @@ function AutocompleteInner<T extends Item>(
 		menuTrigger = 'input',
 		messages,
 		onActiveChange,
+		onAddNewItem,
 		onChange,
 		onItemsChange,
 		onLoadMore,
@@ -279,6 +289,8 @@ function AutocompleteInner<T extends Item>(
 			) !== null,
 		[value]
 	);
+
+	const allowsCustomValueMessage = messages?.allowsCustomValue!;
 
 	useEffect(() => {
 		// Validates that the initial value exists in the items.
@@ -404,13 +416,50 @@ function AutocompleteInner<T extends Item>(
 		),
 		items: filteredItems,
 		notFound: (
-			<DropDown.Item
-				aria-disabled="true"
-				className="disabled"
-				roleItem="option"
-			>
-				{messages.notFound}
-			</DropDown.Item>
+			<>
+				{allowsCustomValue && (
+					<>
+						<DropDown.Item
+							className=""
+							id={value}
+							key={value}
+							onClick={() => {
+								if (allowsCustomValue && items && onAddNewItem) {
+									onAddNewItem();
+
+									items.push(value);
+
+									inputElementRef.current?.focus();
+
+									setValue('');
+								}
+							}}
+							roleItem="option"
+						>
+							{messages.setAsHTML &&
+							typeof allowsCustomValueMessage === 'string' ? (
+								<span
+									dangerouslySetInnerHTML={{
+										__html: sub(allowsCustomValueMessage, [
+											value,
+										]),
+									}}
+								/>
+							) : (
+								sub(allowsCustomValueMessage, [value])
+							)}
+						</DropDown.Item>
+						<li className="dropdown-divider"></li>
+					</>
+				)}
+				<DropDown.Item
+					aria-disabled="true"
+					className="disabled"
+					roleItem="option"
+				>
+					{messages.notFound}
+				</DropDown.Item>
+			</>
 		),
 		suppressTextValueWarning: false,
 		virtualizer: items ? virtualizer : undefined,
@@ -554,6 +603,14 @@ function AutocompleteInner<T extends Item>(
 							break;
 						}
 						case Keys.Enter: {
+							if (allowsCustomValue && items && onAddNewItem) {
+								onAddNewItem();
+
+								items.push(value);
+
+								setValue('');
+							}
+
 							setActive(false);
 
 							if (active && activeDescendant) {
@@ -607,6 +664,7 @@ function AutocompleteInner<T extends Item>(
 							}
 
 							navigationProps.onKeyDown(event);
+
 							break;
 						}
 						default:

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -506,3 +506,69 @@ export const AsyncData = () => {
 		</div>
 	);
 };
+
+export const AddNewItem = () => {
+	const [items, setItems] = useState([
+		'Footwear',
+		'Historical Figures',
+		'Items in a Vending Machine',
+		'Reasons to Call 911',
+		"Something You're Afraid Of",
+		'Sports Played Indoors',
+		'Things You Do at Work',
+		'Things You Plug In',
+		'Things You Save Up to Buy',
+	]);
+
+	const [value, setValue] = useState('');
+
+	return (
+		<div className="row">
+			<div className="col-md-5">
+				<p>This example shows how to add new items to Autocomplete.</p>
+				<div className="sheet">
+					<div className="form-group">
+						<label
+							htmlFor="clay-autocomplete-add-new-item"
+							id="clay-autocomplete-label-add-new-item"
+						>
+							Categories
+						</label>
+						<ClayAutocomplete
+							allowsCustomValue
+							aria-labelledby="clay-autocomplete-label-add-new-item"
+							defaultItems={items}
+							id="clay-autocomplete-add-new-item"
+							messages={{
+								allowsCustomValue:
+									'<span class="text-primary">{0} <i>(Add New Category)</i></span>',
+								setAsHTML: true,
+							}}
+							onAddNewItem={() => {
+								if (items.indexOf(value) < 0) {
+									setItems(() => {
+										const newItems = [
+											...items,
+											value,
+										].sort();
+
+										return newItems;
+									});
+								}
+							}}
+							onChange={setValue}
+							placeholder="Enter a category"
+							value={value}
+						>
+							{items.map((item) => (
+								<ClayAutocomplete.Item key={item}>
+									{item}
+								</ClayAutocomplete.Item>
+							))}
+						</ClayAutocomplete>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-54854

This is still a draft PR. I'm having issues with the React component type (controlled / uncontrolled). From my experimentation, controlled autocomplete isn't functioning, but it could be a knowledge issue here. The storybook example I added is an uncontrolled component.

This PR adds the prop `onAddNewItem`. It's called when a new item is added to the list via the enter key or clicking on the dropdown item button. I'm pretty sure I've implemented it incorrectly. I'm looking for some help writing it the right way.

I've added the keys `allowsCustomValue` and `setAsHTML` to the `messages` prop. `allowsCustomValue` is used to pass in the text to display for the Create New Menu Item interaction, https://liferay.atlassian.net/wiki/spaces/ENGLEXICON/pages/3811442825/Create+New+Option#%E2%9C%A8-Interaction.

The `setAsHTML` key is used to enable the ability to pass in markup as well as text for the Create New Menu Item interaction.