### PR TITLE
chore: use node 20 to match DXP version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                  node-version: '18'
+                  node-version: '20.12.2'
             - uses: actions/cache@v4
               with:
                   path: '**/node_modules'
@@ -47,7 +47,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                  node-version: '18'
+                  node-version: '20.12.2'
             - name: Fetch and Diff
               id: diff
               run: |
@@ -79,7 +79,7 @@ jobs:
                   clean: false
             - uses: actions/setup-node@v2
               with:
-                  node-version: '18'
+                  node-version: '20.12.2'
             - name: Generate Bundle Size Table
               if: ${{ steps.diff.outputs.packages }}
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                  node-version: '18'
+                  node-version: '20.12.2'
             - uses: actions/cache@v4
               with:
                   path: '**/node_modules'
@@ -45,7 +45,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-node@v2
               with:
-                  node-version: '18'
+                  node-version: '20.12.2'
             - uses: actions/cache@v4
               with:
                   path: '**/node_modules'
@@ -71,7 +71,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-node@v2
               with:
-                  node-version: '18'
+                  node-version: '20.12.2'
             - uses: actions/cache@v4
               with:
                   path: '**/node_modules'
@@ -105,7 +105,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-node@v2
               with:
-                  node-version: '18'
+                  node-version: '20.12.2'
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@clayui'
             - uses: actions/cache@v4

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"repository": "https://github.com/liferay/clay",
 	"engines": {
-		"node": "18.x"
+		"node": "^20.x"
 	},
 	"size-limit": [
 		{


### PR DESCRIPTION
Not sure if there was a reason we pinned at node 18... I updated our Netlify settings to use node 20 as well