### PR TITLE
LPD-60233 Add accessible text to clay table's column visibility header cell

### DIFF
--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -86,6 +86,11 @@ export function Head<T extends Record<string, any>>(
 
 					{columnsVisibility && (
 						<Cell keyValue="visibility" width="72px">
+							<span className="sr-only">
+								{messages['columnsVisibilityCellLabel'] ||
+									messages['columnsVisibility']}
+							</span>
+
 							<Menu
 								UNSAFE_focusableElements={[
 									'input[role="switch"]',

--- a/packages/clay-core/src/table/Head.tsx
+++ b/packages/clay-core/src/table/Head.tsx
@@ -87,7 +87,7 @@ export function Head<T extends Record<string, any>>(
 					{columnsVisibility && (
 						<Cell keyValue="visibility" width="72px">
 							<span className="sr-only">
-								{messages['columnsVisibilityCellLabel'] ||
+								{messages['columnsVisibilityCell'] ||
 									messages['columnsVisibility']}
 							</span>
 

--- a/packages/clay-core/src/table/Table.tsx
+++ b/packages/clay-core/src/table/Table.tsx
@@ -59,6 +59,7 @@ interface IProps extends React.HTMLAttributes<HTMLTableElement> {
 	 */
 	messages?: {
 		columnsVisibility: string;
+		columnsVisibilityCellLabel?: string;
 		columnsVisibilityDescription: string;
 		columnsVisibilityHeader: string;
 		expandable: string;

--- a/packages/clay-core/src/table/Table.tsx
+++ b/packages/clay-core/src/table/Table.tsx
@@ -59,7 +59,7 @@ interface IProps extends React.HTMLAttributes<HTMLTableElement> {
 	 */
 	messages?: {
 		columnsVisibility: string;
-		columnsVisibilityCellLabel?: string;
+		columnsVisibilityCell?: string;
 		columnsVisibilityDescription: string;
 		columnsVisibilityHeader: string;
 		expandable: string;

--- a/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -33,6 +33,11 @@ exports[`Table basic rendering render dynamic content 1`] = `
             style="width: 72px;"
             tabindex="-1"
           >
+            <span
+              class="sr-only"
+            >
+              Manage Columns Visibility
+            </span>
             <div
               class="dropdown"
             >
@@ -189,6 +194,11 @@ exports[`Table basic rendering render static content 1`] = `
             style="width: 72px;"
             tabindex="-1"
           >
+            <span
+              class="sr-only"
+            >
+              Manage Columns Visibility
+            </span>
             <div
               class="dropdown"
             >
@@ -419,6 +429,11 @@ exports[`Table basic rendering render with sort column 1`] = `
             style="width: 72px;"
             tabindex="-1"
           >
+            <span
+              class="sr-only"
+            >
+              Manage Columns Visibility
+            </span>
             <div
               class="dropdown"
             >
@@ -580,6 +595,11 @@ exports[`Table basic rendering render with treegrid 1`] = `
             style="width: 72px;"
             tabindex="-1"
           >
+            <span
+              class="sr-only"
+            >
+              Manage Columns Visibility
+            </span>
             <div
               class="dropdown"
             >


### PR DESCRIPTION
Resent from: https://github.com/liferay/clay/pull/6102

_Original Message:_

**Bug ticket:** https://liferay.atlassian.net/browse/LPD-59500
**Subtask:** https://liferay.atlassian.net/browse/LPD-60233

---

- This adds sr-only text to the columns visibility header to fix an accessibility issue where header cells can't be empty.
  - Using the WAVE tool extension mentioned in the bug ticket this is how it appears:  <img width="562" height="501" alt="Screenshot 2025-07-10 at 2 05 30 PM" src="https://github.com/user-attachments/assets/ed0a2792-22d7-4741-a719-f93447f92537" />

- This also adds a new message `columnsVisibilityCellLabel` to allow customizing the message for cases when this column is also used as the "row actions"
  - For example: <img width="1225" height="330" alt="Screenshot 2025-07-10 at 4 44 35 PM" src="https://github.com/user-attachments/assets/f4b5ddcc-d730-4397-8994-0b1d671a893e" />

