### PR TITLE
fix(date-picker): create a new date object for initialMonth if none is provided and create new variable so that we aren't re-assigning a prop value

### DIFF
--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -742,4 +742,60 @@ describe('IncrementalInteractions', () => {
 		expect(dayNumber.classList).not.toContain('active');
 		expect(endDate.classList).not.toContain('active');
 	});
+
+	it('clicking the dot button should set the current time when the button is clicked', () => {
+		jest.useFakeTimers();
+
+		const date = new Date('1/1/2025');
+
+		date.setMinutes(15);
+
+		jest.setSystemTime(date);
+
+		const {getByLabelText, getByTestId} = render(
+			<ClayDatePicker spritemap={spritemap} time />
+		);
+
+		const dotButtonEl = getByLabelText(ariaLabels.buttonDot);
+
+		fireEvent.click(dotButtonEl);
+
+		expect(getByTestId('minutes')).toHaveDisplayValue('15');
+
+		date.setMinutes(30);
+
+		jest.setSystemTime(date);
+
+		fireEvent.click(dotButtonEl);
+
+		expect(getByTestId('minutes')).toHaveDisplayValue('30');
+
+		jest.useRealTimers();
+	});
+
+	it('clicking the dot button should set the time to whatever is specified in defaultMonth', () => {
+		jest.useFakeTimers();
+
+		const date = new Date('1/1/2025');
+
+		date.setMinutes(15);
+
+		jest.setSystemTime(date);
+
+		const {getByLabelText, getByTestId} = render(
+			<ClayDatePicker
+				defaultMonth={new Date('1/1/2025 12:00')}
+				spritemap={spritemap}
+				time
+			/>
+		);
+
+		const dotButtonEl = getByLabelText(ariaLabels.buttonDot);
+
+		fireEvent.click(dotButtonEl);
+
+		expect(getByTestId('minutes')).toHaveDisplayValue('00');
+
+		jest.useRealTimers();
+	});
 });

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -259,7 +259,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			footerElement,
 			id,
 			initialExpanded = false,
-			initialMonth = NEW_DATE,
+			initialMonth,
 			inputName,
 			months = [
 				'January',
@@ -299,7 +299,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 	) => {
 		// For backward compatibility `defaultMonth` is just an alias for
 		// `initialMonth`.
-		initialMonth = defaultMonth ?? initialMonth;
+		const initialMonthInternal = defaultMonth ?? initialMonth ?? new Date();
 
 		const [internalValue, setValue, isUncontrolled] = useControlledState({
 			defaultName: 'defaultValue',
@@ -331,7 +331,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 				}
 			}
 
-			const date = normalizeTime(initialMonth);
+			const date = normalizeTime(initialMonthInternal);
 
 			return [date, date] as const;
 		});
@@ -489,9 +489,12 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		const updateDate = useCallback(
 			(value: string) => {
 				if (!value) {
-					changeMonth(initialMonth);
+					changeMonth(initialMonthInternal);
 
-					setDaysSelected([initialMonth, initialMonth]);
+					setDaysSelected([
+						initialMonthInternal,
+						initialMonthInternal,
+					]);
 
 					if (time) {
 						setCurrentTime('--', '--', undefined);
@@ -554,14 +557,16 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		 * is no date selected.
 		 */
 		const handleDotClicked = () => {
+			const currentTime = defaultMonth || new Date();
+
 			const [, endDate] = daysSelected;
 
-			changeMonth(initialMonth);
+			changeMonth(currentTime);
 
 			const newDaysSelected: [Date, Date] =
-				range && endDate < initialMonth
-					? [endDate, initialMonth]
-					: [initialMonth, endDate];
+				range && endDate < currentTime
+					? [endDate, currentTime]
+					: [currentTime, endDate];
 
 			let dateFormatted;
 
@@ -569,17 +574,17 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 				dateFormatted = fromRangeToString(newDaysSelected, dateFormat);
 			} else if (time) {
 				dateFormatted = `${formatDate(
-					initialMonth,
+					currentTime,
 					dateFormat
 				)} ${setCurrentTime(
-					initialMonth.getHours(),
-					initialMonth.getMinutes(),
+					currentTime.getHours(),
+					currentTime.getMinutes(),
 					use12Hours
-						? (formatDate(initialMonth, 'a') as Input['ampm'])
+						? (formatDate(currentTime, 'a') as Input['ampm'])
 						: undefined
 				)}`;
 			} else {
-				dateFormatted = formatDate(initialMonth, dateFormat);
+				dateFormatted = formatDate(currentTime, dateFormat);
 			}
 
 			setDaysSelected(newDaysSelected);

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -297,9 +297,10 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		}: IProps,
 		ref
 	) => {
-		// For backward compatibility `defaultMonth` is just an alias for
-		// `initialMonth`.
-		const initialMonthInternal = defaultMonth ?? initialMonth ?? new Date();
+		const getDefaultMonth = useCallback(
+			() => defaultMonth ?? initialMonth ?? new Date(),
+			[defaultMonth, initialMonth]
+		);
 
 		const [internalValue, setValue, isUncontrolled] = useControlledState({
 			defaultName: 'defaultValue',
@@ -331,7 +332,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 				}
 			}
 
-			const date = normalizeTime(initialMonthInternal);
+			const date = normalizeTime(getDefaultMonth());
 
 			return [date, date] as const;
 		});
@@ -488,13 +489,12 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 
 		const updateDate = useCallback(
 			(value: string) => {
-				if (!value) {
-					changeMonth(initialMonthInternal);
+				const currentDate = getDefaultMonth();
 
-					setDaysSelected([
-						initialMonthInternal,
-						initialMonthInternal,
-					]);
+				if (!value) {
+					changeMonth(currentDate);
+
+					setDaysSelected([currentDate, currentDate]);
 
 					if (time) {
 						setCurrentTime('--', '--', undefined);
@@ -557,16 +557,16 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		 * is no date selected.
 		 */
 		const handleDotClicked = () => {
-			const currentTime = defaultMonth || new Date();
+			const currentDateTime = getDefaultMonth();
 
 			const [, endDate] = daysSelected;
 
-			changeMonth(currentTime);
+			changeMonth(currentDateTime);
 
 			const newDaysSelected: [Date, Date] =
-				range && endDate < currentTime
-					? [endDate, currentTime]
-					: [currentTime, endDate];
+				range && endDate < currentDateTime
+					? [endDate, currentDateTime]
+					: [currentDateTime, endDate];
 
 			let dateFormatted;
 
@@ -574,17 +574,17 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 				dateFormatted = fromRangeToString(newDaysSelected, dateFormat);
 			} else if (time) {
 				dateFormatted = `${formatDate(
-					currentTime,
+					currentDateTime,
 					dateFormat
 				)} ${setCurrentTime(
-					currentTime.getHours(),
-					currentTime.getMinutes(),
+					currentDateTime.getHours(),
+					currentDateTime.getMinutes(),
 					use12Hours
-						? (formatDate(currentTime, 'a') as Input['ampm'])
+						? (formatDate(currentDateTime, 'a') as Input['ampm'])
 						: undefined
 				)}`;
 			} else {
-				dateFormatted = formatDate(currentTime, dateFormat);
+				dateFormatted = formatDate(currentDateTime, dateFormat);
 			}
 
 			setDaysSelected(newDaysSelected);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61062

one of the rules in react is that we shouldn't ever manually change a prop value or reassign it. So I moved initialMonth to a newly named variable and set it to `new Date()` if no prop is assigned.