### PR TITLE
fix@color-picker: Allow for 8 digits in color-picker input.

### DIFF
--- a/packages/clay-color-picker/src/Editor.tsx
+++ b/packages/clay-color-picker/src/Editor.tsx
@@ -255,9 +255,7 @@ export function Editor({
 									}
 								}}
 								type="text"
-								value={hex
-									.toUpperCase()
-									.substring(0, color.getAlpha() < 1 ? 8 : 6)}
+								value={hex.toUpperCase().substring(0, 8)}
 							/>
 
 							<ClayInput.GroupInsetItem before tag="label">

--- a/packages/clay-color-picker/stories/ColorPicker.stories.tsx
+++ b/packages/clay-color-picker/stories/ColorPicker.stories.tsx
@@ -175,7 +175,7 @@ Native.args = {
 export const Validation = () => {
 	const [color, setColor] = useState('');
 
-	const valid = color.length === 6;
+	const valid = color.length === 8;
 
 	return (
 		<ClayForm.Group className={!valid ? 'has-error' : ''}>

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.117.0
+ * Clay 3.141.0
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>


### PR DESCRIPTION
I was looking at https://liferay.atlassian.net/browse/LPD-58303 and noticed that we already have the Alpha slider and allow for 8 digits when pasting, but not when typing into the input box. This resolves the issue in Clay Storybook as far as I can tell, but not in Clay. Is there somewhere else where this might need to be changed? 
cc @pat270 