### PR TITLE
fix: selecting an option in multi-select should not close the dropdown menu

### DIFF
--- a/packages/clay-multi-select/src/MultiSelect.tsx
+++ b/packages/clay-multi-select/src/MultiSelect.tsx
@@ -79,6 +79,11 @@ export interface IProps<T extends Record<string, any> = Item>
 	closeButtonAriaLabel?: string;
 
 	/**
+	 * Flag that indicates whether to close DropDown when clicking on the item.
+	 */
+	closeOnClick?: boolean;
+
+	/**
 	 * The initial value of the active state (uncontrolled).
 	 */
 	defaultActive?: boolean;
@@ -250,6 +255,7 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 		children,
 		clearAllTitle = 'Clear All',
 		closeButtonAriaLabel = 'Remove {0}',
+		closeOnClick = false,
 		defaultActive = false,
 		defaultItems = [],
 		defaultValue = '',
@@ -389,7 +395,10 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 
 						event.preventDefault();
 
-						setActive(false);
+						if (closeOnClick) {
+							setActive(false);
+						}
+
 						setItems([...items, item]);
 						setValue('');
 					},
@@ -405,7 +414,10 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 					onClick={(event) => {
 						event.preventDefault();
 
-						setActive(false);
+						if (closeOnClick) {
+							setActive(false);
+						}
+
 						setItems([...items, item]);
 						setValue('');
 					}}

--- a/packages/clay-multi-select/src/__tests__/index.tsx
+++ b/packages/clay-multi-select/src/__tests__/index.tsx
@@ -4,7 +4,8 @@
  */
 
 import ClayMultiSelect from '..';
-import {cleanup, fireEvent, render} from '@testing-library/react';
+import {cleanup, fireEvent, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 global.ResizeObserver = require('resize-observer-polyfill');
@@ -43,6 +44,57 @@ const ClayMultiSelectWithState = (props: any) => {
 
 describe('Interactions', () => {
 	afterEach(cleanup);
+
+	it('can click on autocomplete item without closing the dropdown menu', () => {
+		render(
+			<ClayMultiSelectWithState
+				items={[]}
+				onItemsChange={jest.fn()}
+				sourceItems={items}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		userEvent.click(screen.getByRole('combobox'));
+
+		const menuOptions = screen.getAllByRole('option');
+
+		userEvent.click(menuOptions.at(0)!);
+
+		menuOptions.forEach((option) => {
+			expect(option).toBeVisible();
+		});
+	});
+
+	it('can click on autocomplete custom child item without closing the dropdown menu', () => {
+		render(
+			<ClayMultiSelectWithState
+				items={[]}
+				onItemsChange={jest.fn()}
+				sourceItems={items}
+				spritemap="/foo/bar"
+			>
+				{(item: any) => (
+					<ClayMultiSelect.Item
+						key={item.value}
+						textValue={item.label}
+					>
+						<strong>{item.label}</strong>
+					</ClayMultiSelect.Item>
+				)}
+			</ClayMultiSelectWithState>
+		);
+
+		userEvent.click(screen.getByRole('combobox'));
+
+		const menuOptions = screen.getAllByRole('option');
+
+		userEvent.click(menuOptions.at(0)!);
+
+		menuOptions.forEach((option) => {
+			expect(option).toBeVisible();
+		});
+	});
 
 	xit('clicking on autocomplete item calls onItemsChange', () => {
 		const onItemsChangeFn = jest.fn();


### PR DESCRIPTION
Hi team!

One of our customers complained that [dropdowns in Forms' "Select from List" field close after selecting an item](https://liferay.atlassian.net/browse/LPP-59701). The behavior is reproducible with the field setting "Allow Multiple Selections" enabled.

After investigating, I found that `ClayMultiSelect` does not have a `closeOnClick` prop like `ClayDropDown` [does](https://github.com/liferay/clay/blob/master/packages/clay-drop-down/src/DropDown.tsx#L176). This PR implements `closeOnClick` on `ClayMultiSelect`, allowing the user to select multiple options without having to retrigger the dropdown menu.  

Why `false` as default? Because, [according to Lexicon](http://liferay.design/lexicon/core-components/dropdowns/#gatsby-focus-wrapper):

> To close a dropdown, use one of the following methods:
> 
> - Select an option in the panel, if they are mutually exclusive.
> - Click on the button that triggered it.
> - Click outside the panel.

I'm assuming that, because in `MultiSelect` **options are not mutually exclusive**, clicking them should not close the dropdown. Think about it: if the user can select multiple options, it is more convenient if the selection dropdown stays available while the user clicks the items.

This will change the default behavior for every current usage of `ClayMultiSelect` in Liferay Portal. After this change, If there is any case where closing the dropdown after clicking is better, then the caller must pass `closeOnClick={true}`. Some tests might break, but I believe it is a change for the better. If you think we should be more conservative and keep the current behavior as default, let me know and I can update the PR, defaulting to `true`.

Thanks!