### PR TITLE
fix: types should always be first in exports

### DIFF
--- a/packages/clay-alert/package.json
+++ b/packages/clay-alert/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-badge/package.json
+++ b/packages/clay-badge/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-breadcrumb/package.json
+++ b/packages/clay-breadcrumb/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-button/package.json
+++ b/packages/clay-button/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-charts/package.json
+++ b/packages/clay-charts/package.json
@@ -6,9 +6,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-color-picker/package.json
+++ b/packages/clay-color-picker/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-data-provider/package.json
+++ b/packages/clay-data-provider/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-drop-down/package.json
+++ b/packages/clay-drop-down/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-empty-state/package.json
+++ b/packages/clay-empty-state/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-form/package.json
+++ b/packages/clay-form/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-icon/package.json
+++ b/packages/clay-icon/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-label/package.json
+++ b/packages/clay-label/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-layout/package.json
+++ b/packages/clay-layout/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-link/package.json
+++ b/packages/clay-link/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-list/package.json
+++ b/packages/clay-list/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-loading-indicator/package.json
+++ b/packages/clay-loading-indicator/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-localized-input/package.json
+++ b/packages/clay-localized-input/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-management-toolbar/package.json
+++ b/packages/clay-management-toolbar/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-modal/package.json
+++ b/packages/clay-modal/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-multi-select/package.json
+++ b/packages/clay-multi-select/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-multi-step-nav/package.json
+++ b/packages/clay-multi-step-nav/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-nav/package.json
+++ b/packages/clay-nav/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-navigation-bar/package.json
+++ b/packages/clay-navigation-bar/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-pagination-bar/package.json
+++ b/packages/clay-pagination-bar/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-pagination/package.json
+++ b/packages/clay-pagination/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-panel/package.json
+++ b/packages/clay-panel/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-popover/package.json
+++ b/packages/clay-popover/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-progress-bar/package.json
+++ b/packages/clay-progress-bar/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-shared/package.json
+++ b/packages/clay-shared/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-slider/package.json
+++ b/packages/clay-slider/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-sticker/package.json
+++ b/packages/clay-sticker/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-table/package.json
+++ b/packages/clay-table/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-tabs/package.json
+++ b/packages/clay-tabs/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-time-picker/package.json
+++ b/packages/clay-time-picker/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-toolbar/package.json
+++ b/packages/clay-toolbar/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-tooltip/package.json
+++ b/packages/clay-tooltip/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/clay-upper-toolbar/package.json
+++ b/packages/clay-upper-toolbar/package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",

--- a/packages/generator-clay-component/app/templates/_package.json
+++ b/packages/generator-clay-component/app/templates/_package.json
@@ -8,9 +8,9 @@
 	"module": "lib/esm/index.js",
 	"exports": {
 		".": {
+			"types": "./lib/index.d.ts",
 			"import": "./lib/esm/index.js",
-			"require": "./lib/cjs/index.js",
-			"types": "./lib/index.d.ts"
+			"require": "./lib/cjs/index.js"
 		}
 	},
 	"types": "lib/index.d.ts",


### PR DESCRIPTION
One more change, I caught this in the TS release notes of 4.7, see the bottom 'The "types" condition should always come first in "exports".'

[Source](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing)

<img width="747" height="793" alt="Screenshot 2025-08-22 at 2 53 54 PM" src="https://github.com/user-attachments/assets/819a2549-335f-4c35-ac75-59df57922118" />

