### PR TITLE
feat(@clayui/core): LPD-48310 Add tests

### DIFF
--- a/packages/clay-core/src/side-panel/Header.tsx
+++ b/packages/clay-core/src/side-panel/Header.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {ClayButtonWithIcon} from '@clayui/button';
 import Icon from '@clayui/icon';
 import classnames from 'classnames';
 import React from 'react';
@@ -23,9 +24,7 @@ type Props = {
 	/**
 	 * Messages for the Side Panel Header.
 	 */
-	messages?: {
-		closeAriaLabel?: string;
-	};
+	messages?: Messages;
 
 	/**
 	 * Property to make the Header sticky. Absolutely positioned SidePanel's
@@ -33,15 +32,27 @@ type Props = {
 	 * for any fixed or sticky navigation bars on the page.
 	 */
 	sticky?: boolean;
+
+	/**
+	 * Function to execute when the back button is pressed.
+	 */
+	onBack?: () => void;
+};
+
+export type Messages = {
+	backAriaLabel?: string;
+	closeAriaLabel?: string;
 };
 
 export const Header = ({
 	children,
 	className,
 	messages = {
+		backAriaLabel: 'Go back.',
 		closeAriaLabel: 'Close the side panel.',
 	},
 	sticky,
+	onBack,
 }: Props) => {
 	const {onOpenChange} = useSidePanel();
 
@@ -56,6 +67,17 @@ export const Header = ({
 			)}
 		>
 			<div className="autofit-row">
+				{onBack ? (
+					<div className="autofit-col">
+						<ClayButtonWithIcon
+							aria-label={messages.backAriaLabel}
+							className="component-action ml-n2"
+							displayType={null}
+							onClick={onBack}
+							symbol="angle-left"
+						/>
+					</div>
+				) : null}
 				<div className="autofit-col autofit-col-expand">{children}</div>
 				<div className="autofit-col">
 					<button

--- a/packages/clay-core/src/side-panel/SidePanel.tsx
+++ b/packages/clay-core/src/side-panel/SidePanel.tsx
@@ -87,6 +87,12 @@ export type Props = {
 	displayType?: 'light' | 'dark';
 
 	/**
+	 * External reference for the side panel.
+	 */
+
+	externalSidePanelRef?: React.RefObject<HTMLDivElement>;
+
+	/**
 	 * The id of the component.
 	 */
 	id?: string;
@@ -114,14 +120,17 @@ export function SidePanel({
 	defaultOpen,
 	direction = 'right',
 	displayType = 'light',
+	externalSidePanelRef,
 	onOpenChange,
 	open: externalOpen,
 	position = 'absolute',
 	triggerRef,
 	...otherProps
 }: Props) {
-	const sidePanelRef = useRef<HTMLDivElement>(null);
+	const internalSidePanelRef = useRef<HTMLDivElement>(null);
 	const slideoutRef = useRef<HTMLDivElement>(null);
+
+	const sidePanelRef = externalSidePanelRef || internalSidePanelRef;
 
 	const {prefersReducedMotion} = useProvider();
 

--- a/packages/clay-core/src/side-panel/SidePanelWithDrilldown.tsx
+++ b/packages/clay-core/src/side-panel/SidePanelWithDrilldown.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {InternalDispatch} from '@clayui/shared';
+import {InternalDispatch, usePrevious} from '@clayui/shared';
 import classnames from 'classnames';
 import React from 'react';
 import {CSSTransition} from 'react-transition-group';
@@ -48,6 +48,13 @@ export function SidePanelWithDrilldown({
 	selectedPanelKey,
 	...otherProps
 }: Props) {
+	const previousSelectedPanel = usePrevious<keyof Panels>(selectedPanelKey);
+
+	const transitionDirection =
+		panels[previousSelectedPanel]?.parentKey === selectedPanelKey
+			? 'prev'
+			: 'next';
+
 	return (
 		<SidePanel {...otherProps} aria-label={panels[selectedPanelKey]?.title}>
 			<div className="drilldown-inner">
@@ -55,12 +62,23 @@ export function SidePanelWithDrilldown({
 					const active = selectedPanelKey === panelKey;
 					const parentPanelKey = panel.parentKey;
 
+					const initialClasses = classnames('transitioning', {
+						'drilldown-prev-initial':
+							transitionDirection === 'prev',
+					});
+
 					return (
 						<CSSTransition
 							aria-hidden={!active}
 							className={classnames('drilldown-item', {
 								'drilldown-current': active,
 							})}
+							classNames={{
+								enter: initialClasses,
+								enterActive: `drilldown-transition drilldown-${transitionDirection}-active`,
+								exit: initialClasses,
+								exitActive: `drilldown-transition drilldown-${transitionDirection}-active`,
+							}}
 							in={active}
 							key={panelKey}
 							timeout={250}

--- a/packages/clay-core/src/side-panel/SidePanelWithDrilldown.tsx
+++ b/packages/clay-core/src/side-panel/SidePanelWithDrilldown.tsx
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {InternalDispatch} from '@clayui/shared';
+import classnames from 'classnames';
+import React from 'react';
+import {CSSTransition} from 'react-transition-group';
+
+import {Messages} from './Header';
+import {Props as SidePanelProps, SidePanel} from './SidePanel';
+
+export type Props = {
+	/**
+	 * Callback is called when the selectedPanelKey prop changes (controlled).
+	 */
+
+	onSelectedPanelKeyChange: InternalDispatch<string>;
+
+	/**
+	 * Group of panels to be rendered
+	 */
+
+	panels: Panels;
+
+	/**
+	 * Selected panel key
+	 */
+
+	selectedPanelKey: keyof Panels;
+} & Omit<SidePanelProps, 'children'>;
+
+type Panel = {
+	component: React.ReactNode;
+	headerMessages?: Messages;
+	parentKey?: string;
+	title: string;
+};
+
+type Panels = {
+	[key: React.Key]: Panel;
+};
+
+export function SidePanelWithDrilldown({
+	onSelectedPanelKeyChange,
+	panels,
+	selectedPanelKey,
+	...otherProps
+}: Props) {
+	return (
+		<SidePanel {...otherProps} aria-label={panels[selectedPanelKey]?.title}>
+			<div className="drilldown-inner">
+				{Object.entries(panels).map(([panelKey, panel]) => {
+					const active = selectedPanelKey === panelKey;
+					const parentPanelKey = panel.parentKey;
+
+					return (
+						<CSSTransition
+							aria-hidden={!active}
+							className={classnames('drilldown-item', {
+								'drilldown-current': active,
+							})}
+							in={active}
+							key={panelKey}
+							timeout={250}
+						>
+							<div className="drilldown-item-inner">
+								<SidePanel.Header
+									messages={panel.headerMessages}
+									{...(parentPanelKey && {
+										onBack: () =>
+											onSelectedPanelKeyChange(
+												parentPanelKey
+											),
+									})}
+								>
+									<SidePanel.Title>
+										{panel.title}
+									</SidePanel.Title>
+								</SidePanel.Header>
+
+								{panel.component}
+							</div>
+						</CSSTransition>
+					);
+				})}
+			</div>
+		</SidePanel>
+	);
+}

--- a/packages/clay-core/src/side-panel/SidePanelWithDrilldown.tsx
+++ b/packages/clay-core/src/side-panel/SidePanelWithDrilldown.tsx
@@ -5,7 +5,7 @@
 
 import {InternalDispatch, usePrevious} from '@clayui/shared';
 import classnames from 'classnames';
-import React from 'react';
+import React, {useRef} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
 import {Messages} from './Header';
@@ -48,6 +48,7 @@ export function SidePanelWithDrilldown({
 	selectedPanelKey,
 	...otherProps
 }: Props) {
+	const panelRef = useRef<HTMLDivElement>(null);
 	const previousSelectedPanel = usePrevious<keyof Panels>(selectedPanelKey);
 
 	const transitionDirection =
@@ -56,7 +57,11 @@ export function SidePanelWithDrilldown({
 			: 'next';
 
 	return (
-		<SidePanel {...otherProps} aria-label={panels[selectedPanelKey]?.title}>
+		<SidePanel
+			{...otherProps}
+			aria-label={panels[selectedPanelKey]?.title}
+			externalSidePanelRef={panelRef}
+		>
 			<div className="drilldown-inner">
 				{Object.entries(panels).map(([panelKey, panel]) => {
 					const active = selectedPanelKey === panelKey;
@@ -81,6 +86,9 @@ export function SidePanelWithDrilldown({
 							}}
 							in={active}
 							key={panelKey}
+							onEntered={() => {
+								panelRef.current?.focus();
+							}}
 							timeout={250}
 						>
 							<div className="drilldown-item-inner">

--- a/packages/clay-core/src/side-panel/__tests__/SidePanelWithDrillDown.tsx
+++ b/packages/clay-core/src/side-panel/__tests__/SidePanelWithDrillDown.tsx
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, {useRef, useState} from 'react';
+
+import '@testing-library/jest-dom';
+
+import {SidePanelWithDrilldown} from '../SidePanelWithDrilldown';
+
+function Component({
+	selectedPanelKey = 'x1',
+}: {selectedPanelKey?: React.Key} = {}) {
+	const [panelKey, setPanelKey] = useState<React.Key>(selectedPanelKey);
+
+	const ref = useRef<HTMLDivElement | null>(null);
+
+	return (
+		<SidePanelWithDrilldown
+			containerRef={ref}
+			onSelectedPanelKeyChange={setPanelKey}
+			open
+			panels={{
+				x1: {
+					component: (
+						<button onClick={() => setPanelKey('x2')}>
+							Next Panel
+						</button>
+					),
+					title: 'Main Panel',
+				},
+				x2: {
+					component: <div>Hello!</div>,
+					headerMessages: {
+						backAriaLabel: 'Go to the main panel',
+					},
+					parentKey: 'x1',
+					title: 'Child Panel',
+				},
+			}}
+			selectedPanelKey={panelKey}
+		/>
+	);
+}
+
+describe('SidePanelWithDrilldown', () => {
+	it('shows the main panel as the active panel', () => {
+		render(<Component />);
+
+		const activePanel = document.querySelector('.drilldown-current');
+		const nextPanelButton = screen.getByRole('button', {
+			name: 'Next Panel',
+		});
+		const backButton = screen.getByLabelText('Go to the main panel');
+
+		expect(activePanel).toHaveTextContent('Main Panel');
+		expect(activePanel).toContainElement(nextPanelButton);
+		expect(activePanel).not.toHaveTextContent('Child Panel');
+		expect(activePanel).not.toContainElement(backButton);
+	});
+
+	it('shows the child panel through a drilldown when the Child Panel button is pressed', async () => {
+		render(<Component />);
+
+		const nextPanelButton = screen.getByRole('button', {
+			name: 'Next Panel',
+		});
+
+		userEvent.click(nextPanelButton);
+
+		await waitFor(() => {
+			const activePanel = document.querySelector('.drilldown-current');
+			const backButton = screen.getByLabelText('Go to the main panel');
+
+			expect(activePanel).not.toHaveTextContent('Main Panel');
+			expect(activePanel).not.toContainElement(nextPanelButton);
+			expect(activePanel).toHaveTextContent('Child Panel');
+			expect(activePanel).toContainElement(backButton);
+		});
+	});
+
+	it('goes to the parent panel when the "Go Back" button is pressed', async () => {
+		render(<Component selectedPanelKey="x2" />);
+
+		const backButton = screen.getByLabelText('Go to the main panel');
+
+		userEvent.click(backButton);
+
+		await waitFor(() => {
+			const activePanel = document.querySelector('.drilldown-current');
+			const nextPanelButton = screen.getByRole('button', {
+				name: 'Next Panel',
+			});
+
+			expect(activePanel).toHaveTextContent('Main Panel');
+			expect(activePanel).toContainElement(nextPanelButton);
+			expect(activePanel).not.toHaveTextContent('Child Panel');
+			expect(activePanel).not.toContainElement(backButton);
+		});
+	});
+});

--- a/packages/clay-core/src/side-panel/index.ts
+++ b/packages/clay-core/src/side-panel/index.ts
@@ -4,4 +4,5 @@
  */
 
 export {SidePanel} from './SidePanel';
+export {SidePanelWithDrilldown} from './SidePanelWithDrilldown';
 export type {Props as SidePanelProps} from './SidePanel';

--- a/packages/clay-core/src/vertical-bar/Panel.tsx
+++ b/packages/clay-core/src/vertical-bar/Panel.tsx
@@ -4,8 +4,9 @@
  */
 
 import {useProvider} from '@clayui/provider';
+import {usePrevious} from '@clayui/shared';
 import classNames from 'classnames';
-import React, {useContext, useEffect, useRef} from 'react';
+import React, {useContext, useRef} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
 import {ContentContext} from './Content';
@@ -137,15 +138,4 @@ export function Panel({children, keyValue = null, tabIndex}: Props) {
 			</div>
 		</CSSTransition>
 	);
-}
-
-function usePrevious<T>(value: T) {
-	const ref = useRef<T>(value);
-
-	useEffect(() => {
-		ref.current = value;
-	}, [value]);
-
-	// eslint-disable-next-line
-	return ref.current;
 }

--- a/packages/clay-core/stories/SidePanel.stories.tsx
+++ b/packages/clay-core/stories/SidePanel.stories.tsx
@@ -4,13 +4,14 @@
  */
 
 import Button from '@clayui/button';
+import {ClayCardWithNavigation} from '@clayui/card';
 import ClayForm, {ClayInput, ClaySelect} from '@clayui/form';
 import Panel from '@clayui/panel';
 import {useId} from '@clayui/shared';
 import Toolbar from '@clayui/toolbar';
 import React, {useRef, useState} from 'react';
 
-import {SidePanel} from '../src/side-panel';
+import {SidePanel, SidePanelWithDrilldown} from '../src/side-panel';
 
 export default {
 	title: 'Design System/Components/SidePanel',
@@ -127,14 +128,14 @@ export const PositionAbsolute = (args: any) => {
 
 				<div className="container-fluid">
 					{`Viennese flavour cup eu, percolator froth ristretto mazagran
-					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
-					spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
-					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
-					spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
-					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
-					spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
-					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
-					spoon acerbic to go macchiato strong.`}
+                    caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+                    spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+                    caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+                    spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+                    caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+                    spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+                    caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+                    spoon acerbic to go macchiato strong.`}
 					<br />
 					<img
 						alt="cat"
@@ -308,14 +309,14 @@ export const PositionFixed = () => {
 
 				<div className="container-fluid">
 					{`Viennese flavour cup eu, percolator froth ristretto mazagran
-					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
-					spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
-					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
-					spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
-					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
-					spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
-					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
-					spoon acerbic to go macchiato strong.`}
+                    caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+                    spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+                    caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+                    spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+                    caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+                    spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+                    caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+                    spoon acerbic to go macchiato strong.`}
 					<br />
 					<img
 						alt="cat"
@@ -348,6 +349,103 @@ export const PositionFixed = () => {
 						</Button.Group>
 					</SidePanel.Footer>
 				</SidePanel>
+			</div>
+		</div>
+	);
+};
+
+export const Drilldown = () => {
+	const [open, setOpen] = useState(true);
+	const [panelKey, setPanelKey] = useState<React.Key>('x1');
+
+	const sidePanelId = useId();
+
+	const ref = useRef<HTMLDivElement | null>(null);
+
+	return (
+		<div className="m-n3 min-vh-100">
+			<div className="side-panel-container" ref={ref}>
+				<Button
+					aria-controls={sidePanelId}
+					aria-pressed={open}
+					onClick={() => setOpen(!open)}
+				>
+					Open Panel
+				</Button>
+
+				<SidePanelWithDrilldown
+					containerRef={ref}
+					id={sidePanelId}
+					onOpenChange={setOpen}
+					onSelectedPanelKeyChange={setPanelKey}
+					open={open}
+					panels={{
+						x1: {
+							component: (
+								<SidePanel.Body>
+									<ClayCardWithNavigation
+										horizontal
+										horizontalSymbol="user"
+										onClick={() => setPanelKey('x2')}
+										title="Profile"
+									/>
+									<ClayCardWithNavigation
+										horizontal
+										horizontalSymbol="edit-layout"
+										onClick={() => setPanelKey('x3')}
+										title="Dashboard"
+									/>
+								</SidePanel.Body>
+							),
+							title: 'User',
+						},
+						x2: {
+							component: (
+								<SidePanel.Body>
+									This is the Profile panel
+									<ClayCardWithNavigation
+										className="mt-4"
+										horizontal
+										horizontalSymbol="pencil"
+										onClick={() => setPanelKey('x4')}
+										title="Edit Profile"
+									/>
+								</SidePanel.Body>
+							),
+							headerMessages: {
+								backAriaLabel: 'Go to the user panel.',
+							},
+							parentKey: 'x1',
+							title: 'Profile',
+						},
+						x3: {
+							component: (
+								<SidePanel.Body>
+									This is the Dashboard panel
+								</SidePanel.Body>
+							),
+							headerMessages: {
+								backAriaLabel: 'Go to the user panel.',
+							},
+							parentKey: 'x1',
+							title: 'Dashboard',
+						},
+						x4: {
+							component: (
+								<SidePanel.Body>
+									This the Edit Profile panel
+								</SidePanel.Body>
+							),
+							headerMessages: {
+								backAriaLabel: 'Go to the profile panel.',
+							},
+							parentKey: 'x2',
+							title: 'Edit Profile',
+						},
+					}}
+					position="fixed"
+					selectedPanelKey={panelKey}
+				/>
 			</div>
 		</div>
 	);

--- a/packages/clay-core/stories/SidePanel.stories.tsx
+++ b/packages/clay-core/stories/SidePanel.stories.tsx
@@ -45,7 +45,7 @@ export const PositionAbsolute = (args: any) => {
 	const sidePanelStartId = useId();
 	const sidebarTitleId = useId();
 
-	const ref = useRef<HTMLElement | null>(null);
+	const ref = useRef<HTMLDivElement | null>(null);
 
 	const options = [
 		{
@@ -251,7 +251,7 @@ export const PositionFixed = () => {
 	const sidePanelId = useId();
 	const sidePanelStartId = useId();
 
-	const ref = useRef<HTMLElement | null>(null);
+	const ref = useRef<HTMLDivElement | null>(null);
 
 	return (
 		<div className="m-n3 min-vh-100">

--- a/packages/clay-css/src/scss/cadmin/variables/_slideout.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_slideout.scss
@@ -95,9 +95,6 @@ $cadmin-c-slideout: map-deep-merge(
 			flex-shrink: 0,
 			position: relative,
 			width: $cadmin-c-slideout-sidebar-width,
-			sidebar-header: (
-				border-bottom-width: 1px,
-			),
 			sidebar-body: (
 				flex-grow: 1,
 				overflow: visible,

--- a/packages/clay-css/src/scss/variables/_slideout.scss
+++ b/packages/clay-css/src/scss/variables/_slideout.scss
@@ -95,9 +95,6 @@ $c-slideout: map-deep-merge(
 			flex-shrink: 0,
 			position: relative,
 			width: $c-slideout-sidebar-width,
-			sidebar-header: (
-				border-bottom-width: 1px,
-			),
 			sidebar-body: (
 				flex-grow: 1,
 				overflow: visible,

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -28,6 +28,7 @@ export {useNavigation, isTypeahead, getFocusableList} from './useNavigation';
 export {useOverlayPosition} from './useOverlayPositon';
 export {useHover} from './useHover';
 export {useIsMobileDevice} from './useIsMobileDevice';
+export {usePrevious} from './usePrevious';
 export {useIsFirstRender} from './useIsFirstRender';
 export {isMac, isIPhone, isIPad, isIOS, isAppleDevice} from './platform';
 export {throttle} from './throttle';

--- a/packages/clay-shared/src/usePrevious.ts
+++ b/packages/clay-shared/src/usePrevious.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useEffect, useRef} from 'react';
+
+export function usePrevious<T>(value: T) {
+	const ref = useRef<T>(value);
+
+	useEffect(() => {
+		ref.current = value;
+	}, [value]);
+
+	return ref.current;
+}


### PR DESCRIPTION
Hi team,

I’m sending a PR for this story https://liferay.atlassian.net/browse/LPD-47740, which includes a variant of the SidePanel with drilldown.


https://github.com/user-attachments/assets/7c12a67e-2316-4104-ab81-ae178a61a246



Additionally, I’ve also done a modification of the SidePanel header, as specified in this task https://liferay.atlassian.net/browse/LPD-60257. 

@pat270, I tried to adjust the back button in the header using `btn-outline-borderless btn-secondary ml-n2`. However, the negative margin should be 12 px instead of 8 px, and we currently don’t have a class for that margin. Could you help me with this?

Thanks in advance!