### PR TITLE
feat(@clayui/css): LPD-65287 Restrict drilldown scrolling to dropdown menu only

### DIFF
--- a/packages/clay-css/src/scss/variables/_drilldown.scss
+++ b/packages/clay-css/src/scss/variables/_drilldown.scss
@@ -14,7 +14,6 @@ $drilldown-inner: map-merge(
 	(
 		display: flex,
 		flex-grow: 1,
-		overflow: hidden,
 		transition: $drilldown-inner-transition,
 	),
 	$drilldown-inner
@@ -59,6 +58,7 @@ $drilldown-dropdown-menu-drilldown-inner: () !default;
 $drilldown-dropdown-menu-drilldown-inner: map-merge(
 	(
 		min-height: 266px,
+		overflow: hidden,
 	),
 	$drilldown-dropdown-menu-drilldown-inner
 );


### PR DESCRIPTION
Hey @pat270, could you review this PR? 

Since we use the same classes for the drilldown in the SidePanel and the drilldown in the Dropdown, the `.drilldown-inner` class needs to have scroll enabled in the SidePanel. Therefore, I limited the scroll blocking only to when it’s used inside the Dropdown.

Thanks in advance!