### PR TITLE
feat: add a primaryAction API for autocomplete

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const config = {
 	stories: ['../packages/*/stories/*.stories.@(js|jsx|ts|tsx)'],
 	addons: [
@@ -35,6 +37,174 @@ const config = {
 	},
 	webpackFinal: (config) => {
 		config.resolve.mainFields = ['ts:main', ...config.resolve.mainFields];
+
+		config.resolve.alias = {
+			'@clayui/alert': path.resolve(
+				__dirname,
+				'../packages/clay-alert/src'
+			),
+			'@clayui/autocomplete': path.resolve(
+				__dirname,
+				'../packages/clay-autocomplete/src'
+			),
+			'@clayui/badge': path.resolve(
+				__dirname,
+				'../packages/clay-badge/src'
+			),
+			'@clayui/breadcrumb': path.resolve(
+				__dirname,
+				'../packages/clay-breadcrumb/src'
+			),
+			'@clayui/button': path.resolve(
+				__dirname,
+				'../packages/clay-button/src'
+			),
+			'@clayui/card': path.resolve(
+				__dirname,
+				'../packages/clay-card/src'
+			),
+			'@clayui/charts': path.resolve(
+				__dirname,
+				'../packages/clay-charts/src'
+			),
+			'@clayui/color-picker': path.resolve(
+				__dirname,
+				'../packages/clay-color-picker/src'
+			),
+			'@clayui/core': path.resolve(
+				__dirname,
+				'../packages/clay-core/src'
+			),
+			'@clayui/data-provider': path.resolve(
+				__dirname,
+				'../packages/clay-data-provider/src'
+			),
+			'@clayui/date-picker': path.resolve(
+				__dirname,
+				'../packages/clay-date-picker/src'
+			),
+			'@clayui/drop-down': path.resolve(
+				__dirname,
+				'../packages/clay-drop-down/src'
+			),
+			'@clayui/empty-state': path.resolve(
+				__dirname,
+				'../packages/clay-empty-state/src'
+			),
+			'@clayui/form': path.resolve(
+				__dirname,
+				'../packages/clay-form/src'
+			),
+			'@clayui/icon': path.resolve(
+				__dirname,
+				'../packages/clay-icon/src'
+			),
+			'@clayui/label': path.resolve(
+				__dirname,
+				'../packages/clay-label/src'
+			),
+			'@clayui/layout': path.resolve(
+				__dirname,
+				'../packages/clay-layout/src'
+			),
+			'@clayui/link': path.resolve(
+				__dirname,
+				'../packages/clay-link/src'
+			),
+			'@clayui/list': path.resolve(
+				__dirname,
+				'../packages/clay-list/src'
+			),
+			'@clayui/loading-indicator': path.resolve(
+				__dirname,
+				'../packages/clay-loading-indicator/src'
+			),
+			'@clayui/localized-input': path.resolve(
+				__dirname,
+				'../packages/clay-localized-input/src'
+			),
+			'@clayui/management-toolbar': path.resolve(
+				__dirname,
+				'../packages/clay-management-toolbar/src'
+			),
+			'@clayui/modal': path.resolve(
+				__dirname,
+				'../packages/clay-modal/src'
+			),
+			'@clayui/multi-select': path.resolve(
+				__dirname,
+				'../packages/clay-multi-select/src'
+			),
+			'@clayui/multi-step-nav': path.resolve(
+				__dirname,
+				'../packages/clay-multi-step-nav/src'
+			),
+			'@clayui/nav': path.resolve(__dirname, '../packages/clay-nav/src'),
+			'@clayui/navigation-bar': path.resolve(
+				__dirname,
+				'../packages/clay-navigation-bar/src'
+			),
+			'@clayui/pagination': path.resolve(
+				__dirname,
+				'../packages/clay-pagination/src'
+			),
+			'@clayui/pagination-bar': path.resolve(
+				__dirname,
+				'../packages/clay-pagination-bar/src'
+			),
+			'@clayui/panel': path.resolve(
+				__dirname,
+				'../packages/clay-panel/src'
+			),
+			'@clayui/popover': path.resolve(
+				__dirname,
+				'../packages/clay-popover/src'
+			),
+			'@clayui/progress-bar': path.resolve(
+				__dirname,
+				'../packages/clay-progress-bar/src'
+			),
+			'@clayui/provider': path.resolve(
+				__dirname,
+				'../packages/clay-provider/src'
+			),
+			'@clayui/shared': path.resolve(
+				__dirname,
+				'../packages/clay-shared/src'
+			),
+			'@clayui/slider': path.resolve(
+				__dirname,
+				'../packages/clay-slider/src'
+			),
+			'@clayui/sticker': path.resolve(
+				__dirname,
+				'../packages/clay-sticker/src'
+			),
+			'@clayui/table': path.resolve(
+				__dirname,
+				'../packages/clay-table/src'
+			),
+			'@clayui/tabs': path.resolve(
+				__dirname,
+				'../packages/clay-tabs/src'
+			),
+			'@clayui/time-picker': path.resolve(
+				__dirname,
+				'../packages/clay-time-picker/src'
+			),
+			'@clayui/toolbar': path.resolve(
+				__dirname,
+				'../packages/clay-toolbar/src'
+			),
+			'@clayui/tooltip': path.resolve(
+				__dirname,
+				'../packages/clay-tooltip/src'
+			),
+			'@clayui/upper-toolbar': path.resolve(
+				__dirname,
+				'../packages/clay-upper-toolbar/src'
+			),
+		};
 
 		return config;
 	},

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -24,7 +24,6 @@ import {
 	useNavigation,
 	useOverlayPosition,
 } from '@clayui/shared';
-import classNames from 'classnames';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {AutocompleteContext} from './Context';
@@ -149,8 +148,6 @@ export interface IProps<T>
 	primaryAction?: {
 		label: React.ReactNode;
 		onClick: () => void;
-		symbolLeft?: string;
-		symbolRight?: string;
 	};
 
 	/**
@@ -689,15 +686,7 @@ function AutocompleteInner<T extends Item>(
 					triggerRef={inputElementRef}
 				>
 					<div
-						className={classNames(
-							'dropdown-menu dropdown-menu-select show',
-							{
-								'dropdown-menu-indicator-end':
-									primaryAction?.symbolRight,
-								'dropdown-menu-indicator-start':
-									primaryAction?.symbolLeft,
-							}
-						)}
+						className="dropdown-menu dropdown-menu-select show"
 						ref={menuRef}
 						role="presentation"
 						style={{

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -383,6 +383,7 @@ function AutocompleteInner<T extends Item>(
 			{...primaryAction}
 			className="text-primary"
 			data-collection-no-filter
+			highlightMatch={false}
 			key="__PRIMARY_ACTION__"
 			onClick={(event) => {
 				event.preventDefault();

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -24,9 +24,11 @@ import {
 	useNavigation,
 	useOverlayPosition,
 } from '@clayui/shared';
+import classNames from 'classnames';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {AutocompleteContext} from './Context';
+import Item from './Item';
 
 import type {AnnouncerAPI, ICollectionProps} from '@clayui/core';
 import type {Locator} from '@clayui/shared';
@@ -142,6 +144,16 @@ export interface IProps<T>
 	onLoadMore?: () => Promise<any> | null;
 
 	/**
+	 * Config for showing a default action as the first item in the dropdown
+	 */
+	primaryAction?: {
+		label: React.ReactNode;
+		onClick: () => void;
+		symbolLeft?: string;
+		symbolRight?: string;
+	};
+
+	/**
 	 * The current value of the input (controlled).
 	 */
 	value?: string;
@@ -217,6 +229,7 @@ function AutocompleteInner<T extends Item>(
 		onChange,
 		onItemsChange,
 		onLoadMore,
+		primaryAction,
 		value: externalValue,
 		...otherProps
 	}: IProps<T>,
@@ -352,16 +365,59 @@ function AutocompleteInner<T extends Item>(
 		});
 	}, [debouncedLoadingChange, isItemsUncontrolled, items, filterFn]);
 
+	const dynamicCollection = children instanceof Function;
+
+	const filteredItemsWithPrimaryAction =
+		primaryAction && dynamicCollection
+			? ['__PRIMARY_ACTION__' as T, ...filteredItems]
+			: filteredItems;
+
 	const virtualizer = useVirtual({
 		estimateSize: 37,
-		items: filteredItems,
+		items: filteredItemsWithPrimaryAction,
 		parentRef: menuRef,
 	});
+
+	const primaryActionChild = (
+		<Item
+			{...primaryAction}
+			className="text-primary"
+			data-collection-no-filter
+			key="__PRIMARY_ACTION__"
+			onClick={(event) => {
+				event.preventDefault();
+
+				if (primaryAction?.onClick) {
+					primaryAction.onClick();
+				}
+			}}
+		>
+			{primaryAction?.label}
+		</Item>
+	);
+
+	let wrappedChildren = children;
+
+	if (primaryAction) {
+		if (dynamicCollection) {
+			wrappedChildren = (item: T, ...args: Array<any>) => {
+				if (item === '__PRIMARY_ACTION__') {
+					return primaryActionChild;
+				}
+
+				return children(item, ...args);
+			};
+		} else if (Array.isArray(children)) {
+			wrappedChildren = [primaryActionChild, ...children];
+		} else {
+			wrappedChildren = [primaryActionChild, children];
+		}
+	}
 
 	// We initialize the collection in the picker and then pass it down so the
 	// collection can be cached even before the listbox is not mounted.
 	const collection = useCollection<T, unknown>({
-		children,
+		children: wrappedChildren,
 		filter: isItemsUncontrolled ? filterFn : undefined,
 		filterKey: 'value',
 		itemContainer: useCallback(
@@ -402,7 +458,7 @@ function AutocompleteInner<T extends Item>(
 			},
 			[value]
 		),
-		items: filteredItems,
+		items: filteredItemsWithPrimaryAction,
 		notFound: (
 			<DropDown.Item
 				aria-disabled="true"
@@ -632,7 +688,15 @@ function AutocompleteInner<T extends Item>(
 					triggerRef={inputElementRef}
 				>
 					<div
-						className="dropdown-menu dropdown-menu-select show"
+						className={classNames(
+							'dropdown-menu dropdown-menu-select show',
+							{
+								'dropdown-menu-indicator-end':
+									primaryAction?.symbolRight,
+								'dropdown-menu-indicator-start':
+									primaryAction?.symbolLeft,
+							}
+						)}
 						ref={menuRef}
 						role="presentation"
 						style={{

--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -31,6 +31,11 @@ export interface IProps
 	'data-index'?: number;
 
 	/**
+	 * Flag to indicate if matched text is highlighted
+	 */
+	highlightMatch?: boolean;
+
+	/**
 	 * Path for item to link to.
 	 */
 	href?: string;
@@ -95,6 +100,7 @@ const NewItem = React.forwardRef<HTMLLIElement, IProps>(function NewItem(
 		children,
 		className,
 		disabled,
+		highlightMatch = true,
 		innerRef,
 		keyValue,
 		match = '',
@@ -134,7 +140,10 @@ const NewItem = React.forwardRef<HTMLLIElement, IProps>(function NewItem(
 			ref={ref}
 			tabIndex={-1}
 		>
-			{match && fuzzyMatch && typeof children === 'string'
+			{highlightMatch &&
+			match &&
+			fuzzyMatch &&
+			typeof children === 'string'
 				? fuzzyMatch.rendered
 						.split('|')
 						.map((item, index) => {

--- a/packages/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
@@ -639,4 +639,92 @@ describe('Autocomplete incremental interactions', () => {
 			expect(queryByRole('listbox')).toBeFalsy();
 		});
 	});
+
+	describe('Primary Action interactions', () => {
+		it('renders', async () => {
+			const {getByRole, getByText} = render(
+				<ClayAutocomplete
+					messages={messages}
+					placeholder="Enter a number from One to Five"
+					primaryAction={{
+						label: 'Create',
+						onClick: () => {},
+					}}
+				>
+					{['one', 'two', 'three'].map((item) => (
+						<ClayAutocomplete.Item key={item}>
+							{item}
+						</ClayAutocomplete.Item>
+					))}
+				</ClayAutocomplete>
+			);
+
+			const input = getByRole('combobox');
+
+			userEvent.click(input);
+			userEvent.type(input, '{arrowdown}');
+
+			expect(getByText('Create')).toBeTruthy();
+		});
+
+		it('onClick fires when item is selected', async () => {
+			const onClickMock = jest.fn();
+
+			const {getByRole} = render(
+				<ClayAutocomplete
+					primaryAction={{
+						label: 'Create',
+						onClick: onClickMock,
+					}}
+				>
+					{['one', 'two', 'three'].map((item) => (
+						<ClayAutocomplete.Item key={item}>
+							{item}
+						</ClayAutocomplete.Item>
+					))}
+				</ClayAutocomplete>
+			);
+
+			const input = getByRole('combobox');
+
+			userEvent.click(input);
+			userEvent.type(input, '{arrowdown}');
+			userEvent.type(input, '{enter}');
+
+			expect(onClickMock).toHaveBeenCalled();
+		});
+
+		it('renders when autocomplete uses dynamic rendering', async () => {
+			const onClickMock = jest.fn();
+
+			const {getByRole, getByText} = render(
+				<ClayAutocomplete
+					defaultItems={['one', 'two', 'three']}
+					primaryAction={{
+						label: 'Create',
+						onClick: onClickMock,
+					}}
+				>
+					{(item) => (
+						<ClayAutocomplete.Item key={item}>
+							{item}
+						</ClayAutocomplete.Item>
+					)}
+				</ClayAutocomplete>
+			);
+
+			expect(onClickMock).not.toHaveBeenCalled();
+
+			const input = getByRole('combobox');
+
+			userEvent.click(input);
+
+			userEvent.type(input, '{arrowdown}');
+
+			expect(getByText('Create')).toBeTruthy();
+
+			userEvent.type(input, '{enter}');
+			expect(onClickMock).toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -532,8 +532,8 @@ export const CreationActionWithStaticRendering = () => {
 							}}
 							value={value}
 						>
-							{items.map((item) => (
-								<ClayAutocomplete.Item key={item}>
+							{items.map((item, i) => (
+								<ClayAutocomplete.Item key={item + i}>
 									{item}
 								</ClayAutocomplete.Item>
 							))}
@@ -571,8 +571,8 @@ export const CreationActionWithDynamicRendering = () => {
 							}}
 							value={value}
 						>
-							{(item) => (
-								<ClayAutocomplete.Item key={item}>
+							{(item, i) => (
+								<ClayAutocomplete.Item key={item + i}>
 									{item}
 								</ClayAutocomplete.Item>
 							)}

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -529,7 +529,6 @@ export const CreationActionWithStaticRendering = () => {
 									setItems([...items, value]);
 									setValue('');
 								},
-								symbolLeft: 'plus',
 							}}
 							value={value}
 						>
@@ -569,7 +568,6 @@ export const CreationActionWithDynamicRendering = () => {
 								onClick: () => {
 									alert('create!');
 								},
-								symbolLeft: 'plus',
 							}}
 							value={value}
 						>

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -502,3 +502,86 @@ export const AsyncData = () => {
 		</div>
 	);
 };
+
+export const CreationActionWithStaticRendering = () => {
+	const [value, setValue] = useState('');
+	const [items, setItems] = useState(['Small', 'Medium', 'Large']);
+
+	return (
+		<div className="row">
+			<div className="col-md-5">
+				<div className="sheet">
+					<div className="form-group">
+						<label
+							htmlFor="clay-autocomplete-1"
+							id="clay-autocomplete-label-1"
+						>
+							Tags
+						</label>
+						<ClayAutocomplete
+							aria-labelledby="clay-autocomplete-label-1"
+							id="clay-autocomplete-1"
+							onChange={setValue}
+							placeholder="Add a tag or create a new one"
+							primaryAction={{
+								label: 'Create New Tag',
+								onClick: () => {
+									setItems([...items, value]);
+									setValue('');
+								},
+								symbolLeft: 'plus',
+							}}
+							value={value}
+						>
+							{items.map((item) => (
+								<ClayAutocomplete.Item key={item}>
+									{item}
+								</ClayAutocomplete.Item>
+							))}
+						</ClayAutocomplete>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export const CreationActionWithDynamicRendering = () => {
+	const [value, setValue] = useState('');
+
+	return (
+		<div className="row">
+			<div className="col-md-5">
+				<div className="sheet">
+					<div className="form-group">
+						<label
+							htmlFor="clay-autocomplete-1"
+							id="clay-autocomplete-label-1"
+						>
+							Tags
+						</label>
+						<ClayAutocomplete
+							aria-labelledby="clay-autocomplete-label-1"
+							defaultItems={['Small', 'Medium', 'Large']}
+							onChange={setValue}
+							primaryAction={{
+								label: 'Create New Tag',
+								onClick: () => {
+									alert('create!');
+								},
+								symbolLeft: 'plus',
+							}}
+							value={value}
+						>
+							{(item) => (
+								<ClayAutocomplete.Item key={item}>
+									{item}
+								</ClayAutocomplete.Item>
+							)}
+						</ClayAutocomplete>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -86,6 +86,10 @@ export function useCollection<
 				return false;
 			}
 
+			if (child.props['data-collection-no-filter']) {
+				return false;
+			}
+
 			if (typeof child.props.children === 'string') {
 				return !filter(child.props.children);
 			}

--- a/packages/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/packages/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -457,3 +457,38 @@ export const Group = (args: any) => {
 Group.args = {
 	isValid: false,
 };
+
+export const WithPrimaryAction = () => {
+	const [value, setValue] = React.useState('');
+	const [items, setItems] = React.useState([
+		{
+			label: 'one',
+			value: '1',
+		},
+	]);
+
+	return (
+		<>
+			<label htmlFor="multiSelect" id="multi-select-label">
+				Multi Select
+			</label>
+
+			<ClayMultiSelect
+				aria-labelledby="multi-select-label"
+				inputName="myInput"
+				items={items}
+				onChange={setValue}
+				onItemsChange={(val) => setItems(val as any)}
+				primaryAction={{
+					label: 'Create',
+					onClick: () => {
+						alert('create!');
+					},
+					symbolLeft: 'plus',
+				}}
+				sourceItems={sourceItems}
+				value={value}
+			/>
+		</>
+	);
+};

--- a/packages/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/packages/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -484,7 +484,6 @@ export const WithPrimaryAction = () => {
 					onClick: () => {
 						alert('create!');
 					},
-					symbolLeft: 'plus',
 				}}
 				sourceItems={sourceItems}
 				value={value}


### PR DESCRIPTION
This new API allows for configuring an action in the autocomplete dropdown that will always appear as the first item in the list and when selecting it will call the onClick callback. This also works in MultiSelect as well

https://github.com/user-attachments/assets/7f16d754-d071-4b5a-b19f-bd3db7d44059


