### PR TITLE
feat(@clayui/autocomplete): LPD-66883 Adds displayType prop to mimic picker input

### DIFF
--- a/packages/clay-autocomplete/docs/autocomplete.mdx
+++ b/packages/clay-autocomplete/docs/autocomplete.mdx
@@ -381,3 +381,58 @@ export default function App() {
 	);
 }
 ```
+
+## Display Types
+
+The style of the input can be changed to mimic <a href="./picker">ClayPicker</a> with `displayType="select"` or `displayType="select-secondary"`.
+
+```jsx preview
+import {Provider} from '@clayui/core';
+import Autocomplete from '@clayui/autocomplete';
+import Form from '@clayui/form';
+import React from 'react';
+
+import '@clayui/css/lib/css/atlas.css';
+
+export default function App() {
+	return (
+		<Provider spritemap="/public/icons.svg">
+			<div className="p-4">
+				<Form.Group>
+					<label
+						htmlFor="clay-autocomplete-2"
+						id="clay-autocomplete-label-2"
+					>
+						Fruits
+					</label>
+					<Autocomplete
+						aria-labelledby="clay-autocomplete-label-2"
+						id="clay-autocomplete-2"
+						defaultItems={[
+							'Apples',
+							'Bananas',
+							'Cantaloupe',
+							'Mangos',
+							'Oranges',
+							'Strawberries',
+						]}
+						displayType="select"
+						messages={{
+							loading: 'Loading...',
+							notFound: 'No results found',
+						}}
+						placeholder="Enter the name of a fruit"
+						menuTrigger="focus"
+					>
+						{(item) => (
+							<Autocomplete.Item key={item}>
+								{item}
+							</Autocomplete.Item>
+						)}
+					</Autocomplete>
+				</Form.Group>
+			</div>
+		</Provider>
+	);
+}
+```

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -24,6 +24,7 @@ import {
 	useNavigation,
 	useOverlayPosition,
 } from '@clayui/shared';
+import classNames from 'classnames';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {AutocompleteContext} from './Context';
@@ -94,6 +95,11 @@ export interface IProps<T>
 	 * Direction the menu will render relative to the Autocomplete.
 	 */
 	direction?: 'bottom' | 'top';
+
+	/**
+	 * Flag to toggle the use of Picker input styles.
+	 */
+	displayType?: 'select' | 'select-secondary';
 
 	/**
 	 * Defines the name of the property key that is used in the items filter
@@ -217,6 +223,7 @@ function AutocompleteInner<T extends Item>(
 		defaultItems,
 		defaultValue,
 		direction = 'bottom',
+		displayType,
 		filterKey,
 		items: externalItems,
 		loadingState,
@@ -563,6 +570,12 @@ function AutocompleteInner<T extends Item>(
 				aria-expanded={active}
 				autoComplete="off"
 				autoCorrect="off"
+				className={classNames({
+					'form-control-select':
+						displayType === 'select' || 'select-secondary',
+					'form-control-select-secondary':
+						displayType === 'select-secondary',
+				})}
 				insetAfter={isLoading}
 				onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
 					const {value} = event.target;

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -47,6 +47,7 @@ export const Default = (args: any) => (
 					</label>
 					<ClayAutocomplete
 						aria-labelledby="clay-autocomplete-label-1"
+						displayType="select"
 						id="clay-autocomplete-1"
 						menuTrigger={args.menuTrigger}
 						messages={{

--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -424,6 +424,11 @@ $form-control-select-palette: map-deep-merge(
 				background-image: clay-icon(caret-double-l, $gray-900),
 				color: $gray-900,
 			),
+			input-group-inset-item: (
+				background-color: $white,
+				border-color: $secondary-l0,
+				color: $gray-600,
+			),
 		),
 	),
 	$form-control-select-palette

--- a/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
@@ -245,7 +245,10 @@
 		@include border-right-radius(0);
 
 		border-right-width: 0;
-		padding-right: 0;
+
+		&:not(.form-control-select) {
+			padding-right: 0;
+		}
 	}
 
 	.input-group-inset-item-after {

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -1353,6 +1353,11 @@ $cadmin-form-control-select-palette: map-deep-merge(
 				background-image: clay-icon(caret-double-l, $cadmin-gray-900),
 				color: $cadmin-gray-900,
 			),
+			input-group-inset-item: (
+				background-color: $cadmin-white,
+				border-color: $cadmin-secondary-l0,
+				color: $cadmin-gray-600,
+			),
 		),
 		'.form-control-select-shrink': (
 			max-width: 100%,

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -295,7 +295,10 @@
 		@include border-right-radius(0);
 
 		border-right-width: 0;
-		padding-right: 0;
+
+		&:not(.form-control-select) {
+			padding-right: 0;
+		}
 	}
 
 	.input-group-inset-item-after {

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -936,6 +936,16 @@
 				);
 			}
 
+			$_input-group-inset-item: map-get($map, input-group-inset-item);
+
+			@if ($_input-group-inset-item) {
+				@at-root {
+					.input-group & ~ .input-group-inset-item {
+						@include clay-css($_input-group-inset-item);
+					}
+				}
+			}
+
 			@if (length($hover) != 0) {
 				&:hover,
 				&.hover {
@@ -961,6 +971,19 @@
 								&:checked {
 									@include clay-css($_checked);
 								}
+							}
+						}
+					}
+
+					$_input-group-inset-item: map-get(
+						$hover,
+						input-group-inset-item
+					);
+
+					@if ($_input-group-inset-item) {
+						@at-root {
+							.input-group & ~ .input-group-inset-item {
+								@include clay-css($_input-group-inset-item);
 							}
 						}
 					}
@@ -994,6 +1017,19 @@
 									&:checked {
 										@include clay-css($_checked);
 									}
+								}
+							}
+						}
+
+						$_input-group-inset-item: map-get(
+							$focus,
+							input-group-inset-item
+						);
+
+						@if ($_input-group-inset-item) {
+							@at-root {
+								.input-group & ~ .input-group-inset-item {
+									@include clay-css($_input-group-inset-item);
 								}
 							}
 						}
@@ -1096,6 +1132,19 @@
 								&:checked {
 									@include clay-css($_checked);
 								}
+							}
+						}
+					}
+
+					$_input-group-inset-item: map-get(
+						$disabled,
+						input-group-inset-item
+					);
+
+					@if ($_input-group-inset-item) {
+						@at-root {
+							.input-group & ~ .input-group-inset-item {
+								@include clay-css($_input-group-inset-item);
 							}
 						}
 					}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-66883

![autocomplete](https://github.com/user-attachments/assets/3fb9ec2d-08e8-4bf0-9400-94467157d904)

![autocomplete-loading](https://github.com/user-attachments/assets/70907033-473f-45d2-9ec8-2d14e9c51728)

@ethib137 I don't think we need to add `insetItemAfter`. We can use the classes we use for Picker on the input. Let me know if this works.