### PR TITLE
fix(@clayui/autocomplete,@clayui/multi-select): LPD-74696 Improve Enter key handling

### DIFF
--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -547,15 +547,52 @@ function AutocompleteInner<T extends Record<string, any> | string | number>(
 							break;
 						}
 						case Keys.Enter: {
+							if (active && activeDescendant) {
+								event.preventDefault();
+
+								setActive(false);
+
+								onPress();
+
+								break;
+							}
+
+							// Typing into the input clears activeDescendant, so
+							// an exact match would otherwise require an extra
+							// arrow-down before Enter to commit it. Select the
+							// match directly when one exists.
+
+							if (active && value) {
+								const lowerValue = value.toLowerCase();
+
+								const matchedKey = collection
+									.getItems()
+									.find(
+										(key) =>
+											collection
+												.getItem(key)
+												?.value?.toLowerCase() ===
+											lowerValue
+									);
+
+								if (matchedKey && menuRef.current) {
+									event.preventDefault();
+
+									setActive(false);
+
+									const matchedElement =
+										menuRef.current.querySelector(
+											`#${CSS.escape(String(matchedKey))}`
+										) as HTMLElement | null;
+
+									matchedElement?.click();
+
+									break;
+								}
+							}
+
 							setActive(false);
 
-							if (active && activeDescendant) {
-								onPress();
-							}
-
-							if (!active && event.key === Keys.Esc) {
-								setValue('');
-							}
 							break;
 						}
 						case Keys.Home:

--- a/packages/clay-multi-select/src/Labels.tsx
+++ b/packages/clay-multi-select/src/Labels.tsx
@@ -363,7 +363,10 @@ export const Labels = React.forwardRef<HTMLInputElement, IProps>(
 									event.preventDefault();
 								}
 
-								if (key === Keys.Enter && activeDescendant) {
+								if (
+									key === Keys.Enter &&
+									(activeDescendant || event.defaultPrevented)
+								) {
 									return;
 								}
 

--- a/packages/clay-multi-select/src/MultiSelect.tsx
+++ b/packages/clay-multi-select/src/MultiSelect.tsx
@@ -420,6 +420,7 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 					UNSAFE_loadingShrink
 					active={MenuRenderer ? false : active}
 					allowsCustomLabel={allowsCustomLabel}
+					allowsCustomValue
 					ariaDescriptionId={ariaDescriptionId}
 					as={Labels}
 					closeButtonAriaLabel={closeButtonAriaLabel}

--- a/packages/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
@@ -148,4 +148,87 @@ describe('MultiSelect incremental interactions', () => {
 
 		expect(document.activeElement).toEqual(close);
 	});
+
+	it('pressing enter on an exact label match adds the source item and clears the input', () => {
+		const onItemsChange = jest.fn();
+		const sourceItems = [
+			{label: 'one', value: '1'},
+			{label: 'two', value: '2'},
+		];
+
+		const {getByRole} = render(
+			<MultiSelect
+				onItemsChange={onItemsChange}
+				sourceItems={sourceItems}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		const combobox = getByRole('combobox') as HTMLInputElement;
+
+		userEvent.type(combobox, 'one');
+
+		userEvent.keyboard('[Enter]');
+
+		expect(onItemsChange).toHaveBeenLastCalledWith([sourceItems[0]]);
+
+		expect(combobox.value).toBe('');
+	});
+
+	it('pressing enter on a non-matching value with allowsCustomLabel false preserves the input', () => {
+		const onItemsChange = jest.fn();
+		const sourceItems = [
+			{label: 'one', value: '1'},
+			{label: 'two', value: '2'},
+		];
+
+		const {getByRole} = render(
+			<MultiSelect
+				allowsCustomLabel={false}
+				onItemsChange={onItemsChange}
+				sourceItems={sourceItems}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		const combobox = getByRole('combobox') as HTMLInputElement;
+
+		userEvent.type(combobox, 'foo');
+
+		userEvent.keyboard('[Enter]');
+
+		expect(onItemsChange).not.toHaveBeenCalled();
+
+		expect(combobox.value).toBe('foo');
+	});
+
+	it('pressing enter on a non-matching value with allowsCustomLabel true adds it as a custom label', () => {
+		const onItemsChange = jest.fn();
+		const sourceItems = [
+			{label: 'one', value: '1'},
+			{label: 'two', value: '2'},
+		];
+
+		const {getByRole} = render(
+			<MultiSelect
+				onItemsChange={onItemsChange}
+				sourceItems={sourceItems}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		const combobox = getByRole('combobox') as HTMLInputElement;
+
+		userEvent.type(combobox, 'foo');
+
+		userEvent.keyboard('[Enter]');
+
+		expect(onItemsChange).toHaveBeenCalledTimes(1);
+
+		expect(onItemsChange).toHaveBeenLastCalledWith([
+			expect.objectContaining({label: 'foo', value: 'foo'}),
+		]);
+
+		expect(combobox.value).toBe('');
+	});
 });

--- a/packages/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/packages/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -81,6 +81,39 @@ Default.args = {
 	isValid: false,
 	size: null,
 };
+export function AllowsCustomLabel(args: any) {
+	const [value, setValue] = useState('');
+	const [items, setItems] = useState([
+		{
+			label: 'one',
+			value: '1',
+		},
+	]);
+
+	return (
+		<>
+			<label htmlFor="multiSelect" id="multi-select-label">
+				Multi Select
+			</label>
+
+			<ClayMultiSelect
+				allowsCustomLabel={args.allowsCustomLabel}
+				aria-labelledby="multi-select-label"
+				id="multiSelect"
+				inputName="myInput"
+				items={items}
+				onChange={setValue}
+				onItemsChange={(val) => setItems(val as any)}
+				sourceItems={sourceItems}
+				value={value}
+			/>
+		</>
+	);
+}
+
+AllowsCustomLabel.args = {
+	allowsCustomLabel: true,
+};
 
 export const ComparingItems = () => {
 	const [items, setItems] = useState([


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-74696

Backport of the Clay fixes from liferay-platform-experience/liferay-portal#1978 to `3.136.x`.

Fixes Enter handling in `ClayMultiSelect`:
- Exact-match + Enter now commits the item (previously did nothing without an arrow-down first).
- Non-matching + Enter no longer wipes the input and loses focus.

Changes: `Autocomplete` commits an exact typed match directly; `MultiSelect` forwards `allowsCustomValue` to skip the single-select revert; `Labels` skips Enter when `Autocomplete` already handled it. Includes 3 MultiSelect tests.
